### PR TITLE
hotfix(ui): k8s/CDN deploys hit Cloudflare SPA fallback as API (regression from #9)

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -7,12 +7,21 @@ declare global {
 function getApiBase(): string {
   const stored = localStorage.getItem('dune_admin_backend')
   if (stored) return stored.replace(/\/$/, '') + '/api/v1'
-  // When the SPA is served from a Go-binary deploy (any host other than the
-  // Vite dev server's localhost), the backend is the same origin. Only the
-  // dev-time localhost case needs the :8080 default.
-  if (typeof window !== 'undefined' &&
-      window.location.hostname !== 'localhost' &&
-      window.location.hostname !== '127.0.0.1') {
+
+  // CDN-hosted deploy detection: VITE_CDN_BASE_URL is set at build time by
+  // the Cloudflare Pages workflow and unset for single-binary Go builds
+  // (AMP / local make build / GoReleaser). On a CDN deploy the SPA and the
+  // backend are on different origins, so defaulting to window.location.origin
+  // would hit Cloudflare's SPA fallback (index.html) instead of the API,
+  // producing the "Unexpected token '<', '<!DOCTYPE'" JSON parse error on
+  // every tab. Fall through to the localhost dev default and require k8s
+  // users to set localStorage('dune_admin_backend') to their SSH tunnel.
+  const isCdnDeploy = !!(import.meta.env.VITE_CDN_BASE_URL as string | undefined)
+
+  // Single-binary deploys (AMP, local Go): SPA and API are same-origin.
+  // Anything that isn't the Vite dev server gets the auto-detected origin.
+  const devHosts = new Set(['localhost', '127.0.0.1', '::1', '[::1]'])
+  if (!isCdnDeploy && typeof window !== 'undefined' && !devHosts.has(window.location.hostname)) {
     return window.location.origin + '/api/v1'
   }
   return 'http://localhost:8080/api/v1'


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by #9 that breaks all API calls on the Cloudflare-Pages-hosted frontend (k8s deployments). Every tab fails with:

```
Status failed: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

## Root cause

#9's `getApiBase()` in `web/src/api/client.ts` added a same-origin default for any non-localhost hostname so that single-binary deploys (AMP, local Go) Just Work:

```ts
if (window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1') {
  return window.location.origin + '/api/v1'
}
```

On the Cloudflare Pages deploy, `window.location.origin` is `https://dune-admin.layout.tools`. Cloudflare Pages serves `index.html` for any path that doesn't match a static file, so calls to `https://dune-admin.layout.tools/api/v1/status` come back as the SPA shell. The frontend's `res.json()` then chokes on `<!DOCTYPE html>`.

## Fix

Detect CDN-hosted builds via the existing `VITE_CDN_BASE_URL` env var (set by `.github/workflows/deploy.yml`, unset for single-binary builds). When `VITE_CDN_BASE_URL` is defined, fall through to the pre-#9 localhost default — Cloudflare users must still set `localStorage('dune_admin_backend')` to their SSH tunnel, same behaviour as before.

```ts
const isCdnDeploy = !!(import.meta.env.VITE_CDN_BASE_URL as string | undefined)
const devHosts = new Set(['localhost', '127.0.0.1', '::1', '[::1]'])
if (!isCdnDeploy && typeof window !== 'undefined' && !devHosts.has(window.location.hostname)) {
  return window.location.origin + '/api/v1'
}
return 'http://localhost:8080/api/v1'
```

Also closes #15 (IPv6 `::1` not excluded from the dev-host set) in the same diff — same file, related concern.

## Behaviour matrix

| Deploy | `VITE_CDN_BASE_URL` | hostname | localStorage | Result |
|---|---|---|---|---|
| Cloudflare Pages (k8s users) | set | `dune-admin.layout.tools` | unset | `http://localhost:8080/api/v1` (matches pre-#9) |
| Cloudflare Pages (k8s users) | set | `dune-admin.layout.tools` | set | localStorage value |
| Single-binary (AMP, local) | unset | `172.16.x.x` or any other | unset | `window.location.origin + /api/v1` |
| Vite dev (`pnpm dev`) | unset | `localhost` / `::1` | unset | `http://localhost:8080/api/v1` |

## Verification

* `pnpm build` passes
* No backend changes
* Single file diff (`web/src/api/client.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
