### PR TITLE
feat: vehicle repair/refuel + batch gear repair

### DIFF
--- a/db.go
+++ b/db.go
@@ -3219,23 +3219,66 @@ func cmdRepairItem(itemID int64) Cmd {
 		if globalDB == nil {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
-		res, err := globalDB.Exec(context.Background(), `
-			UPDATE dune.items
+		ctx := context.Background()
+
+		// Derive owning player from item → inventory → actor (pawn) so we can gate Offline.
+		var pawnID int64
+		err := globalDB.QueryRow(ctx, `
+			SELECT inv.actor_id
+			FROM dune.items i
+			JOIN dune.inventories inv ON inv.id = i.inventory_id
+			WHERE i.id = $1::bigint`, itemID).Scan(&pawnID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return msgMutate{err: fmt.Errorf("item %d not found", itemID)}
+		}
+		if err != nil {
+			return msgMutate{err: fmt.Errorf("look up item owner: %w", err)}
+		}
+		if err := checkPlayerOffline(ctx, pawnID); err != nil {
+			return msgMutate{err: err}
+		}
+
+		// Write both fields: Current-only gets clamped to surviving Decayed on reload.
+		// Fallback target = 100.0 covers the 0-100 gear scale when MaxDurability is absent.
+		res, err := globalDB.Exec(ctx, `
+			UPDATE dune.items i
 			SET stats = jsonb_set(
-				stats,
-				'{FItemStackAndDurabilityStats,1,CurrentDurability}',
-				(stats->'FItemStackAndDurabilityStats'->1->'MaxDurability')
-			)
-			WHERE id = $1::bigint
-			  AND stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability' IS NOT NULL
-			  AND (stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float > 0`, itemID)
+				jsonb_set(i.stats,
+					'{FItemStackAndDurabilityStats,1,CurrentDurability}',
+					to_jsonb(t.val), true),
+				'{FItemStackAndDurabilityStats,1,DecayedMaxDurability}',
+				to_jsonb(t.val), true)
+			FROM (
+				SELECT COALESCE(
+					(stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float8,
+					100.0
+				) AS val
+				FROM dune.items
+				WHERE id = $1::bigint
+				  AND stats ? 'FItemStackAndDurabilityStats'
+			) AS t
+			WHERE i.id = $1::bigint
+			  AND (
+				abs(COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0) - t.val) > 0.01
+				OR abs(COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0) - t.val) > 0.01
+			  )`, itemID)
 		if err != nil {
 			return msgMutate{err: fmt.Errorf("repair item: %w", err)}
 		}
 		if res.RowsAffected() == 0 {
-			return msgMutate{err: fmt.Errorf("item %d not found or has no repairable durability", itemID)}
+			// Item exists (owner lookup succeeded). Either no durability field, or already at ceiling.
+			var hasDur bool
+			if err := globalDB.QueryRow(ctx, `
+				SELECT stats ? 'FItemStackAndDurabilityStats'
+				FROM dune.items WHERE id = $1::bigint`, itemID).Scan(&hasDur); err != nil {
+				return msgMutate{err: fmt.Errorf("check item: %w", err)}
+			}
+			if !hasDur {
+				return msgMutate{err: fmt.Errorf("item %d has no durability field", itemID)}
+			}
+			return msgMutate{ok: fmt.Sprintf("Item %d already at full durability", itemID)}
 		}
-		return msgMutate{ok: fmt.Sprintf("Repaired item %d", itemID)}
+		return msgMutate{ok: fmt.Sprintf("Repaired item %d — relog to see in-game", itemID)}
 	}
 }
 

--- a/db.go
+++ b/db.go
@@ -3380,6 +3380,81 @@ func cmdRepairPlayerGear(playerID int64) Cmd {
 	}
 }
 
+func cmdRepairVehicle(playerID, vehicleID int64) Cmd {
+	return func() Msg {
+		if globalDB == nil {
+			return msgRepairVehicle{err: fmt.Errorf("not connected")}
+		}
+		if playerID == 0 {
+			return msgRepairVehicle{err: fmt.Errorf("player ID required")}
+		}
+		ctx := context.Background()
+		if err := checkPlayerOffline(ctx, playerID); err != nil {
+			return msgRepairVehicle{err: err}
+		}
+
+		var exists bool
+		err := globalDB.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM dune.actors WHERE id = $1::bigint)`, vehicleID).Scan(&exists)
+		if err != nil {
+			return msgRepairVehicle{err: fmt.Errorf("look up vehicle: %w", err)}
+		}
+		if !exists {
+			return msgRepairVehicle{err: fmt.Errorf("vehicle %d not found", vehicleID)}
+		}
+
+		rows, err := globalDB.Query(ctx, `
+			SELECT id, template_id
+			FROM dune.vehicle_modules
+			WHERE vehicle_id = $1::bigint`, vehicleID)
+		if err != nil {
+			return msgRepairVehicle{err: fmt.Errorf("scan modules: %w", err)}
+		}
+		defer rows.Close()
+
+		type moduleRow struct {
+			id         int64
+			templateID string
+		}
+		var modules []moduleRow
+		for rows.Next() {
+			var m moduleRow
+			if err := rows.Scan(&m.id, &m.templateID); err != nil {
+				continue
+			}
+			modules = append(modules, m)
+		}
+		if err := rows.Err(); err != nil {
+			return msgRepairVehicle{err: err}
+		}
+
+		total := len(modules)
+		repaired := 0
+		skipped := 0
+		for _, m := range modules {
+			target, ok := itemMaxDurability(m.templateID)
+			if !ok || target <= 0 {
+				skipped++
+				continue
+			}
+			// Both fields must be written — Current-only is clamped to surviving Decayed on reload.
+			_, err := globalDB.Exec(ctx, `
+				UPDATE dune.vehicle_modules
+				SET stats = jsonb_set(
+					jsonb_set(stats,
+						'{FVehicleModuleDurabilityStats,1,CurrentDurability}',
+						to_jsonb($2::float8), true),
+					'{FVehicleModuleDurabilityStats,1,DecayedMaxDurability}',
+					to_jsonb($2::float8), true)
+				WHERE id = $1::bigint`, m.id, target)
+			if err != nil {
+				return msgRepairVehicle{repaired: repaired, skipped: skipped, total: total, err: fmt.Errorf("repair module %d: %w", m.id, err)}
+			}
+			repaired++
+		}
+		return msgRepairVehicle{repaired: repaired, skipped: skipped, total: total}
+	}
+}
+
 func cmdFetchCheatLog() Cmd {
 	return func() Msg {
 		if globalDB == nil {

--- a/db.go
+++ b/db.go
@@ -3282,6 +3282,104 @@ func cmdRepairItem(itemID int64) Cmd {
 	}
 }
 
+// Carried inventories: backpack, equipment, emote wheel, equipped weapons, action wheel, bank.
+var repairGearInventoryTypes = []int32{0, 1, 14, 15, 27, 30}
+
+func cmdRepairPlayerGear(playerID int64) Cmd {
+	return func() Msg {
+		if globalDB == nil {
+			return msgRepairGear{err: fmt.Errorf("not connected")}
+		}
+		if playerID == 0 {
+			return msgRepairGear{err: fmt.Errorf("player ID required")}
+		}
+		ctx := context.Background()
+		if err := checkPlayerOffline(ctx, playerID); err != nil {
+			return msgRepairGear{err: err}
+		}
+
+		rows, err := globalDB.Query(ctx, `
+			SELECT i.id, i.template_id,
+			       (i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability'),
+			       (i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability'),
+			       (i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')
+			FROM dune.items i
+			JOIN dune.inventories inv ON inv.id = i.inventory_id
+			WHERE inv.actor_id = $1::bigint
+			  AND inv.inventory_type = ANY($2::int[])
+			  AND i.stats ? 'FItemStackAndDurabilityStats'`,
+			playerID, repairGearInventoryTypes)
+		if err != nil {
+			return msgRepairGear{err: fmt.Errorf("scan items: %w", err)}
+		}
+		defer rows.Close()
+
+		type repairCandidate struct {
+			id     int64
+			target float64
+		}
+		var toRepair []repairCandidate
+		scanned := 0
+		for rows.Next() {
+			scanned++
+			var id int64
+			var templateID string
+			var maxStr, curStr, decayedStr pgtype.Text
+			if err := rows.Scan(&id, &templateID, &maxStr, &curStr, &decayedStr); err != nil {
+				continue
+			}
+
+			// Target priority: catalog (vehicle modules stored as items) → stats.MaxDurability → 100.
+			var target float64
+			if v, ok := itemMaxDurability(templateID); ok && v > 0 {
+				target = v
+			} else if maxStr.Valid {
+				if v, perr := strconv.ParseFloat(maxStr.String, 64); perr == nil && v > 0 {
+					target = v
+				} else {
+					target = 100.0
+				}
+			} else {
+				target = 100.0
+			}
+
+			cur := 0.0
+			if curStr.Valid {
+				cur, _ = strconv.ParseFloat(curStr.String, 64)
+			}
+			decayed := 0.0
+			if decayedStr.Valid {
+				decayed, _ = strconv.ParseFloat(decayedStr.String, 64)
+			}
+			if math.Abs(cur-target) < 0.01 && math.Abs(decayed-target) < 0.01 {
+				continue
+			}
+			toRepair = append(toRepair, repairCandidate{id: id, target: target})
+		}
+		if err := rows.Err(); err != nil {
+			return msgRepairGear{err: fmt.Errorf("scan rows: %w", err)}
+		}
+
+		repaired := 0
+		for _, rc := range toRepair {
+			_, err := globalDB.Exec(ctx, `
+				UPDATE dune.items
+				SET stats = jsonb_set(
+					jsonb_set(stats,
+						'{FItemStackAndDurabilityStats,1,CurrentDurability}',
+						to_jsonb($2::float8), true),
+					'{FItemStackAndDurabilityStats,1,DecayedMaxDurability}',
+					to_jsonb($2::float8), true)
+				WHERE id = $1::bigint`, rc.id, rc.target)
+			if err != nil {
+				return msgRepairGear{repaired: repaired, scanned: scanned, err: fmt.Errorf("repair item %d: %w", rc.id, err)}
+			}
+			repaired++
+		}
+		return msgRepairGear{repaired: repaired, scanned: scanned}
+	}
+}
+
 func cmdFetchCheatLog() Cmd {
 	return func() Msg {
 		if globalDB == nil {

--- a/db.go
+++ b/db.go
@@ -3455,6 +3455,49 @@ func cmdRepairVehicle(playerID, vehicleID int64) Cmd {
 	}
 }
 
+func cmdRefuelVehicle(playerID, vehicleID int64) Cmd {
+	return func() Msg {
+		if globalDB == nil {
+			return msgMutate{err: fmt.Errorf("not connected")}
+		}
+		if playerID == 0 {
+			return msgMutate{err: fmt.Errorf("player ID required")}
+		}
+		ctx := context.Background()
+		if err := checkPlayerOffline(ctx, playerID); err != nil {
+			return msgMutate{err: err}
+		}
+
+		// Each vehicle BP has its own properties bag keyed by the class basename
+		// (e.g. "BP_Sandbike_CHOAM_C"), so we derive it before writing m_InitialFuel.
+		var class string
+		err := globalDB.QueryRow(ctx, `SELECT class FROM dune.actors WHERE id = $1::bigint`, vehicleID).Scan(&class)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return msgMutate{err: fmt.Errorf("vehicle %d not found", vehicleID)}
+		}
+		if err != nil {
+			return msgMutate{err: fmt.Errorf("look up vehicle class: %w", err)}
+		}
+		bpClass := class
+		if idx := strings.LastIndex(class, "."); idx >= 0 {
+			bpClass = class[idx+1:]
+		}
+
+		_, err = globalDB.Exec(ctx, `
+			UPDATE dune.actors
+			SET properties = jsonb_set(
+				COALESCE(properties, '{}'::jsonb),
+				ARRAY[$2::text, 'm_InitialFuel'],
+				to_jsonb(1.0::float8),
+				true)
+			WHERE id = $1::bigint`, vehicleID, bpClass)
+		if err != nil {
+			return msgMutate{err: fmt.Errorf("refuel vehicle: %w", err)}
+		}
+		return msgMutate{ok: fmt.Sprintf("Refueled vehicle %d — relog to see in-game", vehicleID)}
+	}
+}
+
 func cmdFetchCheatLog() Cmd {
 	return func() Msg {
 		if globalDB == nil {

--- a/handlers_players.go
+++ b/handlers_players.go
@@ -1036,6 +1036,26 @@ func handleRepairItem(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"ok": msg.ok})
 }
 
+func handleRepairPlayerGear(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		PlayerID int64 `json:"player_id"`
+	}
+	if err := decode(r, &req); err != nil {
+		jsonErr(w, err, 400)
+		return
+	}
+	msg, ok := cmdRepairPlayerGear(req.PlayerID)().(msgRepairGear)
+	if !ok {
+		jsonErr(w, fmt.Errorf("internal error"), 500)
+		return
+	}
+	if msg.err != nil {
+		jsonErr(w, msg.err, 500)
+		return
+	}
+	jsonOK(w, map[string]any{"repaired": msg.repaired, "scanned": msg.scanned})
+}
+
 func handleGetPartitions(w http.ResponseWriter, r *http.Request) {
 	msg, ok := cmdListPartitions()().(msgPartitions)
 	if !ok {

--- a/handlers_players.go
+++ b/handlers_players.go
@@ -1056,6 +1056,27 @@ func handleRepairPlayerGear(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]any{"repaired": msg.repaired, "scanned": msg.scanned})
 }
 
+func handleRepairVehicle(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		PlayerID  int64 `json:"player_id"`
+		VehicleID int64 `json:"vehicle_id"`
+	}
+	if err := decode(r, &req); err != nil {
+		jsonErr(w, err, 400)
+		return
+	}
+	msg, ok := cmdRepairVehicle(req.PlayerID, req.VehicleID)().(msgRepairVehicle)
+	if !ok {
+		jsonErr(w, fmt.Errorf("internal error"), 500)
+		return
+	}
+	if msg.err != nil {
+		jsonErr(w, msg.err, 500)
+		return
+	}
+	jsonOK(w, map[string]any{"repaired": msg.repaired, "skipped": msg.skipped, "total": msg.total})
+}
+
 func handleGetPartitions(w http.ResponseWriter, r *http.Request) {
 	msg, ok := cmdListPartitions()().(msgPartitions)
 	if !ok {

--- a/handlers_players.go
+++ b/handlers_players.go
@@ -1077,6 +1077,27 @@ func handleRepairVehicle(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]any{"repaired": msg.repaired, "skipped": msg.skipped, "total": msg.total})
 }
 
+func handleRefuelVehicle(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		PlayerID  int64 `json:"player_id"`
+		VehicleID int64 `json:"vehicle_id"`
+	}
+	if err := decode(r, &req); err != nil {
+		jsonErr(w, err, 400)
+		return
+	}
+	msg, ok := cmdRefuelVehicle(req.PlayerID, req.VehicleID)().(msgMutate)
+	if !ok {
+		jsonErr(w, fmt.Errorf("internal error"), 500)
+		return
+	}
+	if msg.err != nil {
+		jsonErr(w, msg.err, 500)
+		return
+	}
+	jsonOK(w, map[string]string{"ok": msg.ok})
+}
+
 func handleGetPartitions(w http.ResponseWriter, r *http.Request) {
 	msg, ok := cmdListPartitions()().(msgPartitions)
 	if !ok {

--- a/helpers.go
+++ b/helpers.go
@@ -1,6 +1,9 @@
 package main
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 // shortClass strips the UE class path prefix and _C suffix from an actor class name.
 func shortClass(s string) string {
@@ -14,4 +17,24 @@ func shortClass(s string) string {
 		"DunePlayerState", "PlayerState",
 	)
 	return replacer.Replace(s)
+}
+
+// Per-position locomotion modules (e.g. OrnithopterLightLocomotionFrontLeft_6) share
+// a single generic catalog entry (ornithopterlightlocomotion_6).
+var locomotionPositionRe = regexp.MustCompile(`locomotion(frontleft|frontright|backleft|backright|backcenter)`)
+
+// itemMaxDurability returns the catalog-defined max_durability for a template_id,
+// retrying with the position suffix stripped for per-position locomotion modules.
+// Returns (0, false) when the catalog has no max_durability for the template.
+func itemMaxDurability(templateID string) (float64, bool) {
+	key := strings.ToLower(templateID)
+	if rule, ok := itemData.Items[key]; ok && rule.MaxDurability != nil {
+		return *rule.MaxDurability, true
+	}
+	if stripped := locomotionPositionRe.ReplaceAllString(key, "locomotion"); stripped != key {
+		if rule, ok := itemData.Items[stripped]; ok && rule.MaxDurability != nil {
+			return *rule.MaxDurability, true
+		}
+	}
+	return 0, false
 }

--- a/model.go
+++ b/model.go
@@ -61,11 +61,12 @@ type specTrack struct {
 }
 
 type itemRule struct {
-	Name     string  `json:"name"`
-	StackMax int64   `json:"stack_max"`
-	Volume   float64 `json:"volume"`
-	Tier     int     `json:"tier"`
-	Rarity   string  `json:"rarity"`
+	Name          string   `json:"name"`
+	StackMax      int64    `json:"stack_max"`
+	Volume        float64  `json:"volume"`
+	Tier          int      `json:"tier"`
+	Rarity        string   `json:"rarity"`
+	MaxDurability *float64 `json:"max_durability,omitempty"`
 }
 
 type itemDataFile struct {
@@ -150,6 +151,11 @@ type msgSQL struct {
 type msgMutate struct {
 	ok  string
 	err error
+}
+type msgRepairGear struct {
+	repaired int
+	scanned  int
+	err      error
 }
 type msgJourney struct {
 	rows []journeyNode

--- a/model.go
+++ b/model.go
@@ -157,6 +157,12 @@ type msgRepairGear struct {
 	scanned  int
 	err      error
 }
+type msgRepairVehicle struct {
+	repaired int
+	skipped  int
+	total    int
+	err      error
+}
 type msgJourney struct {
 	rows []journeyNode
 	err  error

--- a/server.go
+++ b/server.go
@@ -109,6 +109,7 @@ func startServer(addr string) {
 	mux.HandleFunc("POST /api/v1/players/grant-max-spec", handleGrantMaxSpec)
 	mux.HandleFunc("GET /api/v1/players/{id}/vehicles", handleGetPlayerVehicles)
 	mux.HandleFunc("POST /api/v1/players/repair-item", handleRepairItem)
+	mux.HandleFunc("POST /api/v1/players/repair-gear", handleRepairPlayerGear)
 	mux.HandleFunc("GET /api/v1/players/partitions", handleGetPartitions)
 	mux.HandleFunc("POST /api/v1/players/teleport", handleTeleportPlayer)
 	mux.HandleFunc("GET /api/v1/players/{id}/events", handleGetPlayerEvents)

--- a/server.go
+++ b/server.go
@@ -111,6 +111,7 @@ func startServer(addr string) {
 	mux.HandleFunc("POST /api/v1/players/repair-item", handleRepairItem)
 	mux.HandleFunc("POST /api/v1/players/repair-gear", handleRepairPlayerGear)
 	mux.HandleFunc("POST /api/v1/players/repair-vehicle", handleRepairVehicle)
+	mux.HandleFunc("POST /api/v1/players/refuel-vehicle", handleRefuelVehicle)
 	mux.HandleFunc("GET /api/v1/players/partitions", handleGetPartitions)
 	mux.HandleFunc("POST /api/v1/players/teleport", handleTeleportPlayer)
 	mux.HandleFunc("GET /api/v1/players/{id}/events", handleGetPlayerEvents)

--- a/server.go
+++ b/server.go
@@ -110,6 +110,7 @@ func startServer(addr string) {
 	mux.HandleFunc("GET /api/v1/players/{id}/vehicles", handleGetPlayerVehicles)
 	mux.HandleFunc("POST /api/v1/players/repair-item", handleRepairItem)
 	mux.HandleFunc("POST /api/v1/players/repair-gear", handleRepairPlayerGear)
+	mux.HandleFunc("POST /api/v1/players/repair-vehicle", handleRepairVehicle)
 	mux.HandleFunc("GET /api/v1/players/partitions", handleGetPartitions)
 	mux.HandleFunc("POST /api/v1/players/teleport", handleTeleportPlayer)
 	mux.HandleFunc("GET /api/v1/players/{id}/events", handleGetPlayerEvents)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -159,6 +159,8 @@ export const api = {
     repairItem: (id: number) => req<MutateResult>('POST', '/players/repair-item', { id }),
     repairGear: (player_id: number) =>
       req<{repaired: number; scanned: number}>('POST', '/players/repair-gear', { player_id }),
+    repairVehicle: (vehicle_id: number, player_id: number) =>
+      req<{repaired: number; skipped: number; total: number}>('POST', '/players/repair-vehicle', { vehicle_id, player_id }),
     partitions: () => req<TeleportLocation[]>('GET', '/players/partitions'),
     teleport: (fls_id: string, partition_label: string) =>
       req<MutateResult>('POST', '/players/teleport', { fls_id, partition_label }),

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -161,6 +161,8 @@ export const api = {
       req<{repaired: number; scanned: number}>('POST', '/players/repair-gear', { player_id }),
     repairVehicle: (vehicle_id: number, player_id: number) =>
       req<{repaired: number; skipped: number; total: number}>('POST', '/players/repair-vehicle', { vehicle_id, player_id }),
+    refuelVehicle: (vehicle_id: number, player_id: number) =>
+      req<MutateResult>('POST', '/players/refuel-vehicle', { vehicle_id, player_id }),
     partitions: () => req<TeleportLocation[]>('GET', '/players/partitions'),
     teleport: (fls_id: string, partition_label: string) =>
       req<MutateResult>('POST', '/players/teleport', { fls_id, partition_label }),

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -157,6 +157,8 @@ export const api = {
       req<MutateResult>('POST', '/players/grant-all-keystones', { player_id }),
     vehicles: (controller_id: number) => req<VehicleRow[]>('GET', `/players/${controller_id}/vehicles`),
     repairItem: (id: number) => req<MutateResult>('POST', '/players/repair-item', { id }),
+    repairGear: (player_id: number) =>
+      req<{repaired: number; scanned: number}>('POST', '/players/repair-gear', { player_id }),
     partitions: () => req<TeleportLocation[]>('GET', '/players/partitions'),
     teleport: (fls_id: string, partition_label: string) =>
       req<MutateResult>('POST', '/players/teleport', { fls_id, partition_label }),

--- a/web/src/tabs/PlayersTab/modals/InventoryModal.tsx
+++ b/web/src/tabs/PlayersTab/modals/InventoryModal.tsx
@@ -76,6 +76,21 @@ export function InventoryModal({ player, open, onClose }: Props) {
     }
   }
 
+  const handleRepairAllGear = async () => {
+    try {
+      const res = await api.players.repairGear(player.id)
+      if (res.repaired === 0) {
+        toast.success(`No gear needed repair (${res.scanned} items scanned)`)
+      } else {
+        toast.success(`Repaired ${res.repaired} of ${res.scanned} gear pieces — relog to see in-game`)
+        // Refetch so the UI reflects the new durability values.
+        api.players.inventory(player.id).then(setItems).catch(() => {})
+      }
+    } catch (e: unknown) {
+      toast.danger(e instanceof Error ? e.message : String(e))
+    }
+  }
+
   return (
     <Modal>
       <Modal.Backdrop isOpen={open} onOpenChange={v => !v && onClose()}>
@@ -89,45 +104,51 @@ export function InventoryModal({ player, open, onClose }: Props) {
               ) : (
                 <div className="flex flex-col gap-4 flex-1 min-h-0 overflow-hidden">
                   {/* Items — fills remaining space and owns its own scroll */}
-                  <DataTable<InventoryItem, ItemKey>
-                    aria-label="Inventory items"
-                    className="flex-1 min-h-0"
-                    columns={ITEM_COLUMNS}
-                    rows={items}
-                    rowId={i => String(i.id)}
-                    initialSort={{ column: 'template', direction: 'ascending' }}
-                    sortValue={(i, k) => {
-                      if (k === 'template')   return i.name || i.template_id
-                      if (k === 'stack')      return i.stack_size
-                      if (k === 'quality')    return i.quality
-                      if (k === 'durability') return typeof i.durability === 'number' ? i.durability : 0
-                      return ''
-                    }}
-                    emptyState={<div className="py-6 text-center text-muted">No items found</div>}
-                    renderCell={(i, key) => {
-                      switch (key) {
-                        case 'template':
-                          return (
-                            <span className="inline-flex flex-col">
-                              <span className="font-semibold">{i.name || i.template_id}</span>
-                              {i.name && <span className="font-mono text-muted text-[10px]">{i.template_id}</span>}
-                            </span>
-                          )
-                        case 'stack':      return <span className="text-muted">{i.stack_size}</span>
-                        case 'quality':    return <span className="text-muted">{i.quality}</span>
-                        case 'durability': return <span className="text-muted">{i.durability} / {i.max_durability}</span>
-                        case 'actions':
-                          return (
-                            <div className="flex gap-1">
-                              {i.max_durability !== 'N/A' && (
-                                <Button size="sm" variant="ghost" onPress={() => handleRepair(i)}>Repair</Button>
-                              )}
-                              <Button size="sm" variant="danger-soft" onPress={() => handleDelete(i.id)}>X</Button>
-                            </div>
-                          )
-                      }
-                    }}
-                  />
+                  <div className="flex-1 min-h-0 flex flex-col gap-2">
+                    <div className="shrink-0 flex items-center justify-between">
+                      <h3 className="text-sm font-semibold text-accent">Items</h3>
+                      <Button size="sm" variant="ghost" onPress={handleRepairAllGear}>Repair gear</Button>
+                    </div>
+                    <DataTable<InventoryItem, ItemKey>
+                      aria-label="Inventory items"
+                      className="flex-1 min-h-0"
+                      columns={ITEM_COLUMNS}
+                      rows={items}
+                      rowId={i => String(i.id)}
+                      initialSort={{ column: 'template', direction: 'ascending' }}
+                      sortValue={(i, k) => {
+                        if (k === 'template')   return i.name || i.template_id
+                        if (k === 'stack')      return i.stack_size
+                        if (k === 'quality')    return i.quality
+                        if (k === 'durability') return typeof i.durability === 'number' ? i.durability : 0
+                        return ''
+                      }}
+                      emptyState={<div className="py-6 text-center text-muted">No items found</div>}
+                      renderCell={(i, key) => {
+                        switch (key) {
+                          case 'template':
+                            return (
+                              <span className="inline-flex flex-col">
+                                <span className="font-semibold">{i.name || i.template_id}</span>
+                                {i.name && <span className="font-mono text-muted text-[10px]">{i.template_id}</span>}
+                              </span>
+                            )
+                          case 'stack':      return <span className="text-muted">{i.stack_size}</span>
+                          case 'quality':    return <span className="text-muted">{i.quality}</span>
+                          case 'durability': return <span className="text-muted">{i.durability} / {i.max_durability}</span>
+                          case 'actions':
+                            return (
+                              <div className="flex gap-1">
+                                {i.max_durability !== 'N/A' && (
+                                  <Button size="sm" variant="ghost" onPress={() => handleRepair(i)}>Repair</Button>
+                                )}
+                                <Button size="sm" variant="danger-soft" onPress={() => handleDelete(i.id)}>X</Button>
+                              </div>
+                            )
+                        }
+                      }}
+                    />
+                  </div>
 
                   {/* Vehicles — fixed ~4-row window, scrolls independently */}
                   <div className="shrink-0 flex flex-col gap-2">

--- a/web/src/tabs/PlayersTab/modals/InventoryModal.tsx
+++ b/web/src/tabs/PlayersTab/modals/InventoryModal.tsx
@@ -5,7 +5,7 @@ import type { Player, InventoryItem, VehicleRow } from '../../../api/client'
 import { DataTable, type Column } from '../../../dune-ui'
 
 type ItemKey = 'template' | 'stack' | 'quality' | 'durability' | 'actions'
-type VehicleKey = 'class' | 'location' | 'chassis' | 'name' | 'type'
+type VehicleKey = 'class' | 'location' | 'chassis' | 'name' | 'type' | 'actions'
 
 const ITEM_COLUMNS: Column<ItemKey>[] = [
   { key: 'template',   label: 'Template', isRowHeader: true },
@@ -21,6 +21,7 @@ const VEHICLE_COLUMNS: Column<VehicleKey>[] = [
   { key: 'chassis',  label: 'Chassis' },
   { key: 'name',     label: 'Name' },
   { key: 'type',     label: 'Type', sortable: false },
+  { key: 'actions',  label: '', sortable: false },
 ]
 
 interface Props {
@@ -71,6 +72,24 @@ export function InventoryModal({ player, open, onClose }: Props) {
       await api.players.repairItem(item.id)
       setItems(prev => prev.map(i => i.id === item.id ? { ...i, durability: i.max_durability } : i))
       toast.success(`Repaired ${item.name || item.template_id}`)
+    } catch (e: unknown) {
+      toast.danger(e instanceof Error ? e.message : String(e))
+    }
+  }
+
+  const handleRepairVehicle = async (v: VehicleRow) => {
+    try {
+      const res = await api.players.repairVehicle(v.id, player.id)
+      const label = v.vehicle_name || v.class
+      if (res.total === 0) {
+        toast.success(`No modules found on ${label}`)
+      } else if (res.skipped > 0) {
+        toast.success(`Repaired ${res.repaired} of ${res.total} modules on ${label} (${res.skipped} skipped, no catalog data) — relog to see in-game`)
+      } else {
+        toast.success(`Repaired ${res.repaired} modules on ${label} — relog to see in-game`)
+      }
+      // Refresh the chassis % indicator.
+      api.players.vehicles(player.controller_id).then(setVehicles).catch(() => {})
     } catch (e: unknown) {
       toast.danger(e instanceof Error ? e.message : String(e))
     }
@@ -189,6 +208,12 @@ export function InventoryModal({ player, open, onClose }: Props) {
                                 {v.is_recovered && <Chip size="sm" color="warning" variant="soft">Recovered</Chip>}
                               </div>
                             )
+                          case 'actions':
+                            return !v.is_backup ? (
+                              <div className="flex gap-1">
+                                <Button size="sm" variant="ghost" onPress={() => handleRepairVehicle(v)}>Repair</Button>
+                              </div>
+                            ) : null
                         }
                       }}
                     />

--- a/web/src/tabs/PlayersTab/modals/InventoryModal.tsx
+++ b/web/src/tabs/PlayersTab/modals/InventoryModal.tsx
@@ -77,6 +77,21 @@ export function InventoryModal({ player, open, onClose }: Props) {
     }
   }
 
+  const handleRepairAllGear = async () => {
+    try {
+      const res = await api.players.repairGear(player.id)
+      if (res.repaired === 0) {
+        toast.success(`No gear needed repair (${res.scanned} items scanned)`)
+      } else {
+        toast.success(`Repaired ${res.repaired} of ${res.scanned} gear pieces — relog to see in-game`)
+        // Refetch so the UI reflects the new durability values.
+        api.players.inventory(player.id).then(setItems).catch(() => {})
+      }
+    } catch (e: unknown) {
+      toast.danger(e instanceof Error ? e.message : String(e))
+    }
+  }
+
   const handleRepairVehicle = async (v: VehicleRow) => {
     try {
       const res = await api.players.repairVehicle(v.id, player.id)
@@ -95,16 +110,10 @@ export function InventoryModal({ player, open, onClose }: Props) {
     }
   }
 
-  const handleRepairAllGear = async () => {
+  const handleRefuelVehicle = async (v: VehicleRow) => {
     try {
-      const res = await api.players.repairGear(player.id)
-      if (res.repaired === 0) {
-        toast.success(`No gear needed repair (${res.scanned} items scanned)`)
-      } else {
-        toast.success(`Repaired ${res.repaired} of ${res.scanned} gear pieces — relog to see in-game`)
-        // Refetch so the UI reflects the new durability values.
-        api.players.inventory(player.id).then(setItems).catch(() => {})
-      }
+      await api.players.refuelVehicle(v.id, player.id)
+      toast.success(`Refueled ${v.vehicle_name || v.class} — relog to see in-game`)
     } catch (e: unknown) {
       toast.danger(e instanceof Error ? e.message : String(e))
     }
@@ -212,6 +221,7 @@ export function InventoryModal({ player, open, onClose }: Props) {
                             return !v.is_backup ? (
                               <div className="flex gap-1">
                                 <Button size="sm" variant="ghost" onPress={() => handleRepairVehicle(v)}>Repair</Button>
+                                <Button size="sm" variant="ghost" onPress={() => handleRefuelVehicle(v)}>Refuel</Button>
                               </div>
                             ) : null
                         }


### PR DESCRIPTION
## Summary

Four "fix what the game won't let you fix" admin actions, all gated on the player being Offline:

- **Fix** — `repair-item` (existing): missing Offline gate + writes both `CurrentDurability` and `DecayedMaxDurability` (writing only Current is silently clamped to the surviving Decayed ceiling on the next reload).
- **Feature** — batch repair player gear (one-click "Repair gear" in the inventory header).
- **Feature** — per-vehicle module repair + per-row Repair button.
- **Feature** — vehicle refuel (sets `m_InitialFuel = 1.0`) + per-row Refuel button.

## Why these exist

Funcom hardcoded all the decay/recovery math — no `*.ini` knob to disable or tune. Concretely:

| Pain | Fix |
|---|---|
| Vehicle modules accumulate `DecayedMaxDurability` — permanent ceiling drops over time | Restore both Current and Decayed to original max |
| Vehicle recovery applies a hardcoded 15% chassis penalty (`0.85` constant) | Same SQL — running repair post-recovery cancels the penalty exactly |
| Vehicle fuel doesn't refill at safehouses | Set `m_InitialFuel = 1.0` on the BP-class properties bag |
| Player gear decays during use; rates live on `FCharacterDurabilityLossAttributesComponent` AttributeSet (also no ini knob) | Bulk SQL bump across the player's carried inventories |

## Endpoints

| Method | Path | Body | Returns |
|---|---|---|---|
| POST | `/api/v1/players/repair-item` | `{id}` | `{ok}` |
| POST | `/api/v1/players/repair-gear` | `{player_id}` | `{repaired, scanned}` |
| POST | `/api/v1/players/repair-vehicle` | `{player_id, vehicle_id}` | `{repaired, skipped, total}` |
| POST | `/api/v1/players/refuel-vehicle` | `{player_id, vehicle_id}` | `{ok}` |

## Schema dependencies (first-touch in this codebase)

- `dune.vehicle_modules` (id, vehicle_id, template_id, stats) — per-module durability. jsonb shape: `stats.FVehicleModuleDurabilityStats[1].{CurrentDurability,DecayedMaxDurability}`.
- `dune.actors.properties[<BP_class_basename>].m_InitialFuel` — fuel lives on the per-BP-class sub-bag (e.g. `properties.BP_Sandbike_CHOAM_C.m_InitialFuel`); derived from `actors.class` via the `rsplit('.', 1)[-1]` basename rule.

Both confirmed empirically against a live GA cluster.

## Catalog dependency

Adds optional `max_durability *float64` on `itemRule`, plus an `itemMaxDurability()` helper that reads it with locomotion-position suffix normalization (per-position modules like `OrnithopterLightLocomotionFrontLeft_6` resolve to the generic `ornithopterlightlocomotion_6` entry).

Degrades gracefully when the field is absent:
- Vehicle repair: skips the module, surfaces the skip count in the toast.
- Gear repair: falls back to `stats.MaxDurability` (canteens etc.) or 100.0 (the 0–100 gear scale).

## Safety invariants

- All four mutations gate on `checkPlayerOffline()`.
- Vehicle-module and item writes touch both `CurrentDurability` AND `DecayedMaxDurability` — Current-only is clamped on the next reload.
- Idempotent: items/modules already at ceiling (within 0.01 tolerance) are skipped.
- All success toasts include "— relog to see in-game" since the running client caches these values.

## Test plan

- [ ] Player Offline → POST `/players/repair-gear`, returns sensible `{repaired, scanned}`
- [ ] Player Offline → POST `/players/repair-vehicle` with a deployed vehicle's id, returns `{repaired, skipped, total}` with `skipped=0` for templates that have `max_durability` in `item-data.json`
- [ ] Player Offline → POST `/players/refuel-vehicle`, returns `{ok}` and `actors.properties[<bp_class>].m_InitialFuel == 1.0`
- [ ] Player Online → any of the above returns a "player is X — log out first" error
- [ ] UI: open inventory modal, "Repair gear" button visible in the new Items header
- [ ] UI: vehicles table shows Repair + Refuel buttons on non-backup rows (hidden on backups)
- [ ] Relog → in-game durability / fuel bars match the DB writes

## Out of scope (on purpose)

- Container / placeable inventory repair (separate workflow — bases have lots of storage; a single "fix everything" button felt too aggressive).
- Auto-repair on a cron (the relog requirement makes it pointless — user already has to log out/in to see the result).

🤖 Generated with [Claude Code](https://claude.com/claude-code)