### PR TITLE
[REFACTOR] Phase 2: embed market bot and harden deployment/runtime paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,10 @@ sshKey.pub
 fetch-item-data.js
 
 # Compiled binaries
-dune-admin
-dune-admin-linux
-dune-admin.exe
+/bin/
+/dune-admin
+/dune-admin-linux
+/dune-admin.exe
 *.exe
 
 # Tools (downloaded, not part of the project)
@@ -37,9 +38,12 @@ blueprint.json
 # Exception: community-facing ADRs and deployment docs are tracked.
 docs/*
 !docs/amp-direct-connect/
+!docs/adr/
+!docs/plans/
 
 # Local dev/testing artifacts
 local/
+deploy/k8s/dune-admin.rendered.yaml
 
 # Reference material / ideas / scratch — not for sharing
 Samples-Ideas/

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,35 +1,3 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-cmdGiveItem                    db.go:262:1                         109  https://github.com/Icehunter/dune-admin/issues/18
-handleExportBase               handlers_bases.go:82:1              53   https://github.com/Icehunter/dune-admin/issues/19
-cmdReverseContracts            db.go:1695:1                        51   https://github.com/Icehunter/dune-admin/issues/20
-cmdRepairPlayerGear            db.go:3336:1                        46   https://github.com/Icehunter/dune-admin/issues/21
-handleGetServerSettings        handlers_server_settings.go:410:1   41   https://github.com/Icehunter/dune-admin/issues/22
-importBlueprintData            handlers_blueprints.go:274:1        41   https://github.com/Icehunter/dune-admin/issues/23
-cmdCompleteContracts           db.go:1618:1                        38   https://github.com/Icehunter/dune-admin/issues/24
-handleBGBackupUpload           handlers_battlegroup.go:203:1       37   https://github.com/Icehunter/dune-admin/issues/25
-checkInventoryCapacity         db.go:476:1                         37   https://github.com/Icehunter/dune-admin/issues/26
-handleMarketItems              handlers_market.go:12:1             34   https://github.com/Icehunter/dune-admin/issues/27
-cmdAwardCharXP                 db.go:2723:1                        33   https://github.com/Icehunter/dune-admin/issues/28
-cmdProgressionUnlock           db.go:2314:1                        32   https://github.com/Icehunter/dune-admin/issues/29
-cmdReverseProgressionUnlock    db.go:2457:1                        32   https://github.com/Icehunter/dune-admin/issues/30
-main                           main.go:420:1                       30   https://github.com/Icehunter/dune-admin/issues/31
-handleUpdateServerSettings     handlers_server_settings.go:862:1   26   https://github.com/Icehunter/dune-admin/issues/33
-discoverDefaultINI             handlers_server_settings.go:339:1   26   https://github.com/Icehunter/dune-admin/issues/34
-cmdSetStarterClass             db.go:1866:1                        25   https://github.com/Icehunter/dune-admin/issues/35
-runKubectlSetup                setup.go:99:1                       25   https://github.com/Icehunter/dune-admin/issues/36
-parseINILines                  handlers_server_settings.go:198:1   24   https://github.com/Icehunter/dune-admin/issues/37
-cmdRepairVehicle               db.go:3440:1                        24   https://github.com/Icehunter/dune-admin/issues/39
-stripEmptySections             handlers_server_settings.go:703:1   22   https://github.com/Icehunter/dune-admin/issues/40
-handleGiveItems                handlers_players.go:230:1           22   https://github.com/Icehunter/dune-admin/issues/41
-fetchBlueprintData             handlers_blueprints.go:148:1        22   https://github.com/Icehunter/dune-admin/issues/42
-cmdApplyProgressionPreset      progression_presets.go:92:1         19   https://github.com/Icehunter/dune-admin/issues/43
-connectAll                     connection.go:40:1                  18   https://github.com/Icehunter/dune-admin/issues/44
-cmdRepairItem                  db.go:3265:1                        18   https://github.com/Icehunter/dune-admin/issues/45
-listGameProcesses              control_amp.go:104:1                17   https://github.com/Icehunter/dune-admin/issues/46
-cmdRunSQL                      db.go:219:1                         17   https://github.com/Icehunter/dune-admin/issues/47
-stripKeysFromContent           handlers_server_settings.go:756:1   17   https://github.com/Icehunter/dune-admin/issues/48
-handleSaveConfig               handlers_config.go:31:1             16   https://github.com/Icehunter/dune-admin/issues/49
-cmdSampleTable                 db.go:1277:1                        16   https://github.com/Icehunter/dune-admin/issues/50
-cmdGrantAllKeystones           db.go:3015:1                        16   https://github.com/Icehunter/dune-admin/issues/51

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: build web go linux dev dev-server dev-backend dev-web setup deploy-web \
+        render-k8s render-k8s-stdout k8s-dry-run \
         vulncheck gosec pnpm-audit \
         test test-race vet fmt fmt-check \
         tools verify \
@@ -17,14 +18,17 @@ GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_TIME ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS    := -ldflags "-s -w -X main.AppVersion=$(VERSION) -X main.GitCommit=$(GIT_COMMIT) -X main.BuildTime=$(BUILD_TIME)"
 
-# Build the binary.
-build:
+# Build frontend + backend binary.
+build: web go
+
+# Build backend binary only.
+go:
 	@mkdir -p bin
 	$(GO) build -trimpath $(LDFLAGS) -o $(BIN) $(CMD)
 	install -m 0755 $(BIN) ./dune-admin
 
 # Install the binary system-wide.
-install: build
+install: go
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install -m 0755 $(BIN) $(DESTDIR)$(PREFIX)/bin/dune-admin
 
@@ -53,10 +57,19 @@ setup:
 # ── Web ───────────────────────────────────────────────────────────────────────
 
 web:
-	cd web && npm ci && npm run build
+	cd web && pnpm install --frozen-lockfile && pnpm build
 
 deploy-web:
-	cd web && npm ci && npm run build && wrangler pages deploy dist --project-name dune-admin
+	cd web && pnpm install --frozen-lockfile && pnpm build && wrangler pages deploy dist --project-name dune-admin
+
+render-k8s:
+	go run $(CMD) -render-k8s deploy/k8s/dune-admin.rendered.yaml
+
+render-k8s-stdout:
+	go run $(CMD) -render-k8s -
+
+k8s-dry-run:
+	@$(MAKE) render-k8s-stdout | kubectl apply --dry-run=client -f -
 
 # ── Test ──────────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Choose the provider that matches your setup:
 |----------|----------|-------|
 | **kubectl** | Server runs in k3s/K8s on a remote VM | [SETUP_KUBECTL.md](SETUP_KUBECTL.md) |
 | **docker** | Server runs as Docker containers (compose or standalone) | [SETUP_DOCKER.md](SETUP_DOCKER.md) |
+| **amp** | Server runs under CubeCoders AMP (host or podman-backed) | [SETUP_AMP.md](SETUP_AMP.md) |
 | **local** | Server runs on the same machine - AMP, LGSM, bare metal | [SETUP_LOCAL.md](SETUP_LOCAL.md) |
 
 ---
@@ -33,7 +34,7 @@ git clone https://github.com/Icehunter/dune-admin
 cd dune-admin
 
 make setup   # interactive wizard - detects provider, discovers config, writes ~/.dune-admin/config.yaml
-make build
+make build   # builds frontend + dune-admin binary
 ./dune-admin
 ```
 
@@ -43,11 +44,30 @@ See the provider guide above for provider-specific prerequisites (SSH key, Docke
 
 ---
 
+## One-command k8s deploy (external VM)
+
+If your cluster lives on a VM (example: `dune@192.168.0.72`), use the deploy scripts:
+
+```bash
+./deploy.sh
+```
+
+```powershell
+./deploy.ps1
+```
+
+These scripts handle kubeconfig pull, image build/import, manifest render/apply, rollout wait, and port-forward.
+They also auto-fix common deploy drift (embedded bot settings + UI asset presence checks) before opening access.
+
+For full options and troubleshooting, see [SETUP_KUBECTL.md](SETUP_KUBECTL.md).
+
+---
+
 ## Setup wizard
 
-`make setup` (or `go run . -setup`) runs an interactive wizard that:
+`make setup` (or `go run ./cmd/dune-admin -setup`) runs an interactive wizard that:
 
-1. Asks which control plane to use: `kubectl`, `docker`, or `local`
+1. Asks which control plane to use: `kubectl`, `docker`, `amp`, or `local`
 2. Collects the required settings for that provider
 3. Tests connectivity (SSH, Docker, DB)
 4. Writes `~/.dune-admin/config.yaml` (chmod 600, never committed)
@@ -69,7 +89,7 @@ Config is loaded in this order (first match wins for each field):
 
 | Env var | Flag | Default | Description |
 |---------|------|---------|-------------|
-| `CONTROL` | `-control` | *(auto)* | Control plane: `kubectl`, `docker`, or `local` |
+| `CONTROL` | `-control` | *(auto)* | Control plane: `kubectl`, `docker`, `amp`, or `local` |
 | `SSH_HOST` | `-host` | - | VM host:port - when set, all connections tunnel through SSH |
 | `SSH_USER` | `-user` | `dune` | SSH user |
 | `SSH_KEY` | `-key` | *(auto-detected)* | SSH private key path |
@@ -88,6 +108,17 @@ Config is loaded in this order (first match wins for each field):
 
 Provider-specific fields (`docker_gameserver`, `cmd_start`, etc.) have no env var equivalents and must be set via the wizard or config.yaml directly. See the provider guides for the full field list.
 
+### Market bot
+
+dune-admin now runs the market bot **embedded only** (`market_bot_enabled: true` in `config.yaml`).  
+UI lifecycle actions map to the in-process bot runtime:
+
+1. **Resume** (`start`)
+2. **Pause** (`stop`)
+3. **Reinitialize** (`restart`)
+
+Config edits in the Market tab apply directly to the embedded runtime config.
+
 ### SSH key lookup order
 
 When `SSH_KEY` / `-key` is not set, dune-admin checks these paths in order:
@@ -105,11 +136,14 @@ When `SSH_KEY` / `-key` is not set, dune-admin checks these paths in order:
 | Target | Description |
 |--------|-------------|
 | `make setup` | Run the interactive setup wizard |
-| `make build` | Build the Go binary |
+| `make build` | Build frontend + Go binary |
 | `make linux` | Cross-compile a Linux amd64 binary |
-| `make dev-server` | Run without building (`go run .`) |
+| `make dev` | Run backend + frontend in live mode (Air + Vite HMR) |
+| `make dev-server` | Run backend only without building (`go run ./cmd/dune-admin`) |
 | `make web` | Build the frontend only |
 | `make deploy-web` | Build + deploy frontend to Cloudflare Pages |
+| `make render-k8s` | Render `deploy/k8s/dune-admin.rendered.yaml` from `~/.dune-admin/config.yaml` |
+| `make k8s-dry-run` | Render and run `kubectl apply --dry-run=client` |
 | `make test` | Run tests |
 | `make verify` | Run all quality checks (fmt, vet, tests, vuln, gosec) |
 
@@ -120,7 +154,7 @@ When `SSH_KEY` / `-key` is not set, dune-admin checks these paths in order:
 The frontend can be deployed to Cloudflare Pages and pointed at a locally-running binary.
 
 ```bash
-cd web && npm ci && npm run build
+cd web && pnpm install && pnpm build
 wrangler pages deploy dist --project-name dune-admin
 ```
 

--- a/SETUP_AMP.md
+++ b/SETUP_AMP.md
@@ -1,0 +1,99 @@
+# Provider: amp (CubeCoders AMP)
+
+Use this provider when your Dune server is managed by AMP (`ampinstmgr`) and RabbitMQ/Postgres live in the AMP stack (host-native or podman-backed).
+
+```
+dune-admin
+  ├─ ampinstmgr / podman exec → lifecycle + logs + broker ops
+  ├─ elevated INI writes as amp user
+  └─ TCP → PostgreSQL (host or SSH-tunnelled host)
+```
+
+## Prerequisites
+
+| Requirement | Notes |
+|-------------|-------|
+| **Go 1.21+** | `brew install go` or <https://go.dev/dl/> |
+| **AMP host access** | Run dune-admin on the AMP host, or set `ssh_host` to run remotely over SSH |
+| **Sudoers grant** | dune-admin user must run `ampinstmgr`, `podman`, and `tee` as AMP user without prompts |
+
+Example sudoers entry (adjust user/path names as needed):
+
+```bash
+dune-admin ALL=(amp) NOPASSWD: /usr/bin/ampinstmgr, /usr/bin/podman, /usr/bin/tee
+```
+
+## Quick start (wizard)
+
+```bash
+make setup
+# Select: amp
+# Fill AMP instance/container/user details
+make build   # builds frontend + dune-admin binary
+./dune-admin
+```
+
+## Manual config (`~/.dune-admin/config.yaml`)
+
+```yaml
+control: amp
+
+# Optional if running dune-admin from a different machine:
+# ssh_host: 192.168.0.72:22
+# ssh_user: dune-admin
+# ssh_key: /home/you/.ssh/amp-host
+
+db_host: 127.0.0.1
+db_port: 15432
+db_user: postgres
+db_pass: yourpassword
+db_name: dune
+db_schema: dune
+
+amp_instance: DuneAwakening01
+amp_container: AMP_DuneAwakening01
+amp_user: amp
+amp_log_path: /AMP/duneawakening/logs
+server_ini_dir: /home/amp/.ampdata/instances/DuneAwakening01/duneawakening/server/state
+
+# Optional:
+amp_use_container: true
+amp_data_root: /AMP/duneawakening
+director_url: http://127.0.0.1:11717
+broker_exec_prefix: "sudo -i -u amp podman exec AMP_DuneAwakening01"
+listen_addr: :18080   # avoids collision with AMP web panel on :8080
+```
+
+## Embedded market bot (recommended in AMP)
+
+```yaml
+market_bot_enabled: true
+market_bot_cache_db: /home/amp/.dune-admin/market-bot-cache.db
+market_bot_item_data: /path/to/dune-admin/item-data.json
+market_bot_buy_interval: 5m
+market_bot_list_interval: 30m
+market_bot_buy_threshold: 1.05
+market_bot_max_buys: 50
+```
+
+External market-bot mode is removed; use embedded mode for AMP deployments.
+
+## What works
+
+| Feature | Supported |
+|---------|-----------|
+| Battlegroup status | Yes |
+| Start / stop / restart | Yes (`ampinstmgr`) |
+| Process list | Yes |
+| Log streaming | Yes |
+| DB access | Yes (direct or SSH tunnel) |
+| Broker command path | Yes (`broker_exec_prefix`) |
+| INI read/write | Yes (`ampExecutor` writes as AMP user) |
+
+## Troubleshooting
+
+**`sudo` prompts or permission denied** — fix `/etc/sudoers.d/*` for the dune-admin user and AMP user.
+
+**INI changes fail** — verify `server_ini_dir` and that AMP user owns `UserGame.ini` / `UserEngine.ini`.
+
+**Broker commands fail** — set `broker_exec_prefix` to the exact `podman exec` wrapper used on your AMP host.

--- a/SETUP_DOCKER.md
+++ b/SETUP_DOCKER.md
@@ -35,7 +35,7 @@ With SSH set, `docker` CLI commands run on the remote host and DB connections ar
 make setup
 # Select: docker
 # Enter container names when prompted
-make build
+make build   # builds frontend + dune-admin binary
 ./dune-admin
 ```
 
@@ -48,8 +48,8 @@ control: docker
 
 # Container names — must match exactly what `docker ps` shows:
 docker_gameserver: dune-gameserver
-docker_broker_game: dune-mq-game      # optional — for capture mode
-docker_broker_admin: dune-mq-admin    # optional — for capture mode
+docker_broker_game: dune-mq-game      # optional — for broker command path
+docker_broker_admin: dune-mq-admin    # optional — for broker command path
 
 # Database — use Docker DNS name or IP:
 db_host: database       # service name in your compose file
@@ -96,7 +96,7 @@ services:
 | Container list | Yes — `docker ps` |
 | Log streaming | Yes — `docker logs -f` |
 | DB access | Yes — direct TCP to `db_host:db_port` |
-| RabbitMQ capture | Yes — `docker exec` into broker container |
+| RabbitMQ broker commands | Yes — `docker exec` into broker container |
 | Backup download / upload | Yes — through executor file I/O |
 | Backup restore | Yes — `pg_restore` run via executor |
 

--- a/SETUP_KUBECTL.md
+++ b/SETUP_KUBECTL.md
@@ -27,7 +27,7 @@ your machine
 cp /path/to/key ./sshKey && chmod 600 ./sshKey
 
 make setup   # prompts for VM host:port, discovers namespace + DB password automatically
-make build
+make build   # builds frontend + dune-admin binary
 ./dune-admin
 ```
 
@@ -38,6 +38,130 @@ The wizard:
 3. Runs `kubectl get pods -A` to find the database pod and namespace
 4. Reads `~/.dune/<battlegroup>.yaml` on the VM for DB credentials
 5. Writes `~/.dune-admin/config.yaml`
+
+## External VM deploy example (`dune@192.168.0.72`)
+
+```bash
+cd /Volumes/Engineering/Icehunter/dune-admin
+
+# Pull kubeconfig from VM and point kubectl at the external cluster.
+mkdir -p ~/.kube
+ssh dune@192.168.0.72 "sudo cat /etc/rancher/k3s/k3s.yaml" > ~/.kube/dune-external.yaml
+sed -i '' 's/127.0.0.1/192.168.0.72/g' ~/.kube/dune-external.yaml
+export KUBECONFIG=~/.kube/dune-external.yaml
+kubectl get nodes
+
+# Configure dune-admin runtime values.
+make setup
+
+# Ensure these are set in ~/.dune-admin/config.yaml for container runtime:
+# market_bot_enabled: true
+# market_bot_item_data: /app/item-data.json
+# market_bot_cache_db: /data/market-bot-cache.db
+
+# Build local image and import it into k3s runtime on the VM.
+docker buildx build --platform linux/amd64 -f deploy/Dockerfile -t dune-admin:local --load .
+docker save dune-admin:local | ssh dune@192.168.0.72 "sudo k3s ctr images import -"
+
+# Render deployment manifest from ~/.dune-admin/config.yaml and switch image tag.
+make render-k8s
+sed -i '' 's#ghcr.io/icehunter/dune-admin:latest#dune-admin:local#g' deploy/k8s/dune-admin.rendered.yaml
+
+# Deploy and wait for readiness.
+kubectl apply -f deploy/k8s/dune-admin.rendered.yaml
+kubectl -n dune-admin rollout status deploy/dune-admin
+kubectl -n dune-admin get pods,svc
+
+# Verify API and bot from inside the cluster.
+kubectl -n dune-admin run curl --rm -it --restart=Never --image=curlimages/curl -- \
+  sh -c "curl -s http://dune-admin:8080/api/v1/market-bot/status"
+
+# Local access from your laptop.
+kubectl -n dune-admin port-forward svc/dune-admin 8080:8080
+```
+
+## Scripted deploy (Linux/macOS + Windows)
+
+From repo root:
+
+```bash
+./deploy.sh
+```
+
+```powershell
+./deploy.ps1
+```
+
+> On Windows, if script execution is blocked, run once:
+> `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`
+
+Both scripts run the full k8s flow:
+
+1. Pull kubeconfig from VM (`dune@192.168.0.72` by default) unless skipped
+2. Build a fresh timestamped image tag (`dune-admin:local-<timestamp>` by default)
+3. Import image into VM k3s runtime (`k3s ctr images import`)
+4. Render and apply `deploy/k8s/dune-admin.rendered.yaml`
+5. Auto-fix embedded bot deployment settings in the rendered manifest:
+   - `MARKET_BOT_ENABLED: "true"`
+   - `market_bot_enabled: true`
+   - `market_bot_item_data: /app/item-data.json`
+   - `market_bot_cache_db: /data/market-bot-cache.db`
+6. Restart rollout, wait for old terminating pods to drain, then run in-cluster health checks for:
+   - `/api/v1/status` reachable
+   - `/` returns HTTP 200 (no UI 404)
+   - `/api/v1/market-bot/status` reports `"enabled":true`
+7. Open `kubectl port-forward` on `127.0.0.1:8080` (unless disabled)
+
+SSH auth behavior in both scripts:
+
+- If `./sshKey` exists, it is used first (`-i ./sshKey`)
+- If key auth fails or no key is present, SSH falls back to password prompt
+
+### Script options
+
+| Purpose | Bash | PowerShell |
+|---|---|---|
+| VM user | `--vm-user dune` | `-VmUser dune` |
+| VM host | `--vm-host 192.168.0.72` | `-VmHost 192.168.0.72` |
+| SSH key path | `--ssh-key ./sshKey` | `-SshKeyPath .\sshKey` |
+| Kubeconfig path | `--kubeconfig ~/.kube/dune-external.yaml` | `-KubeconfigPath "$HOME/.kube/dune-external.yaml"` |
+| Image tag | `--image dune-admin:local` | `-Image dune-admin:local` |
+| Namespace | `--namespace dune-admin` | `-Namespace dune-admin` |
+| Manifest path | `--manifest deploy/k8s/dune-admin.rendered.yaml` | `-Manifest deploy/k8s/dune-admin.rendered.yaml` |
+| Skip kubeconfig pull | `--skip-kubeconfig` | `-SkipKubeconfig` |
+| Skip image build | `--skip-build` | `-SkipBuild` |
+| Skip VM image import | `--skip-image-import` | `-SkipImageImport` |
+| Skip port-forward | `--no-port-forward` | `-NoPortForward` |
+
+### First deploy vs quick redeploy
+
+First deploy:
+
+```bash
+./deploy.sh
+```
+
+Quick redeploy (reuse kubeconfig, no auto port-forward):
+
+```bash
+./deploy.sh --skip-kubeconfig --no-port-forward
+```
+
+Quick redeploy with the exact same image tag (advanced):
+
+```bash
+./deploy.sh --image dune-admin:local --skip-kubeconfig --no-port-forward
+```
+
+Override defaults with flags (same names on both scripts), e.g.:
+
+```bash
+./deploy.sh --vm-user dune --vm-host 192.168.0.72 --image dune-admin:local --no-port-forward
+```
+
+```powershell
+./deploy.ps1 -VmUser dune -VmHost 192.168.0.72 -Image dune-admin:local -NoPortForward
+```
 
 ## Manual config (`~/.dune-admin/config.yaml`)
 
@@ -58,7 +182,7 @@ db_schema: dune
 # Optional — discovered automatically if omitted:
 control_namespace: funcom-seabass-mybattlegroup
 
-# Optional capture mode:
+# Optional broker command path:
 broker_game_addr: 10.43.48.246:5672
 broker_admin_addr: 10.43.189.193:5672
 broker_tls: true
@@ -79,7 +203,7 @@ scrip_currency: 1
 | Pod list | Yes |
 | Log streaming | Yes — `kubectl logs -f` |
 | DB access | Yes — tunnelled through SSH to pod IP |
-| RabbitMQ capture | Yes — `kubectl exec` into broker pod |
+| RabbitMQ broker commands | Yes — `kubectl exec` into broker pod |
 | Backup download / upload / restore | Yes |
 
 ## Backward compatibility
@@ -93,3 +217,19 @@ Existing `.env` files with just `SSH_HOST`, `SSH_USER`, `DB_PASS`, etc. continue
 **DB connection fails** — pod discovery succeeded but DB password is wrong. Delete `~/.dune-admin/config.yaml` and re-run `make setup`.
 
 **"sudo: kubectl: command not found"** — kubectl is not in the sudo-safe PATH on the VM. Add `/usr/local/bin` (or wherever kubectl lives) to `/etc/sudoers` `secure_path`.
+
+**Port-forward works but `http://127.0.0.1:8080` returns 404** — you are running an old image that does not contain the built frontend (`/app/dist`). Rebuild and redeploy with the deploy script.
+
+**Market bot panel shows inactive after deploy** — verify:
+
+1. `market_bot_enabled: true` in `~/.dune-admin/config.yaml`
+2. `market_bot_item_data: /app/item-data.json`
+3. `market_bot_cache_db: /data/market-bot-cache.db`
+
+Then redeploy and check:
+
+```bash
+kubectl -n dune-admin logs deploy/dune-admin --tail=120
+kubectl -n dune-admin run curl --rm -it --restart=Never --image=curlimages/curl -- \
+  sh -c "curl -s http://dune-admin:8080/api/v1/market-bot/status"
+```

--- a/SETUP_LOCAL.md
+++ b/SETUP_LOCAL.md
@@ -1,6 +1,8 @@
 # Provider: local
 
-Use this provider when dune-admin runs on the same machine as the Dune server and there is no Kubernetes or Docker involved — e.g. AMP, LGSM, bare-metal, or any setup where the game server is managed by shell commands.
+Use this provider when dune-admin runs on the same machine as the Dune server and there is no Kubernetes or Docker involved — e.g. LGSM, bare-metal, or any setup where the game server is managed by shell commands.
+
+> If you run CubeCoders AMP, prefer `control: amp` and follow [SETUP_AMP.md](SETUP_AMP.md).
 
 ```
 dune-admin (same machine)
@@ -23,7 +25,7 @@ make setup
 # Select: local
 # Enter DB host, port, credentials
 # Enter optional shell commands for server control
-make build
+make build   # builds frontend + dune-admin binary
 ./dune-admin
 ```
 
@@ -104,7 +106,7 @@ Leave all `cmd_*` fields empty. The Battlegroup tab will show an error for start
 | Pod/process list | Not supported |
 | Log streaming | Not supported — tail your own log files |
 | DB access | Yes — direct TCP to `db_host:db_port` |
-| RabbitMQ capture | Yes — runs `rabbitmqctl` directly if available in `$PATH` |
+| RabbitMQ broker commands | Yes — runs `rabbitmqctl` directly if available in `$PATH` |
 | Backup download / upload | Yes — through local file I/O |
 | Backup restore | Yes — `pg_restore` run locally |
 
@@ -114,4 +116,4 @@ Leave all `cmd_*` fields empty. The Battlegroup tab will show an error for start
 
 **DB connection fails** — verify PostgreSQL is listening on the configured `db_host:db_port`. For AMP, the DB is usually on `127.0.0.1:5432` or a custom port; check your AMP instance settings.
 
-**RabbitMQ capture fails** — `rabbitmqctl` must be in `$PATH` for the user running dune-admin. Run `which rabbitmqctl` to verify.
+**RabbitMQ broker command fails** — `rabbitmqctl` must be in `$PATH` for the user running dune-admin. Run `which rabbitmqctl` to verify.

--- a/cmd/dune-admin/connection_test.go
+++ b/cmd/dune-admin/connection_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+func TestResolveControl(t *testing.T) {
+	origControlPlane := controlPlane
+	origSSHHost := sshHost
+	t.Cleanup(func() {
+		controlPlane = origControlPlane
+		sshHost = origSSHHost
+	})
+
+	controlPlane = "amp"
+	sshHost = ""
+	if got := resolveControl(); got != "amp" {
+		t.Fatalf("expected explicit control plane to win, got %q", got)
+	}
+
+	controlPlane = ""
+	sshHost = "vm.example:22"
+	if got := resolveControl(); got != "kubectl" {
+		t.Fatalf("expected ssh host to default control to kubectl, got %q", got)
+	}
+
+	controlPlane = ""
+	sshHost = ""
+	if got := resolveControl(); got != "local" {
+		t.Fatalf("expected local default without ssh/control flags, got %q", got)
+	}
+}

--- a/cmd/dune-admin/control.go
+++ b/cmd/dune-admin/control.go
@@ -125,6 +125,7 @@ func newControlPlane(name string, cfg appConfig) ControlPlane {
 			cmdStop:          cfg.CmdStop,
 			cmdRestart:       cfg.CmdRestart,
 			cmdStatus:        cfg.CmdStatus,
+			controlNamespace: cfg.ControlNamespace,
 			brokerExecPrefix: cfg.BrokerExecPrefix,
 		}
 	}

--- a/cmd/dune-admin/control_amp.go
+++ b/cmd/dune-admin/control_amp.go
@@ -99,6 +99,40 @@ type ampGameProcess struct {
 	partition int
 }
 
+func parseAMPMapName(argsFields []string) string {
+	for i, field := range argsFields {
+		if field == "DuneSandbox" && i+1 < len(argsFields) {
+			return argsFields[i+1]
+		}
+	}
+	return ""
+}
+
+func parseAMPArgInt(re *regexp.Regexp, args string) int {
+	m := re.FindStringSubmatch(args)
+	if len(m) <= 1 {
+		return 0
+	}
+	value, _ := strconv.Atoi(m[1])
+	return value
+}
+
+func parseAMPGameProcess(line string) (ampGameProcess, bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return ampGameProcess{}, false
+	}
+	pid, _ := strconv.Atoi(fields[0])
+	argsFields := fields[1:]
+	args := strings.Join(argsFields, " ")
+	return ampGameProcess{
+		pid:       pid,
+		mapName:   parseAMPMapName(argsFields),
+		port:      parseAMPArgInt(ampPortRe, args),
+		partition: parseAMPArgInt(ampPartRe, args),
+	}, true
+}
+
 func (c *ampControl) listGameProcesses(exec Executor) ([]ampGameProcess, error) {
 	out, err := exec.Exec(`ps -eo pid,args --no-headers 2>/dev/null | grep 'DuneSandboxServer-Linux-Shipping' | grep -v grep`)
 	if err != nil && strings.TrimSpace(out) == "" {
@@ -106,31 +140,14 @@ func (c *ampControl) listGameProcesses(exec Executor) ([]ampGameProcess, error) 
 	}
 	var procs []ampGameProcess
 	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		if line == "" {
+		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
+		proc, ok := parseAMPGameProcess(line)
+		if !ok {
 			continue
 		}
-		pid, _ := strconv.Atoi(fields[0])
-		args := strings.Join(fields[1:], " ")
-		mapName := ""
-		for i, p := range fields[1:] {
-			if p == "DuneSandbox" && i+1 < len(fields[1:]) {
-				mapName = fields[1+i+1]
-				break
-			}
-		}
-		port := 0
-		if m := ampPortRe.FindStringSubmatch(args); len(m) > 1 {
-			port, _ = strconv.Atoi(m[1])
-		}
-		partition := 0
-		if m := ampPartRe.FindStringSubmatch(args); len(m) > 1 {
-			partition, _ = strconv.Atoi(m[1])
-		}
-		procs = append(procs, ampGameProcess{pid: pid, mapName: mapName, port: port, partition: partition})
+		procs = append(procs, proc)
 	}
 	return procs, nil
 }

--- a/cmd/dune-admin/control_amp_test.go
+++ b/cmd/dune-admin/control_amp_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"net"
+	"testing"
+)
+
+type fakeAMPExecutor struct {
+	out string
+	err error
+	cmd string
+}
+
+func (f *fakeAMPExecutor) Exec(cmd string) (string, error) {
+	f.cmd = cmd
+	return f.out, f.err
+}
+func (f *fakeAMPExecutor) Stream(string) (<-chan string, func(), error) {
+	return nil, func() {}, nil
+}
+func (f *fakeAMPExecutor) PipeToWriter(string, io.Writer) error { return nil }
+func (f *fakeAMPExecutor) WriteFile(string, io.Reader) error    { return nil }
+func (f *fakeAMPExecutor) Dial(string, string) (net.Conn, error) {
+	return nil, nil
+}
+func (f *fakeAMPExecutor) Close()       {}
+func (f *fakeAMPExecutor) Type() string { return "local" }
+
+func TestParseAMPGameProcess(t *testing.T) {
+	t.Parallel()
+
+	line := "123 /srv/DuneSandboxServer-Linux-Shipping DuneSandbox HaggaBasinS -Port=7777 -PartitionIndex=3"
+	got, ok := parseAMPGameProcess(line)
+	if !ok {
+		t.Fatalf("expected line to parse")
+	}
+	if got.pid != 123 || got.mapName != "HaggaBasinS" || got.port != 7777 || got.partition != 3 {
+		t.Fatalf("unexpected parsed process: %+v", got)
+	}
+
+	if _, ok := parseAMPGameProcess("garbage"); ok {
+		t.Fatalf("expected malformed line to be rejected")
+	}
+}
+
+func TestListGameProcesses(t *testing.T) {
+	t.Parallel()
+
+	ctrl := &ampControl{}
+	exec := &fakeAMPExecutor{
+		out: "100 one DuneSandbox MapA -Port=7001 -PartitionIndex=1\nbad\n200 two DuneSandbox MapB -Port=7002",
+	}
+	procs, err := ctrl.listGameProcesses(exec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(procs) != 2 {
+		t.Fatalf("expected 2 parsed processes, got %d", len(procs))
+	}
+	if procs[0].pid != 100 || procs[0].mapName != "MapA" || procs[0].port != 7001 || procs[0].partition != 1 {
+		t.Fatalf("unexpected first process: %+v", procs[0])
+	}
+	if procs[1].pid != 200 || procs[1].mapName != "MapB" || procs[1].port != 7002 || procs[1].partition != 0 {
+		t.Fatalf("unexpected second process: %+v", procs[1])
+	}
+	if exec.cmd == "" {
+		t.Fatalf("expected process listing command to be executed")
+	}
+}
+
+func TestListGameProcesses_EmptyOnExecErrorWithoutOutput(t *testing.T) {
+	t.Parallel()
+
+	ctrl := &ampControl{}
+	exec := &fakeAMPExecutor{err: errors.New("ps failed")}
+	procs, err := ctrl.listGameProcesses(exec)
+	if err != nil {
+		t.Fatalf("expected no error when exec fails without output, got %v", err)
+	}
+	if len(procs) != 0 {
+		t.Fatalf("expected empty process list, got %+v", procs)
+	}
+}

--- a/cmd/dune-admin/control_kubectl.go
+++ b/cmd/dune-admin/control_kubectl.go
@@ -17,22 +17,30 @@ type kubectlControl struct {
 
 func (c *kubectlControl) Name() string { return "kubectl" }
 
+func kubectlCLI(exec Executor) string {
+	if exec != nil && exec.Type() == "local" {
+		return "kubectl"
+	}
+	return "sudo kubectl"
+}
+
 func (c *kubectlControl) bgName() string {
 	return strings.TrimPrefix(c.namespace, "funcom-seabass-")
 }
 
 func (c *kubectlControl) GetStatus(ctx context.Context, exec Executor) (*BattlegroupStatus, error) {
 	bgName := c.bgName()
+	kctl := kubectlCLI(exec)
 
 	bgOut, _ := exec.Exec(fmt.Sprintf(
-		`sudo kubectl get battlegroups -n %s -o jsonpath="{.items[0].spec.title}|{.items[0].status.phase}|{.items[0].status.database.phase}" 2>/dev/null`,
-		c.namespace))
+		`%s get battlegroups -n %s -o jsonpath="{.items[0].spec.title}|{.items[0].status.phase}|{.items[0].status.database.phase}" 2>/dev/null`,
+		kctl, c.namespace))
 
 	bgParts := strings.SplitN(strings.TrimSpace(bgOut), "|", 3)
 
 	ssOut, _ := exec.Exec(fmt.Sprintf(
-		"sudo kubectl get serverstats -n %s -o jsonpath='{range .items[*]}{.spec.area.map}|{.spec.area.sietch}|{.spec.area.dimension}|{.spec.area.partition}|{.status.runtime.gamePhase}|{.status.runtime.ready}|{.status.runtime.players}{\"\\n\"}{end}' 2>/dev/null",
-		c.namespace))
+		"%s get serverstats -n %s -o jsonpath='{range .items[*]}{.spec.area.map}|{.spec.area.sietch}|{.spec.area.dimension}|{.spec.area.partition}|{.status.runtime.gamePhase}|{.status.runtime.ready}|{.status.runtime.players}{\"\\n\"}{end}' 2>/dev/null",
+		kctl, c.namespace))
 
 	var servers []ServerRow
 	for _, line := range strings.Split(strings.TrimSpace(ssOut), "\n") {
@@ -73,20 +81,21 @@ func (c *kubectlControl) GetStatus(ctx context.Context, exec Executor) (*Battleg
 func (c *kubectlControl) ExecCommand(_ context.Context, exec Executor, cmd string) (string, error) {
 	bgName := c.bgName()
 	ns := c.namespace
+	kctl := kubectlCLI(exec)
 
 	switch cmd {
 	case "start":
 		return exec.Exec(fmt.Sprintf(
-			`sudo kubectl patch battlegroup %s -n %s --type=merge -p '{"spec":{"stop":false}}' 2>&1 && echo "Battlegroup starting"`,
-			bgName, ns))
+			`%s patch battlegroup %s -n %s --type=merge -p '{"spec":{"stop":false}}' 2>&1 && echo "Battlegroup starting"`,
+			kctl, bgName, ns))
 	case "stop":
 		return exec.Exec(fmt.Sprintf(
-			`sudo kubectl patch battlegroup %s -n %s --type=merge -p '{"spec":{"stop":true}}' 2>&1 && echo "Battlegroup stopping"`,
-			bgName, ns))
+			`%s patch battlegroup %s -n %s --type=merge -p '{"spec":{"stop":true}}' 2>&1 && echo "Battlegroup stopping"`,
+			kctl, bgName, ns))
 	case "restart":
 		return exec.Exec(fmt.Sprintf(
-			`sudo kubectl patch battlegroup %s -n %s --type=merge -p '{"spec":{"stop":true}}' 2>/dev/null && sleep 5 && sudo kubectl patch battlegroup %s -n %s --type=merge -p '{"spec":{"stop":false}}' 2>/dev/null && echo "Battlegroup restarting"`,
-			bgName, ns, bgName, ns))
+			`%s patch battlegroup %s -n %s --type=merge -p '{"spec":{"stop":true}}' 2>/dev/null && sleep 5 && %s patch battlegroup %s -n %s --type=merge -p '{"spec":{"stop":false}}' 2>/dev/null && echo "Battlegroup restarting"`,
+			kctl, bgName, ns, kctl, bgName, ns))
 	default:
 		// TODO: NEVER run battlegroup.sh with sudo. The script manages files under
 		// /home/dune/.dune/ and runs as the dune user. Using sudo corrupts ownership
@@ -98,7 +107,8 @@ func (c *kubectlControl) ExecCommand(_ context.Context, exec Executor, cmd strin
 }
 
 func (c *kubectlControl) ListProcesses(_ context.Context, exec Executor) ([]ProcessInfo, string, error) {
-	out, err := exec.Exec(fmt.Sprintf("sudo kubectl get pods -n %s --no-headers 2>&1", c.namespace))
+	kctl := kubectlCLI(exec)
+	out, err := exec.Exec(fmt.Sprintf("%s get pods -n %s --no-headers 2>&1", kctl, c.namespace))
 	if err != nil {
 		return nil, "", fmt.Errorf("kubectl: %w", err)
 	}
@@ -112,13 +122,14 @@ func (c *kubectlControl) ListProcesses(_ context.Context, exec Executor) ([]Proc
 }
 
 func (c *kubectlControl) ListLogSources(_ context.Context, exec Executor) ([]LogSource, error) {
+	kctl := kubectlCLI(exec)
 	out, err := exec.Exec(fmt.Sprintf(
-		"sudo kubectl get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>&1", c.namespace))
+		"%s get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>&1", kctl, c.namespace))
 	if err != nil {
 		return nil, fmt.Errorf("kubectl: %w", err)
 	}
 	out2, _ := exec.Exec(
-		"sudo kubectl get pods -n funcom-operators --no-headers -o custom-columns=NAME:.metadata.name 2>&1")
+		fmt.Sprintf("%s get pods -n funcom-operators --no-headers -o custom-columns=NAME:.metadata.name 2>&1", kctl))
 
 	var sources []LogSource
 	for _, line := range splitLines(out) {
@@ -137,22 +148,24 @@ func (c *kubectlControl) ListLogSources(_ context.Context, exec Executor) ([]Log
 }
 
 func (c *kubectlControl) StreamLog(_ context.Context, exec Executor, ns, name string) (<-chan string, func(), error) {
-	cmd := fmt.Sprintf("sudo kubectl logs -f -n %s %s 2>&1", ns, name)
+	kctl := kubectlCLI(exec)
+	cmd := fmt.Sprintf("%s logs -f -n %s %s 2>&1", kctl, ns, name)
 	return exec.Stream(cmd)
 }
 
 func (c *kubectlControl) CaptureJWT(_ context.Context, exec Executor) (string, string, error) {
+	kctl := kubectlCLI(exec)
 	pod, err := exec.Exec(fmt.Sprintf(
-		"sudo kubectl get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | grep bgd | head -1",
-		c.namespace))
+		"%s get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | grep bgd | head -1",
+		kctl, c.namespace))
 	if err != nil || strings.TrimSpace(pod) == "" {
 		return "", "", fmt.Errorf("find bgd pod: %w", err)
 	}
 	pod = strings.TrimSpace(pod)
 
 	existingToken, err := exec.Exec(fmt.Sprintf(
-		"sudo kubectl exec -n %s %s -- env 2>/dev/null | grep FuncomLiveServices__ServiceAuthToken | cut -d= -f2-",
-		c.namespace, pod))
+		"%s exec -n %s %s -- env 2>/dev/null | grep FuncomLiveServices__ServiceAuthToken | cut -d= -f2-",
+		kctl, c.namespace, pod))
 	if err != nil || strings.TrimSpace(existingToken) == "" {
 		return "", "", fmt.Errorf("read ServiceAuthToken: %w", err)
 	}
@@ -163,16 +176,17 @@ func (c *kubectlControl) EvalOnGameBroker(_ context.Context, exec Executor, expr
 	if c.namespace == "" {
 		return "", errNotSupported("kubectl", "EvalOnGameBroker (namespace not configured)")
 	}
+	kctl := kubectlCLI(exec)
 	pod, err := exec.Exec(fmt.Sprintf(
-		"sudo kubectl get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | grep mq-game | head -1",
-		c.namespace))
+		"%s get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | grep mq-game | head -1",
+		kctl, c.namespace))
 	if err != nil || strings.TrimSpace(pod) == "" {
 		return "", fmt.Errorf("could not find mq-game pod in namespace %s", c.namespace)
 	}
 	pod = strings.TrimSpace(pod)
 	out, err := exec.Exec(fmt.Sprintf(
-		"sudo kubectl exec -n %s %s -- rabbitmqctl eval %s 2>&1",
-		c.namespace, pod, shellQuote(expr)))
+		"%s exec -n %s %s -- rabbitmqctl eval %s 2>&1",
+		kctl, c.namespace, pod, shellQuote(expr)))
 	if err != nil {
 		return "", fmt.Errorf("rabbitmqctl eval: %w (output: %s)", err, strings.TrimSpace(out))
 	}
@@ -183,8 +197,9 @@ func (c *kubectlControl) EvalOnGameBroker(_ context.Context, exec Executor, expr
 
 // discoverDBPod uses kubectl to find the DB pod, returning namespace, name, and pod IP.
 func discoverDBPod(exec Executor) (ns, pod, podIP string, err error) {
+	kctl := kubectlCLI(exec)
 	out, err := exec.Exec(
-		`sudo kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{.status.podIP}{"\n"}{end}' 2>/dev/null | grep db-dbdepl-sts | head -1`)
+		fmt.Sprintf(`%s get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{.status.podIP}{"\n"}{end}' 2>/dev/null | grep db-dbdepl-sts | head -1`, kctl))
 	if err != nil {
 		return "", "", "", fmt.Errorf("kubectl: %w", err)
 	}
@@ -239,14 +254,37 @@ func (c *kubectlControl) ReadDefaultINI(_ context.Context, exec Executor, filena
 	if c.namespace == "" {
 		return ""
 	}
-	// Find the game daemon pod — same pattern used by CaptureJWT.
-	pod, err := exec.Exec(fmt.Sprintf(
-		"sudo kubectl get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | grep bgd | head -1",
-		c.namespace))
-	if err != nil || strings.TrimSpace(pod) == "" {
+	kctl := kubectlCLI(exec)
+
+	podOut, err := exec.Exec(fmt.Sprintf(
+		"%s get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null",
+		kctl, c.namespace))
+	if err != nil {
 		return ""
 	}
-	pod = strings.TrimSpace(pod)
+
+	var sgPods, bgdPods, otherPods []string
+	for _, line := range strings.Split(podOut, "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" {
+			continue
+		}
+		switch {
+		case strings.Contains(name, "-sg-"):
+			sgPods = append(sgPods, name)
+		case strings.Contains(name, "bgd"):
+			bgdPods = append(bgdPods, name)
+		default:
+			otherPods = append(otherPods, name)
+		}
+	}
+	sort.Strings(sgPods)
+	sort.Strings(bgdPods)
+	sort.Strings(otherPods)
+	pods := append(append(sgPods, bgdPods...), otherPods...)
+	if len(pods) == 0 {
+		return ""
+	}
 
 	// Try well-known Config directories directly. find / misses paths that are
 	// only accessible via bind-mount roots or require following symlinks.
@@ -256,31 +294,33 @@ func (c *kubectlControl) ReadDefaultINI(_ context.Context, exec Executor, filena
 		"/home/dune/DuneSandbox/Config/" + filename,
 		"/game/DuneSandbox/Config/" + filename,
 	}
-	for _, p := range candidates {
-		content, err := exec.Exec(fmt.Sprintf(
-			"sudo kubectl exec -n %s %s -- cat %s 2>/dev/null",
-			c.namespace, pod, shellQuote(p)))
-		if err == nil && len(strings.TrimSpace(content)) > 0 {
-			log.Printf("[default-ini] kubectl: read %s (%d bytes) from pod %s", p, len(content), pod)
-			return content
+	for _, pod := range pods {
+		for _, p := range candidates {
+			content, err := exec.Exec(fmt.Sprintf(
+				"%s exec -n %s %s -- cat %s 2>/dev/null",
+				kctl, c.namespace, pod, shellQuote(p)))
+			if err == nil && len(strings.TrimSpace(content)) > 0 {
+				log.Printf("[default-ini] kubectl: read %s (%d bytes) from pod %s", p, len(content), pod)
+				return content
+			}
+		}
+
+		// Fall back: find with symlink-following under game-relevant roots.
+		pathOut, _ := exec.Exec(fmt.Sprintf(
+			"%s exec -n %s %s -- find -L /DuneSandbox /home /app /game -name %s -not -path '*/Saved/*' 2>/dev/null | head -1",
+			kctl, c.namespace, pod, shellQuote(filename)))
+		if p := strings.TrimSpace(pathOut); p != "" {
+			content, err := exec.Exec(fmt.Sprintf(
+				"%s exec -n %s %s -- cat %s 2>/dev/null",
+				kctl, c.namespace, pod, shellQuote(p)))
+			if err == nil && len(strings.TrimSpace(content)) > 0 {
+				log.Printf("[default-ini] kubectl: read %s (%d bytes) from pod %s", p, len(content), pod)
+				return content
+			}
 		}
 	}
 
-	// Fall back: find with symlink-following under game-relevant roots.
-	pathOut, _ := exec.Exec(fmt.Sprintf(
-		"sudo kubectl exec -n %s %s -- find -L /DuneSandbox /home /app /game -name %s -not -path '*/Saved/*' 2>/dev/null | head -1",
-		c.namespace, pod, shellQuote(filename)))
-	if p := strings.TrimSpace(pathOut); p != "" {
-		content, err := exec.Exec(fmt.Sprintf(
-			"sudo kubectl exec -n %s %s -- cat %s 2>/dev/null",
-			c.namespace, pod, shellQuote(p)))
-		if err == nil && len(strings.TrimSpace(content)) > 0 {
-			log.Printf("[default-ini] kubectl: read %s (%d bytes) from pod %s", p, len(content), pod)
-			return content
-		}
-	}
-
-	log.Printf("[default-ini] kubectl: %s not found in pod %s", filename, pod)
+	log.Printf("[default-ini] kubectl: %s not found in namespace %s", filename, c.namespace)
 	return ""
 }
 

--- a/cmd/dune-admin/control_local.go
+++ b/cmd/dune-admin/control_local.go
@@ -14,13 +14,29 @@ type localControl struct {
 	cmdStop          string
 	cmdRestart       string
 	cmdStatus        string
+	controlNamespace string
 	brokerExecPrefix string // e.g. "podman exec AMP_MehDune01" — prepended to rabbitmqctl calls
 }
 
 func (c *localControl) Name() string { return "local" }
 
+func (c *localControl) kubectlEnabled(exec Executor) bool {
+	if c.controlNamespace == "" || exec == nil {
+		return false
+	}
+	_, err := exec.Exec("kubectl version --client >/dev/null 2>&1")
+	return err == nil
+}
+
+func (c *localControl) kubectlDelegate() *kubectlControl {
+	return &kubectlControl{namespace: c.controlNamespace}
+}
+
 func (c *localControl) GetStatus(_ context.Context, exec Executor) (*BattlegroupStatus, error) {
 	if c.cmdStatus == "" {
+		if c.kubectlEnabled(exec) {
+			return c.kubectlDelegate().GetStatus(context.Background(), exec)
+		}
 		return nil, errNotSupported("local", "GetStatus (cmd_status not configured)")
 	}
 	out, err := exec.Exec(c.cmdStatus)
@@ -48,6 +64,9 @@ func (c *localControl) ExecCommand(_ context.Context, exec Executor, cmd string)
 		return "", fmt.Errorf("local control does not support %q", cmd)
 	}
 	if shellCmd == "" {
+		if c.kubectlEnabled(exec) {
+			return c.kubectlDelegate().ExecCommand(context.Background(), exec, cmd)
+		}
 		return "", errNotSupported("local", fmt.Sprintf("ExecCommand %q (cmd_%s not configured)", cmd, cmd))
 	}
 	out, err := exec.Exec(shellCmd)
@@ -57,19 +76,31 @@ func (c *localControl) ExecCommand(_ context.Context, exec Executor, cmd string)
 	return out, nil
 }
 
-func (c *localControl) ListProcesses(_ context.Context, _ Executor) ([]ProcessInfo, string, error) {
+func (c *localControl) ListProcesses(_ context.Context, exec Executor) ([]ProcessInfo, string, error) {
+	if c.kubectlEnabled(exec) {
+		return c.kubectlDelegate().ListProcesses(context.Background(), exec)
+	}
 	return nil, "", errNotSupported("local", "ListProcesses")
 }
 
-func (c *localControl) ListLogSources(_ context.Context, _ Executor) ([]LogSource, error) {
+func (c *localControl) ListLogSources(_ context.Context, exec Executor) ([]LogSource, error) {
+	if c.kubectlEnabled(exec) {
+		return c.kubectlDelegate().ListLogSources(context.Background(), exec)
+	}
 	return nil, errNotSupported("local", "ListLogSources")
 }
 
-func (c *localControl) StreamLog(_ context.Context, _ Executor, _, _ string) (<-chan string, func(), error) {
+func (c *localControl) StreamLog(_ context.Context, exec Executor, ns, name string) (<-chan string, func(), error) {
+	if c.kubectlEnabled(exec) {
+		return c.kubectlDelegate().StreamLog(context.Background(), exec, ns, name)
+	}
 	return nil, func() {}, errNotSupported("local", "StreamLog")
 }
 
-func (c *localControl) CaptureJWT(_ context.Context, _ Executor) (string, string, error) {
+func (c *localControl) CaptureJWT(_ context.Context, exec Executor) (string, string, error) {
+	if c.kubectlEnabled(exec) {
+		return c.kubectlDelegate().CaptureJWT(context.Background(), exec)
+	}
 	return "", "", errNotSupported("local", "CaptureJWT")
 }
 
@@ -88,10 +119,41 @@ func (c *localControl) EvalOnGameBroker(_ context.Context, exec Executor, expr s
 	return strings.TrimSpace(out), nil
 }
 
-func (c *localControl) ReadDefaultINI(_ context.Context, _ Executor, _ string) string {
+func (c *localControl) ReadDefaultINI(ctx context.Context, exec Executor, filename string) string {
+	if c.kubectlEnabled(exec) {
+		return c.kubectlDelegate().ReadDefaultINI(ctx, exec, filename)
+	}
 	return "" // host-path traversal in readDefaultINIContent handles local/Hyper-V
 }
 
-func (c *localControl) DiscoverIniDir(_ context.Context, _ Executor) (string, error) {
+func (c *localControl) DiscoverIniDir(_ context.Context, exec Executor) (string, error) {
+	if c.kubectlEnabled(exec) {
+		ns := c.controlNamespace
+		// UserSettings live on game-server pods (-sg-), not the bgd deploy pod.
+		podOut, err := exec.Exec(fmt.Sprintf(
+			"kubectl get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | grep -- '-sg-' | head -1",
+			ns,
+		))
+		if err != nil || strings.TrimSpace(podOut) == "" {
+			podOut, err = exec.Exec(fmt.Sprintf(
+				"kubectl get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | grep bgd | head -1",
+				ns,
+			))
+		}
+		if err != nil || strings.TrimSpace(podOut) == "" {
+			return "", fmt.Errorf("could not find game or bgd pod in namespace %s", ns)
+		}
+		pod := strings.TrimSpace(podOut)
+		findCmd := `for d in /home/dune/server/DuneSandbox/Saved/UserSettings /DuneSandbox/Saved/UserSettings /game/DuneSandbox/Saved/UserSettings; do if [ -d "$d" ]; then echo "$d"; exit 0; fi; done; find / -type d -path "*/Saved/UserSettings" 2>/dev/null | head -1`
+		dirOut, err := exec.Exec(fmt.Sprintf(
+			"kubectl exec -n %s %s -- sh -lc %s 2>/dev/null",
+			ns, pod, shellQuote(findCmd),
+		))
+		if err != nil || strings.TrimSpace(dirOut) == "" {
+			return "", fmt.Errorf("could not auto-discover ini dir in pod %s", pod)
+		}
+		dir := strings.TrimSpace(dirOut)
+		return fmt.Sprintf("k8s://%s/%s%s", ns, pod, dir), nil
+	}
 	return "", fmt.Errorf("local control plane requires server_ini_dir to be set in config")
 }

--- a/cmd/dune-admin/control_local.go
+++ b/cmd/dune-admin/control_local.go
@@ -24,7 +24,7 @@ func (c *localControl) kubectlEnabled(exec Executor) bool {
 	if c.controlNamespace == "" || exec == nil {
 		return false
 	}
-	_, err := exec.Exec("kubectl version --client >/dev/null 2>&1")
+	_, err := exec.Exec(kubectlCLI(exec) + " version --client >/dev/null 2>&1")
 	return err == nil
 }
 
@@ -129,15 +129,16 @@ func (c *localControl) ReadDefaultINI(ctx context.Context, exec Executor, filena
 func (c *localControl) DiscoverIniDir(_ context.Context, exec Executor) (string, error) {
 	if c.kubectlEnabled(exec) {
 		ns := c.controlNamespace
+		kctl := kubectlCLI(exec)
 		// UserSettings live on game-server pods (-sg-), not the bgd deploy pod.
 		podOut, err := exec.Exec(fmt.Sprintf(
-			"kubectl get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | grep -- '-sg-' | head -1",
-			ns,
+			"%s get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | grep -- '-sg-' | head -1",
+			kctl, ns,
 		))
 		if err != nil || strings.TrimSpace(podOut) == "" {
 			podOut, err = exec.Exec(fmt.Sprintf(
-				"kubectl get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | grep bgd | head -1",
-				ns,
+				"%s get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | grep bgd | head -1",
+				kctl, ns,
 			))
 		}
 		if err != nil || strings.TrimSpace(podOut) == "" {
@@ -146,8 +147,8 @@ func (c *localControl) DiscoverIniDir(_ context.Context, exec Executor) (string,
 		pod := strings.TrimSpace(podOut)
 		findCmd := `for d in /home/dune/server/DuneSandbox/Saved/UserSettings /DuneSandbox/Saved/UserSettings /game/DuneSandbox/Saved/UserSettings; do if [ -d "$d" ]; then echo "$d"; exit 0; fi; done; find / -type d -path "*/Saved/UserSettings" 2>/dev/null | head -1`
 		dirOut, err := exec.Exec(fmt.Sprintf(
-			"kubectl exec -n %s %s -- sh -lc %s 2>/dev/null",
-			ns, pod, shellQuote(findCmd),
+			"%s exec -n %s %s -- sh -lc %s 2>/dev/null",
+			kctl, ns, pod, shellQuote(findCmd),
 		))
 		if err != nil || strings.TrimSpace(dirOut) == "" {
 			return "", fmt.Errorf("could not auto-discover ini dir in pod %s", pod)

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -216,6 +216,51 @@ func cmdFetchSpecs() Msg {
 	return msgSpecs{rows: out}
 }
 
+func sqlHeaderNames(rows pgx.Rows) []string {
+	descs := rows.FieldDescriptions()
+	headers := make([]string, len(descs))
+	for i, desc := range descs {
+		headers[i] = string(desc.Name)
+	}
+	return headers
+}
+
+func collectSQLRows(rows pgx.Rows, limit int) ([][]any, bool) {
+	collected := make([][]any, 0, limit)
+	for rows.Next() && len(collected) < limit {
+		values, err := rows.Values()
+		if err != nil {
+			continue
+		}
+		collected = append(collected, values)
+	}
+	return collected, len(collected) == limit
+}
+
+func formatSQLRow(values []any) string {
+	parts := make([]string, len(values))
+	for i, value := range values {
+		parts[i] = fmt.Sprintf("%v", value)
+	}
+	return strings.Join(parts, " │ ")
+}
+
+func buildSQLResult(headers []string, rows [][]any, truncated bool) string {
+	var sb strings.Builder
+	sb.WriteString(strings.Join(headers, " │ "))
+	sb.WriteString("\n")
+	sb.WriteString(strings.Repeat("─", 80))
+	sb.WriteString("\n")
+	for _, row := range rows {
+		sb.WriteString(formatSQLRow(row))
+		sb.WriteString("\n")
+	}
+	if truncated {
+		sb.WriteString("… (limited to 200 rows)\n")
+	}
+	return sb.String()
+}
+
 func cmdRunSQL(sql string) Cmd {
 	return func() Msg {
 		if globalDB == nil {
@@ -227,246 +272,416 @@ func cmdRunSQL(sql string) Cmd {
 		}
 		defer rows.Close()
 
-		var sb strings.Builder
-		descs := rows.FieldDescriptions()
-		headers := make([]string, len(descs))
-		for i, d := range descs {
-			headers[i] = string(d.Name)
-		}
-		sb.WriteString(strings.Join(headers, " │ "))
-		sb.WriteString("\n")
-		sb.WriteString(strings.Repeat("─", 80))
-		sb.WriteString("\n")
-
-		count := 0
-		for rows.Next() && count < 200 {
-			vals, err := rows.Values()
-			if err != nil {
-				continue
-			}
-			parts := make([]string, len(vals))
-			for i, v := range vals {
-				parts[i] = fmt.Sprintf("%v", v)
-			}
-			sb.WriteString(strings.Join(parts, " │ "))
-			sb.WriteString("\n")
-			count++
-		}
-		if count == 200 {
-			sb.WriteString("… (limited to 200 rows)\n")
-		}
-		return msgSQL{result: sb.String()}
+		headers := sqlHeaderNames(rows)
+		resultRows, truncated := collectSQLRows(rows, 200)
+		return msgSQL{result: buildSQLResult(headers, resultRows, truncated)}
 	}
 }
 
 func cmdGiveItem(playerID int64, template string, qty, quality int64) Cmd {
 	return func() Msg {
-		if globalDB == nil {
-			return msgMutate{err: fmt.Errorf("not connected")}
-		}
-		if playerID == 0 {
-			return msgMutate{err: fmt.Errorf("player ID required")}
-		}
-		template = strings.TrimSpace(template)
-		if template == "" {
-			return msgMutate{err: fmt.Errorf("item template required")}
-		}
-		if qty <= 0 {
-			return msgMutate{err: fmt.Errorf("quantity must be > 0")}
-		}
-		ctx := context.Background()
+		return runGiveItem(playerID, template, qty, quality)
+	}
+}
 
-		// Prefer the backpack (inventory_type=0) — that's where resources live.
-		// Fall back to the first available inventory if not found.
-		var invID int64
-		var maxSlots int
-		var maxVolume float64
-		err := globalDB.QueryRow(ctx, `
-			SELECT id, COALESCE(max_item_count, -1), COALESCE(max_item_volume, -1)
-			FROM dune.inventories
-			WHERE actor_id = $1::bigint AND inventory_type = 0
-			LIMIT 1`, playerID).Scan(&invID, &maxSlots, &maxVolume)
-		if err != nil {
-			err = globalDB.QueryRow(ctx,
-				`SELECT id, COALESCE(max_item_count, -1), COALESCE(max_item_volume, -1)
-				 FROM dune.inventories WHERE actor_id = $1::bigint LIMIT 1`, playerID).Scan(&invID, &maxSlots, &maxVolume)
-			if err != nil {
-				return msgMutate{err: fmt.Errorf("find inventory: %w", err)}
+func runGiveItem(playerID int64, template string, qty, quality int64) Msg {
+	if globalDB == nil {
+		return msgMutate{err: fmt.Errorf("not connected")}
+	}
+	trimmedTemplate, err := validateGiveItemInput(playerID, template, qty)
+	if err != nil {
+		return msgMutate{err: err}
+	}
+	template = trimmedTemplate
+
+	ctx := context.Background()
+	inv, err := findGiveItemInventory(ctx, playerID)
+	if err != nil {
+		return msgMutate{err: err}
+	}
+	state, err := loadGiveItemInventoryState(ctx, inv.id, template, quality, inv.hasVolumeCap)
+	if err != nil {
+		return msgMutate{err: err}
+	}
+	stackMax, err := resolveStackMax(ctx, template, quality)
+	if err != nil {
+		return msgMutate{err: err}
+	}
+	if stackMax < 1 {
+		stackMax = 1
+	}
+	if err := ensureGiveItemVolumeCapacity(ctx, inv, state, template, qty); err != nil {
+		return msgMutate{err: err}
+	}
+
+	updates, newStacks := planGiveItemStacks(qty, stackMax, state.stacks)
+	if err := ensureGiveItemSlotCapacity(inv, state, len(newStacks)); err != nil {
+		return msgMutate{err: err}
+	}
+	if err := applyGiveItemChanges(ctx, inv.id, template, quality, state.maxPos, updates, newStacks); err != nil {
+		return msgMutate{err: err}
+	}
+	return msgMutate{ok: formatGiveItemResult(playerID, template, qty, len(updates), len(newStacks))}
+}
+
+type giveItemInventory struct {
+	id           int64
+	maxSlots     int
+	maxVolume    float64
+	hasSlotCap   bool
+	hasVolumeCap bool
+}
+
+type giveItemStackSlot struct {
+	id   int64
+	size int64
+}
+
+type giveItemInventoryState struct {
+	stacks     []giveItemStackSlot
+	usedSlots  int
+	usedVolume float64
+	maxPos     int64
+}
+
+type giveItemStackUpdate struct {
+	id  int64
+	add int64
+}
+
+func validateGiveItemInput(playerID int64, template string, qty int64) (string, error) {
+	if playerID == 0 {
+		return "", fmt.Errorf("player ID required")
+	}
+	template = strings.TrimSpace(template)
+	if template == "" {
+		return "", fmt.Errorf("item template required")
+	}
+	if qty <= 0 {
+		return "", fmt.Errorf("quantity must be > 0")
+	}
+	return template, nil
+}
+
+func findGiveItemInventory(ctx context.Context, playerID int64) (giveItemInventory, error) {
+	var inv giveItemInventory
+	err := globalDB.QueryRow(ctx, `
+		SELECT id, COALESCE(max_item_count, -1), COALESCE(max_item_volume, -1)
+		FROM dune.inventories
+		WHERE actor_id = $1::bigint AND inventory_type = 0
+		LIMIT 1`, playerID).Scan(&inv.id, &inv.maxSlots, &inv.maxVolume)
+	if err == nil {
+		inv.hasSlotCap = inv.maxSlots > 0
+		inv.hasVolumeCap = inv.maxVolume > 0
+		return inv, nil
+	}
+	err = globalDB.QueryRow(ctx, `
+		SELECT id, COALESCE(max_item_count, -1), COALESCE(max_item_volume, -1)
+		FROM dune.inventories
+		WHERE actor_id = $1::bigint
+		LIMIT 1`, playerID).Scan(&inv.id, &inv.maxSlots, &inv.maxVolume)
+	if err != nil {
+		return giveItemInventory{}, fmt.Errorf("find inventory: %w", err)
+	}
+	inv.hasSlotCap = inv.maxSlots > 0
+	inv.hasVolumeCap = inv.maxVolume > 0
+	return inv, nil
+}
+
+func loadGiveItemInventoryState(ctx context.Context, invID int64, template string, quality int64, includeVolume bool) (giveItemInventoryState, error) {
+	rows, err := globalDB.Query(ctx, `
+		SELECT id, template_id, stack_size, quality_level, volume_override, position_index
+		FROM dune.items
+		WHERE inventory_id = $1::bigint`, invID)
+	if err != nil {
+		return giveItemInventoryState{}, err
+	}
+	defer rows.Close()
+
+	state := giveItemInventoryState{maxPos: -1}
+	for rows.Next() {
+		var id int64
+		var tmpl string
+		var stackSize int64
+		var qLevel int64
+		var vol pgtype.Float8
+		var pos int64
+		if err := rows.Scan(&id, &tmpl, &stackSize, &qLevel, &vol, &pos); err != nil {
+			continue
+		}
+		state.usedSlots++
+		if pos > state.maxPos {
+			state.maxPos = pos
+		}
+		if qLevel == quality && tmpl == template {
+			state.stacks = append(state.stacks, giveItemStackSlot{id: id, size: stackSize})
+		}
+		if includeVolume {
+			state.usedVolume += inventoryItemVolume(tmpl, vol) * float64(stackSize)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return giveItemInventoryState{}, err
+	}
+	return state, nil
+}
+
+func inventoryItemVolume(template string, vol pgtype.Float8) float64 {
+	if vol.Valid && vol.Float64 > 0 {
+		return vol.Float64
+	}
+	if itemData.Items != nil {
+		if rule, ok := itemData.Items[strings.ToLower(template)]; ok {
+			return rule.Volume // 0 is valid — item takes no volume
+		}
+		if itemData.DefaultVolume > 0 {
+			return itemData.DefaultVolume
+		}
+		// Unknown volume: treat as 0 (no space consumed).
+		return 0
+	}
+	if itemData.DefaultVolume > 0 {
+		return itemData.DefaultVolume
+	}
+	return 0
+}
+
+func ensureGiveItemVolumeCapacity(
+	ctx context.Context,
+	inv giveItemInventory,
+	state giveItemInventoryState,
+	template string,
+	qty int64,
+) error {
+	if !inv.hasVolumeCap {
+		return nil
+	}
+	perItemVol, err := resolveItemVolume(ctx, template)
+	if err != nil {
+		return err
+	}
+	if perItemVol <= 0 {
+		return nil
+	}
+	availableVol := inv.maxVolume - state.usedVolume
+	if availableVol < 0 {
+		availableVol = 0
+	}
+	maxByVolume := int64(math.Floor(availableVol / perItemVol))
+	if maxByVolume < qty {
+		return fmt.Errorf(
+			"over weight limit: room for %d more %s (%.2f/%.2f volume used)",
+			maxByVolume, template, state.usedVolume, inv.maxVolume)
+	}
+	return nil
+}
+
+func planGiveItemStacks(qty, stackMax int64, stacks []giveItemStackSlot) ([]giveItemStackUpdate, []int64) {
+	sorted := make([]giveItemStackSlot, len(stacks))
+	copy(sorted, stacks)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].size > sorted[j].size
+	})
+	remaining := qty
+	updates := make([]giveItemStackUpdate, 0, len(sorted))
+	if stackMax > 1 {
+		for _, st := range sorted {
+			if remaining == 0 {
+				break
 			}
-		}
-
-		hasSlotCap := maxSlots > 0
-		hasVolumeCap := maxVolume > 0
-
-		type stackSlot struct {
-			id   int64
-			size int64
-		}
-		var stacks []stackSlot
-		usedSlots := 0
-		usedVolume := 0.0
-		maxPos := int64(-1)
-
-		rows, err := globalDB.Query(ctx, `
-			SELECT id, template_id, stack_size, quality_level, volume_override, position_index
-			FROM dune.items
-			WHERE inventory_id = $1::bigint`, invID)
-		if err != nil {
-			return msgMutate{err: err}
-		}
-		defer rows.Close()
-		for rows.Next() {
-			var id int64
-			var tmpl string
-			var stackSize int64
-			var qLevel int64
-			var vol pgtype.Float8
-			var pos int64
-			if err := rows.Scan(&id, &tmpl, &stackSize, &qLevel, &vol, &pos); err != nil {
+			space := stackMax - st.size
+			if space <= 0 {
 				continue
 			}
-			usedSlots++
-			if pos > maxPos {
-				maxPos = pos
+			add := space
+			if add > remaining {
+				add = remaining
 			}
-			if qLevel == quality && tmpl == template {
-				stacks = append(stacks, stackSlot{id: id, size: stackSize})
-			}
-			if hasVolumeCap {
-				itemVol := 0.0
-				if vol.Valid && vol.Float64 > 0 {
-					itemVol = vol.Float64
-				} else if itemData.Items != nil {
-					if rule, ok := itemData.Items[strings.ToLower(tmpl)]; ok {
-						itemVol = rule.Volume // 0 is valid — item takes no volume
-					} else if itemData.DefaultVolume > 0 {
-						itemVol = itemData.DefaultVolume
-					}
-					// Unknown volume: treat as 0 (no space consumed).
-				} else if itemData.DefaultVolume > 0 {
-					itemVol = itemData.DefaultVolume
-				}
-				usedVolume += itemVol * float64(stackSize)
-			}
+			updates = append(updates, giveItemStackUpdate{id: st.id, add: add})
+			remaining -= add
 		}
-		if rows.Err() != nil {
-			return msgMutate{err: rows.Err()}
-		}
-		stackMax, err := resolveStackMax(ctx, template, quality)
-		if err != nil {
-			return msgMutate{err: err}
-		}
-		if stackMax < 1 {
-			stackMax = 1
-		}
-
-		if hasVolumeCap {
-			perItemVol, err := resolveItemVolume(ctx, template)
-			if err != nil {
-				return msgMutate{err: err}
-			}
-			if perItemVol > 0 {
-				availableVol := maxVolume - usedVolume
-				if availableVol < 0 {
-					availableVol = 0
-				}
-				maxByVolume := int64(math.Floor(availableVol / perItemVol))
-				if maxByVolume < qty {
-					return msgMutate{err: fmt.Errorf(
-						"over weight limit: room for %d more %s (%.2f/%.2f volume used)",
-						maxByVolume, template, usedVolume, maxVolume)}
-				}
-			}
-			// perItemVol == 0: item takes no volume, always fits.
-		}
-
-		sort.Slice(stacks, func(i, j int) bool {
-			return stacks[i].size > stacks[j].size
-		})
-
-		remaining := qty
-		type stackUpdate struct {
-			id  int64
-			add int64
-		}
-		var updates []stackUpdate
-		if stackMax > 1 {
-			for _, st := range stacks {
-				if remaining == 0 {
-					break
-				}
-				space := stackMax - st.size
-				if space <= 0 {
-					continue
-				}
-				add := space
-				if add > remaining {
-					add = remaining
-				}
-				updates = append(updates, stackUpdate{id: st.id, add: add})
-				remaining -= add
-			}
-		}
-
-		var newStacks []int64
-		for remaining > 0 {
-			size := stackMax
-			if size > remaining {
-				size = remaining
-			}
-			newStacks = append(newStacks, size)
-			remaining -= size
-		}
-
-		if hasSlotCap {
-			freeSlots := maxSlots - usedSlots
-			if freeSlots < len(newStacks) {
-				return msgMutate{err: fmt.Errorf(
-					"inventory full: need %d free slots, have %d",
-					len(newStacks), freeSlots)}
-			}
-		}
-
-		tx, err := globalDB.Begin(ctx)
-		if err != nil {
-			return msgMutate{err: err}
-		}
-		defer func() { _ = tx.Rollback(ctx) }()
-
-		for _, u := range updates {
-			_, err = tx.Exec(ctx, `
-				UPDATE dune.items
-				SET stack_size = stack_size + $1::bigint
-				WHERE id = $2::bigint`, u.add, u.id)
-			if err != nil {
-				return msgMutate{err: err}
-			}
-		}
-
-		nextPos := maxPos + 1
-		for _, size := range newStacks {
-			_, err = tx.Exec(ctx, `
-				INSERT INTO dune.items (inventory_id, stack_size, position_index, template_id, quality_level, stats)
-				VALUES ($1::bigint, $2::bigint, $3::bigint, $4::text, $5::bigint, '{}'::jsonb)`,
-				invID, size, nextPos, template, quality)
-			if err != nil {
-				return msgMutate{err: err}
-			}
-			nextPos++
-		}
-
-		if err := tx.Commit(ctx); err != nil {
-			return msgMutate{err: err}
-		}
-
-		msg := fmt.Sprintf("Added %d × %s to player %d", qty, template, playerID)
-		if len(updates) > 0 || len(newStacks) > 0 {
-			msg = fmt.Sprintf(
-				"Added %d × %s to player %d (%d stack(s) topped up, %d new stack(s))",
-				qty, template, playerID, len(updates), len(newStacks))
-		}
-		return msgMutate{ok: msg}
 	}
+	newStackCap := 0
+	if stackMax > 0 {
+		newStackCap = int((remaining + stackMax - 1) / stackMax)
+	}
+	newStacks := make([]int64, 0, newStackCap)
+	for remaining > 0 {
+		size := stackMax
+		if size > remaining {
+			size = remaining
+		}
+		newStacks = append(newStacks, size)
+		remaining -= size
+	}
+	return updates, newStacks
+}
+
+func ensureGiveItemSlotCapacity(inv giveItemInventory, state giveItemInventoryState, newStackCount int) error {
+	if !inv.hasSlotCap {
+		return nil
+	}
+	freeSlots := inv.maxSlots - state.usedSlots
+	if freeSlots < newStackCount {
+		return fmt.Errorf("inventory full: need %d free slots, have %d", newStackCount, freeSlots)
+	}
+	return nil
+}
+
+func applyGiveItemChanges(
+	ctx context.Context,
+	invID int64,
+	template string,
+	quality int64,
+	maxPos int64,
+	updates []giveItemStackUpdate,
+	newStacks []int64,
+) error {
+	tx, err := globalDB.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	for _, u := range updates {
+		if _, err := tx.Exec(ctx, `
+			UPDATE dune.items
+			SET stack_size = stack_size + $1::bigint
+			WHERE id = $2::bigint`, u.add, u.id); err != nil {
+			return err
+		}
+	}
+
+	nextPos := maxPos + 1
+	for _, size := range newStacks {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO dune.items (inventory_id, stack_size, position_index, template_id, quality_level, stats)
+			VALUES ($1::bigint, $2::bigint, $3::bigint, $4::text, $5::bigint, '{}'::jsonb)`,
+			invID, size, nextPos, template, quality); err != nil {
+			return err
+		}
+		nextPos++
+	}
+
+	return tx.Commit(ctx)
+}
+
+func formatGiveItemResult(playerID int64, template string, qty int64, toppedUp, created int) string {
+	msg := fmt.Sprintf("Added %d × %s to player %d", qty, template, playerID)
+	if toppedUp > 0 || created > 0 {
+		return fmt.Sprintf(
+			"Added %d × %s to player %d (%d stack(s) topped up, %d new stack(s))",
+			qty, template, playerID, toppedUp, created)
+	}
+	return msg
+}
+
+type inventoryCapacityProfile struct {
+	id           int64
+	maxSlots     int
+	maxVolume    float64
+	hasSlotCap   bool
+	hasVolumeCap bool
+}
+
+type inventoryUsage struct {
+	usedSlots  int
+	usedVolume float64
+}
+
+func loadBackpackCapacity(ctx context.Context, playerID int64) (inventoryCapacityProfile, bool) {
+	var profile inventoryCapacityProfile
+	err := globalDB.QueryRow(ctx, `
+		SELECT id, COALESCE(max_item_count, -1), COALESCE(max_item_volume, -1)
+		FROM dune.inventories
+		WHERE actor_id = $1::bigint AND inventory_type = 0
+		LIMIT 1`, playerID).Scan(&profile.id, &profile.maxSlots, &profile.maxVolume)
+	if err != nil {
+		// No inventory found — cannot validate; let the game server decide.
+		return inventoryCapacityProfile{}, false
+	}
+	profile.hasSlotCap = profile.maxSlots > 0
+	profile.hasVolumeCap = profile.maxVolume > 0
+	return profile, true
+}
+
+func loadInventoryUsage(ctx context.Context, inventoryID int64, includeVolume bool) (inventoryUsage, error) {
+	rows, err := globalDB.Query(ctx, `
+		SELECT template_id, stack_size, volume_override
+		FROM dune.items
+		WHERE inventory_id = $1::bigint`, inventoryID)
+	if err != nil {
+		return inventoryUsage{}, err
+	}
+	defer rows.Close()
+
+	usage := inventoryUsage{}
+	for rows.Next() {
+		var templateID string
+		var stackSize int64
+		var volumeOverride pgtype.Float8
+		if err := rows.Scan(&templateID, &stackSize, &volumeOverride); err != nil {
+			continue
+		}
+		usage.usedSlots++
+		if includeVolume {
+			usage.usedVolume += inventoryItemVolume(templateID, volumeOverride) * float64(stackSize)
+		}
+	}
+	return usage, nil
+}
+
+func maxItemsByVolume(maxVolume, usedVolume, perItemVol float64) int64 {
+	availableVolume := maxVolume - usedVolume
+	if availableVolume < 0 {
+		availableVolume = 0
+	}
+	return int64(math.Floor(availableVolume / perItemVol))
+}
+
+func requiredStackCount(qty, stackMax int64) int {
+	return int((qty + stackMax - 1) / stackMax)
+}
+
+func checkInventoryVolumeLimit(
+	ctx context.Context,
+	profile inventoryCapacityProfile,
+	usage inventoryUsage,
+	template string,
+	qty int64,
+) error {
+	if !profile.hasVolumeCap {
+		return nil
+	}
+	perItemVol, err := resolveItemVolume(ctx, template)
+	if err != nil || perItemVol <= 0 {
+		return nil
+	}
+	maxByVolume := maxItemsByVolume(profile.maxVolume, usage.usedVolume, perItemVol)
+	if maxByVolume < qty {
+		return fmt.Errorf(
+			"over weight limit: room for %d more %s (%.2f/%.2f volume used)",
+			maxByVolume, template, usage.usedVolume, profile.maxVolume)
+	}
+	return nil
+}
+
+func checkInventorySlotLimit(ctx context.Context, profile inventoryCapacityProfile, usage inventoryUsage, template string, qty int64) error {
+	if !profile.hasSlotCap {
+		return nil
+	}
+	stackMax, err := resolveStackMax(ctx, template, 0)
+	if err != nil || stackMax < 1 {
+		stackMax = 1
+	}
+	freeSlots := profile.maxSlots - usage.usedSlots
+	newStacks := requiredStackCount(qty, stackMax)
+	if freeSlots < newStacks {
+		return fmt.Errorf(
+			"inventory full: need %d free slots, have %d",
+			newStacks, freeSlots)
+	}
+	return nil
 }
 
 // checkInventoryCapacity verifies that qty items of template fit in the player's
@@ -477,88 +692,22 @@ func checkInventoryCapacity(ctx context.Context, playerID int64, template string
 	if globalDB == nil {
 		return fmt.Errorf("not connected")
 	}
-	var invID int64
-	var maxSlots int
-	var maxVolume float64
-	err := globalDB.QueryRow(ctx, `
-		SELECT id, COALESCE(max_item_count, -1), COALESCE(max_item_volume, -1)
-		FROM dune.inventories
-		WHERE actor_id = $1::bigint AND inventory_type = 0
-		LIMIT 1`, playerID).Scan(&invID, &maxSlots, &maxVolume)
-	if err != nil {
-		// No inventory found — cannot validate; let the game server decide.
+	profile, ok := loadBackpackCapacity(ctx, playerID)
+	if !ok {
 		return nil
 	}
-
-	hasSlotCap := maxSlots > 0
-	hasVolumeCap := maxVolume > 0
-	if !hasSlotCap && !hasVolumeCap {
+	if !profile.hasSlotCap && !profile.hasVolumeCap {
 		return nil
 	}
-
-	usedSlots := 0
-	usedVolume := 0.0
-	rows, err := globalDB.Query(ctx, `
-		SELECT template_id, stack_size, volume_override
-		FROM dune.items
-		WHERE inventory_id = $1::bigint`, invID)
+	usage, err := loadInventoryUsage(ctx, profile.id, profile.hasVolumeCap)
 	if err != nil {
 		return nil
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var tmpl string
-		var stackSize int64
-		var vol pgtype.Float8
-		if err := rows.Scan(&tmpl, &stackSize, &vol); err != nil {
-			continue
-		}
-		usedSlots++
-		if hasVolumeCap {
-			itemVol := 0.0
-			if vol.Valid && vol.Float64 > 0 {
-				itemVol = vol.Float64
-			} else if itemData.Items != nil {
-				if rule, ok := itemData.Items[strings.ToLower(tmpl)]; ok {
-					itemVol = rule.Volume
-				} else if itemData.DefaultVolume > 0 {
-					itemVol = itemData.DefaultVolume
-				}
-			} else if itemData.DefaultVolume > 0 {
-				itemVol = itemData.DefaultVolume
-			}
-			usedVolume += itemVol * float64(stackSize)
-		}
+	if err := checkInventoryVolumeLimit(ctx, profile, usage, template, qty); err != nil {
+		return err
 	}
-
-	if hasVolumeCap {
-		perItemVol, err := resolveItemVolume(ctx, template)
-		if err == nil && perItemVol > 0 {
-			availableVol := maxVolume - usedVolume
-			if availableVol < 0 {
-				availableVol = 0
-			}
-			maxByVolume := int64(math.Floor(availableVol / perItemVol))
-			if maxByVolume < qty {
-				return fmt.Errorf(
-					"over weight limit: room for %d more %s (%.2f/%.2f volume used)",
-					maxByVolume, template, usedVolume, maxVolume)
-			}
-		}
-	}
-
-	if hasSlotCap {
-		stackMax, err := resolveStackMax(ctx, template, 0)
-		if err != nil || stackMax < 1 {
-			stackMax = 1
-		}
-		newStacks := int((qty + stackMax - 1) / stackMax)
-		freeSlots := maxSlots - usedSlots
-		if freeSlots < newStacks {
-			return fmt.Errorf(
-				"inventory full: need %d free slots, have %d",
-				newStacks, freeSlots)
-		}
+	if err := checkInventorySlotLimit(ctx, profile, usage, template, qty); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1274,35 +1423,57 @@ func cmdDescribeTable(tbl string) Cmd {
 	}
 }
 
+func sampleTableQuery(tbl string, limit int) string {
+	// Sanitize table name defensively even though tbl comes from pg_stat_user_tables.
+	// pgx.Identifier handles quoting and escaping to prevent SQL injection.
+	safeTable := pgx.Identifier{dbSchema, tbl}.Sanitize()
+	return fmt.Sprintf("SELECT * FROM %s LIMIT %d", safeTable, limit)
+}
+
+func sampleTableHeaders(rows pgx.Rows) []string {
+	descriptions := rows.FieldDescriptions()
+	headers := make([]string, 0, len(descriptions))
+	for _, description := range descriptions {
+		headers = append(headers, description.Name)
+	}
+	return headers
+}
+
+func formatSampleRow(values []any) []string {
+	row := make([]string, 0, len(values))
+	for _, value := range values {
+		row = append(row, fmt.Sprintf("%v", value))
+	}
+	return row
+}
+
+func sampleTableRows(rows pgx.Rows) ([][]string, error) {
+	result := make([][]string, 0)
+	for rows.Next() {
+		values, err := rows.Values()
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, formatSampleRow(values))
+	}
+	return result, nil
+}
+
 func cmdSampleTable(tbl string, limit int) Cmd {
 	return func() Msg {
 		if globalDB == nil {
 			return msgSample{err: fmt.Errorf("not connected")}
 		}
-		// Sanitize table name defensively even though tbl comes from pg_stat_user_tables.
-		// pgx.Identifier handles quoting and escaping to prevent SQL injection.
-		safeTable := pgx.Identifier{dbSchema, tbl}.Sanitize()
-		rows, err := globalDB.Query(context.Background(),
-			fmt.Sprintf("SELECT * FROM %s LIMIT %d", safeTable, limit))
+		rows, err := globalDB.Query(context.Background(), sampleTableQuery(tbl, limit))
 		if err != nil {
 			return msgSample{table: tbl, err: err}
 		}
 		defer rows.Close()
-		var headers []string
-		for _, fd := range rows.FieldDescriptions() {
-			headers = append(headers, fd.Name)
-		}
-		var result [][]string
-		for rows.Next() {
-			vals, err := rows.Values()
-			if err != nil {
-				return msgSample{table: tbl, err: err}
-			}
-			var row []string
-			for _, v := range vals {
-				row = append(row, fmt.Sprintf("%v", v))
-			}
-			result = append(result, row)
+
+		headers := sampleTableHeaders(rows)
+		result, err := sampleTableRows(rows)
+		if err != nil {
+			return msgSample{table: tbl, err: err}
 		}
 		if err := rows.Err(); err != nil {
 			return msgSample{table: tbl, err: err}
@@ -1620,72 +1791,168 @@ func cmdCompleteContracts(accountID int64, contractIDs []string) Cmd {
 		if globalDB == nil {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
-		if accountID == 0 {
-			return msgMutate{err: fmt.Errorf("account ID required")}
-		}
-		if len(contractIDs) == 0 {
-			return msgMutate{err: fmt.Errorf("at least one contract required")}
+		if err := validateContractMutationInput(accountID, contractIDs); err != nil {
+			return msgMutate{err: err}
 		}
 
-		seenTag := map[string]bool{}
-		var allTags []string
-		seenSkill := map[string]bool{}
-		var allSkillGrants []string
-		var resolved []string
-		for _, id := range contractIDs {
-			name, tags, err := resolveContractTags(id)
-			if err != nil {
-				return msgMutate{err: err}
-			}
-			resolved = append(resolved, name)
-			for _, t := range tags {
-				if !seenTag[t] {
-					seenTag[t] = true
-					allTags = append(allTags, t)
-				}
-			}
-			for _, sk := range tagsData.ContractSkillGrants[name] {
-				if !seenSkill[sk] {
-					seenSkill[sk] = true
-					allSkillGrants = append(allSkillGrants, sk)
-				}
-			}
-		}
-
-		ctx := context.Background()
-		extra, err := applyTagsWithTierBump(ctx, accountID, allTags)
+		set, err := buildContractRemovalSet(contractIDs)
 		if err != nil {
 			return msgMutate{err: err}
 		}
 
-		if len(allSkillGrants) > 0 {
-			grantedExtra, err := grantSkillBlocks(ctx, accountID, allSkillGrants)
-			if err != nil {
-				return msgMutate{err: err}
-			}
-			extra += grantedExtra
+		ctx := context.Background()
+		extra, err := applyTagsWithTierBump(ctx, accountID, set.removeTags)
+		if err != nil {
+			return msgMutate{err: err}
 		}
+
+		grantedExtra, err := applyContractSkillGrants(ctx, accountID, set.removeSkills)
+		if err != nil {
+			return msgMutate{err: err}
+		}
+		extra += grantedExtra
 
 		// Strip any in-progress ContractItem rows so the in-game quest
 		// tracker doesn't keep showing the conditions for a contract we just
 		// force-completed. ContractName.Name uses the short alias form
 		// (no DA_CT_ prefix).
-		shortNames := make([]string, 0, len(resolved))
-		for _, full := range resolved {
-			shortNames = append(shortNames, strings.TrimPrefix(full, "DA_CT_"))
-		}
+		shortNames := contractShortNames(set.resolvedNames)
 		dismissedExtra, err := dismissActiveContracts(ctx, accountID, shortNames)
 		if err != nil {
 			return msgMutate{err: err}
 		}
 		extra += dismissedExtra
 
-		summary := resolved[0]
-		if len(resolved) > 1 {
-			summary = fmt.Sprintf("%d contracts", len(resolved))
-		}
+		summary := contractBatchSummary(set.resolvedNames)
 		return msgMutate{ok: fmt.Sprintf("Applied %s%s — takes effect on next login", summary, extra)}
 	}
+}
+
+func validateContractMutationInput(accountID int64, contractIDs []string) error {
+	if accountID == 0 {
+		return fmt.Errorf("account ID required")
+	}
+	if len(contractIDs) == 0 {
+		return fmt.Errorf("at least one contract required")
+	}
+	return nil
+}
+
+type contractRemovalSet struct {
+	resolvedNames []string
+	removeTags    []string
+	removeSkills  []string
+}
+
+func buildContractRemovalSet(contractIDs []string) (contractRemovalSet, error) {
+	seenTag := map[string]bool{}
+	seenSkill := map[string]bool{}
+	set := contractRemovalSet{
+		resolvedNames: make([]string, 0, len(contractIDs)),
+		removeTags:    make([]string, 0, len(contractIDs)),
+		removeSkills:  make([]string, 0, len(contractIDs)),
+	}
+
+	for _, id := range contractIDs {
+		name, tags, err := resolveContractTags(id)
+		if err != nil {
+			return contractRemovalSet{}, err
+		}
+		set.resolvedNames = append(set.resolvedNames, name)
+		for _, tag := range tags {
+			if seenTag[tag] {
+				continue
+			}
+			seenTag[tag] = true
+			set.removeTags = append(set.removeTags, tag)
+		}
+		for _, skill := range tagsData.ContractSkillGrants[name] {
+			if seenSkill[skill] {
+				continue
+			}
+			seenSkill[skill] = true
+			set.removeSkills = append(set.removeSkills, skill)
+		}
+	}
+
+	return set, nil
+}
+
+func applyContractSkillGrants(ctx context.Context, accountID int64, skills []string) (string, error) {
+	if len(skills) == 0 {
+		return "", nil
+	}
+	return grantSkillBlocks(ctx, accountID, skills)
+}
+
+func contractShortNames(resolvedNames []string) []string {
+	shortNames := make([]string, 0, len(resolvedNames))
+	for _, full := range resolvedNames {
+		shortNames = append(shortNames, strings.TrimPrefix(full, "DA_CT_"))
+	}
+	return shortNames
+}
+
+func removeContractTags(ctx context.Context, accountID int64, removeTags []string) error {
+	if len(removeTags) == 0 {
+		return nil
+	}
+	if _, err := globalDB.Exec(ctx,
+		`SELECT dune.update_player_tags($1, '{}'::text[], $2::text[])`,
+		accountID, removeTags); err != nil {
+		return fmt.Errorf("remove tags: %w", err)
+	}
+	return nil
+}
+
+func loadContractPawnID(ctx context.Context, accountID int64) int64 {
+	var pawnID int64
+	_ = globalDB.QueryRow(ctx,
+		`SELECT player_pawn_id FROM dune.player_state WHERE account_id = $1 LIMIT 1`,
+		accountID).Scan(&pawnID)
+	return pawnID
+}
+
+func stripContractSkillBlocks(ctx context.Context, pawnID int64, removeSkills []string) (int, error) {
+	if pawnID == 0 || len(removeSkills) == 0 {
+		return 0, nil
+	}
+
+	stripped := 0
+	for _, skill := range removeSkills {
+		key := fmt.Sprintf(`(TagName="%s")`, skill)
+		tag, err := globalDB.Exec(ctx, `
+			UPDATE dune.fgl_entities fe
+			SET components = jsonb_set(
+				fe.components,
+				ARRAY['FLevelComponent','1','ModuleData'],
+				(fe.components->'FLevelComponent'->1->'ModuleData') - $2::text)
+			WHERE fe.entity_id = (
+				SELECT entity_id FROM dune.actor_fgl_entities
+				WHERE actor_id = $1 AND slot_name = 'DuneCharacter'
+			)
+			AND COALESCE(
+				(fe.components->'FLevelComponent'->1->'ModuleData'->$2->>'SkillPointsSpent')::int,
+				0
+			) <= 1`,
+			pawnID, key)
+		if err != nil {
+			return 0, fmt.Errorf("strip %s: %w", skill, err)
+		}
+		if tag.RowsAffected() > 0 {
+			stripped++
+		}
+	}
+
+	return stripped, nil
+}
+
+func contractBatchSummary(resolvedNames []string) string {
+	summary := resolvedNames[0]
+	if len(resolvedNames) > 1 {
+		summary = fmt.Sprintf("%d contracts", len(resolvedNames))
+	}
+	return summary
 }
 
 // cmdReverseContracts removes the AddedFlagsOnCompletion tags and strips the
@@ -1697,90 +1964,30 @@ func cmdReverseContracts(accountID int64, contractIDs []string) Cmd {
 		if globalDB == nil {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
-		if accountID == 0 {
-			return msgMutate{err: fmt.Errorf("account ID required")}
-		}
-		if len(contractIDs) == 0 {
-			return msgMutate{err: fmt.Errorf("at least one contract required")}
+		if err := validateContractMutationInput(accountID, contractIDs); err != nil {
+			return msgMutate{err: err}
 		}
 
-		seenTag := map[string]bool{}
-		var removeTags []string
-		seenSkill := map[string]bool{}
-		var removeSkills []string
-		var resolved []string
-
-		for _, id := range contractIDs {
-			name, tags, err := resolveContractTags(id)
-			if err != nil {
-				return msgMutate{err: err}
-			}
-			resolved = append(resolved, name)
-			for _, t := range tags {
-				if !seenTag[t] {
-					seenTag[t] = true
-					removeTags = append(removeTags, t)
-				}
-			}
-			for _, sk := range tagsData.ContractSkillGrants[name] {
-				if !seenSkill[sk] {
-					seenSkill[sk] = true
-					removeSkills = append(removeSkills, sk)
-				}
-			}
+		set, err := buildContractRemovalSet(contractIDs)
+		if err != nil {
+			return msgMutate{err: err}
 		}
 
 		ctx := context.Background()
-
-		if len(removeTags) > 0 {
-			if _, err := globalDB.Exec(ctx,
-				`SELECT dune.update_player_tags($1, '{}'::text[], $2::text[])`,
-				accountID, removeTags); err != nil {
-				return msgMutate{err: fmt.Errorf("remove tags: %w", err)}
-			}
+		if err := removeContractTags(ctx, accountID, set.removeTags); err != nil {
+			return msgMutate{err: err}
 		}
 
-		stripped := 0
-		if len(removeSkills) > 0 {
-			var pawnID int64
-			_ = globalDB.QueryRow(ctx,
-				`SELECT player_pawn_id FROM dune.player_state WHERE account_id = $1 LIMIT 1`,
-				accountID).Scan(&pawnID)
-			if pawnID != 0 {
-				for _, sk := range removeSkills {
-					key := fmt.Sprintf(`(TagName="%s")`, sk)
-					tag, err := globalDB.Exec(ctx, `
-						UPDATE dune.fgl_entities fe
-						SET components = jsonb_set(
-							fe.components,
-							ARRAY['FLevelComponent','1','ModuleData'],
-							(fe.components->'FLevelComponent'->1->'ModuleData') - $2::text)
-						WHERE fe.entity_id = (
-							SELECT entity_id FROM dune.actor_fgl_entities
-							WHERE actor_id = $1 AND slot_name = 'DuneCharacter'
-						)
-						AND COALESCE(
-							(fe.components->'FLevelComponent'->1->'ModuleData'->$2->>'SkillPointsSpent')::int,
-							0
-						) <= 1`,
-						pawnID, key)
-					if err != nil {
-						return msgMutate{err: fmt.Errorf("strip %s: %w", sk, err)}
-					}
-					if tag.RowsAffected() > 0 {
-						stripped++
-					}
-				}
-			}
+		pawnID := loadContractPawnID(ctx, accountID)
+		stripped, err := stripContractSkillBlocks(ctx, pawnID, set.removeSkills)
+		if err != nil {
+			return msgMutate{err: err}
 		}
 
-		summary := resolved[0]
-		if len(resolved) > 1 {
-			summary = fmt.Sprintf("%d contracts", len(resolved))
-		}
+		summary := contractBatchSummary(set.resolvedNames)
 		return msgMutate{ok: fmt.Sprintf(
 			"Reversed %s: removed %d tag(s), stripped %d skill block(s) — takes effect on next login",
-			summary, len(removeTags), stripped)}
+			summary, len(set.removeTags), stripped)}
 	}
 }
 
@@ -1853,6 +2060,103 @@ var starterAbilityByJob = map[string]string{
 	"Trooper":       "Skills.Ability.SuspensorGrenade_Reduction",
 }
 
+func resolveStarterClassAbility(job string) (string, error) {
+	if _, ok := tagsData.JobSkillBlocks[job]; !ok {
+		return "", fmt.Errorf("unknown job %q", job)
+	}
+	ability, ok := starterAbilityByJob[job]
+	if !ok {
+		return "", fmt.Errorf("no starter ability mapping for %q", job)
+	}
+	return ability, nil
+}
+
+func loadPawnIDForAccount(ctx context.Context, accountID int64) (int64, error) {
+	var pawnID int64
+	_ = globalDB.QueryRow(ctx, `
+		SELECT player_pawn_id FROM dune.player_state
+		WHERE account_id = $1 LIMIT 1`, accountID).Scan(&pawnID)
+	if pawnID == 0 {
+		return 0, fmt.Errorf("no pawn for account %d", accountID)
+	}
+	return pawnID, nil
+}
+
+func loadStarterTagForPawn(ctx context.Context, pawnID int64) string {
+	var starterTag string
+	_ = globalDB.QueryRow(ctx, `
+		SELECT fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName'
+		FROM dune.fgl_entities fe
+		JOIN dune.actor_fgl_entities afe ON afe.entity_id = fe.entity_id
+		WHERE afe.actor_id = $1 AND afe.slot_name = 'DuneCharacter'`,
+		pawnID).Scan(&starterTag)
+	return starterTag
+}
+
+func starterKeysToRemove(oldStarterTag, newJob string) []string {
+	if !strings.HasPrefix(oldStarterTag, "Skills.Key.") || !strings.HasSuffix(oldStarterTag, "1") {
+		return nil
+	}
+	oldJob := strings.TrimSuffix(strings.TrimPrefix(oldStarterTag, "Skills.Key."), "1")
+	if oldJob == "" || oldJob == newJob {
+		return nil
+	}
+	keys := []string{fmt.Sprintf(`(TagName="%s")`, oldStarterTag)}
+	if oldAbility, ok := starterAbilityByJob[oldJob]; ok {
+		keys = append(keys, fmt.Sprintf(`(TagName="%s")`, oldAbility))
+	}
+	return keys
+}
+
+func starterClassTagAndKeys(job, ability string) (starterTag, starterKey, abilityKey string) {
+	starterTag = fmt.Sprintf("Skills.Key.%s1", job)
+	starterKey = fmt.Sprintf(`(TagName="%s")`, starterTag)
+	abilityKey = fmt.Sprintf(`(TagName="%s")`, ability)
+	return starterTag, starterKey, abilityKey
+}
+
+func applyStarterClassUpdate(
+	ctx context.Context,
+	pawnID int64,
+	newStarterTag, newStarterKey string,
+	keysToRemove []string,
+	newAbilityKey string,
+) error {
+	_, err := globalDB.Exec(ctx, `
+		UPDATE dune.fgl_entities fe
+		SET components = jsonb_set(
+			jsonb_set(
+				jsonb_set(
+					jsonb_set(
+						fe.components,
+						ARRAY['FLevelComponent','1','ModuleData'],
+						(fe.components->'FLevelComponent'->1->'ModuleData') - $4::text[]),
+					ARRAY['FLevelComponent','1','StarterSkillTreeTag','TagName'],
+					to_jsonb($2::text)),
+				ARRAY['FLevelComponent','1','ModuleData',$3],
+				'{"SkillPointsSpent": 1}'::jsonb,
+				true),
+			ARRAY['FLevelComponent','1','ModuleData',$5],
+			'{"SkillPointsSpent": 1}'::jsonb,
+			true)
+		WHERE fe.entity_id = (
+			SELECT entity_id FROM dune.actor_fgl_entities
+			WHERE actor_id = $1 AND slot_name = 'DuneCharacter'
+		)`, pawnID, newStarterTag, newStarterKey, keysToRemove, newAbilityKey)
+	if err != nil {
+		return fmt.Errorf("set starter tag: %w", err)
+	}
+	return nil
+}
+
+func formatStarterClassMessage(job, newStarterTag, newAbility string, removedCount int) string {
+	msg := fmt.Sprintf("Starter class set to %s (%s + %s active)", job, newStarterTag, newAbility)
+	if removedCount > 0 {
+		msg += fmt.Sprintf(", cleared previous starter (%d module(s))", removedCount)
+	}
+	return msg
+}
+
 // cmdSetStarterClass swaps the player's starter class:
 //  1. removes the previous starter's Skills.Key.<Old>1 block + its starter
 //     ability from ModuleData (so you don't end up with two starters
@@ -1871,83 +2175,33 @@ func cmdSetStarterClass(accountID int64, job string) Cmd {
 		if accountID == 0 {
 			return msgMutate{err: fmt.Errorf("account ID required")}
 		}
-		if _, ok := tagsData.JobSkillBlocks[job]; !ok {
-			return msgMutate{err: fmt.Errorf("unknown job %q", job)}
-		}
-		newAbility, ok := starterAbilityByJob[job]
-		if !ok {
-			return msgMutate{err: fmt.Errorf("no starter ability mapping for %q", job)}
+		newAbility, err := resolveStarterClassAbility(job)
+		if err != nil {
+			return msgMutate{err: err}
 		}
 		ctx := context.Background()
 
-		var pawnID int64
-		_ = globalDB.QueryRow(ctx, `
-			SELECT player_pawn_id FROM dune.player_state
-			WHERE account_id = $1 LIMIT 1`, accountID).Scan(&pawnID)
-		if pawnID == 0 {
-			return msgMutate{err: fmt.Errorf("no pawn for account %d", accountID)}
+		pawnID, err := loadPawnIDForAccount(ctx, accountID)
+		if err != nil {
+			return msgMutate{err: err}
 		}
 
 		// Look up the current starter so we can deactivate it. Format is
 		// "Skills.Key.<Job>1"; we strip the prefix/suffix to recover the
 		// job name and look up its starter-ability for removal.
-		var oldStarterTag string
-		_ = globalDB.QueryRow(ctx, `
-			SELECT fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName'
-			FROM dune.fgl_entities fe
-			JOIN dune.actor_fgl_entities afe ON afe.entity_id = fe.entity_id
-			WHERE afe.actor_id = $1 AND afe.slot_name = 'DuneCharacter'`,
-			pawnID).Scan(&oldStarterTag)
-
-		var keysToRemove []string
-		if strings.HasPrefix(oldStarterTag, "Skills.Key.") && strings.HasSuffix(oldStarterTag, "1") {
-			oldJob := strings.TrimSuffix(strings.TrimPrefix(oldStarterTag, "Skills.Key."), "1")
-			if oldJob != "" && oldJob != job {
-				keysToRemove = append(keysToRemove, fmt.Sprintf(`(TagName="%s")`, oldStarterTag))
-				if oldAb, ok := starterAbilityByJob[oldJob]; ok {
-					keysToRemove = append(keysToRemove, fmt.Sprintf(`(TagName="%s")`, oldAb))
-				}
-			}
-		}
-
-		newStarterTag := fmt.Sprintf("Skills.Key.%s1", job)
-		newStarterKey := fmt.Sprintf(`(TagName="%s")`, newStarterTag)
-		newAbilityKey := fmt.Sprintf(`(TagName="%s")`, newAbility)
+		oldStarterTag := loadStarterTagForPawn(ctx, pawnID)
+		keysToRemove := starterKeysToRemove(oldStarterTag, job)
+		newStarterTag, newStarterKey, newAbilityKey := starterClassTagAndKeys(job, newAbility)
 
 		// One chained jsonb update: strip old keys, write new tag, activate
 		// new starter block, grant new starter ability. - operator on an
 		// empty text[] is a no-op so it's safe when there's no old starter
 		// to clean up (e.g. fresh character with StarterSkillTreeTag=None).
-		_, err := globalDB.Exec(ctx, `
-			UPDATE dune.fgl_entities fe
-			SET components = jsonb_set(
-				jsonb_set(
-					jsonb_set(
-						jsonb_set(
-							fe.components,
-							ARRAY['FLevelComponent','1','ModuleData'],
-							(fe.components->'FLevelComponent'->1->'ModuleData') - $4::text[]),
-						ARRAY['FLevelComponent','1','StarterSkillTreeTag','TagName'],
-						to_jsonb($2::text)),
-					ARRAY['FLevelComponent','1','ModuleData',$3],
-					'{"SkillPointsSpent": 1}'::jsonb,
-					true),
-				ARRAY['FLevelComponent','1','ModuleData',$5],
-				'{"SkillPointsSpent": 1}'::jsonb,
-				true)
-			WHERE fe.entity_id = (
-				SELECT entity_id FROM dune.actor_fgl_entities
-				WHERE actor_id = $1 AND slot_name = 'DuneCharacter'
-			)`, pawnID, newStarterTag, newStarterKey, keysToRemove, newAbilityKey)
-		if err != nil {
-			return msgMutate{err: fmt.Errorf("set starter tag: %w", err)}
+		if err := applyStarterClassUpdate(ctx, pawnID, newStarterTag, newStarterKey, keysToRemove, newAbilityKey); err != nil {
+			return msgMutate{err: err}
 		}
 
-		msg := fmt.Sprintf("Starter class set to %s (%s + %s active)", job, newStarterTag, newAbility)
-		if len(keysToRemove) > 0 {
-			msg += fmt.Sprintf(", cleared previous starter (%d module(s))", len(keysToRemove))
-		}
-		return msgMutate{ok: msg}
+		return msgMutate{ok: formatStarterClassMessage(job, newStarterTag, newAbility, len(keysToRemove))}
 	}
 }
 
@@ -2305,6 +2559,231 @@ func nodesForPreset(faction, preset string) []string {
 	return nodes
 }
 
+const progressionUnlockMaxTier = 5
+
+type progressionFactionConfig struct {
+	factionID        int16
+	dialogueFlag     string
+	alignedFlag      string
+	metRecruiterFlag string
+	factionUnlocked  string
+	recruitmentDone  string
+}
+
+func progressionFactionConfigFor(faction string) (progressionFactionConfig, error) {
+	switch faction {
+	case "atreides":
+		return progressionFactionConfig{
+			factionID:        1,
+			dialogueFlag:     "DialogueFlags.Factions.SentToMeetHawat",
+			alignedFlag:      "DialogueFlags.Factions.AlignedAtreides",
+			metRecruiterFlag: "DialogueFlags.Factions.MetHawat",
+			factionUnlocked:  "Contract.Tracking.AtreidesFactionUnlocked",
+			recruitmentDone:  "Contract.Tracking.AtreidesRecruitmentCompleted",
+		}, nil
+	case "harkonnen":
+		return progressionFactionConfig{
+			factionID:        2,
+			dialogueFlag:     "DialogueFlags.Factions.SentToPiterDeVries",
+			alignedFlag:      "DialogueFlags.Factions.AlignedHarkonnen",
+			metRecruiterFlag: "DialogueFlags.Factions.MetPiterDeVries",
+			factionUnlocked:  "Contract.Tracking.HarkonnenFactionUnlocked",
+			recruitmentDone:  "Contract.Tracking.HarkonnenRecruitmentCompleted",
+		}, nil
+	default:
+		return progressionFactionConfig{}, fmt.Errorf("faction must be atreides or harkonnen")
+	}
+}
+
+func progressionTargetTierForPreset(preset string) (int, error) {
+	switch preset {
+	case "ch3_start":
+		return 5, nil
+	case "rank19_eligible":
+		return 19, nil
+	default:
+		return 0, fmt.Errorf("preset must be ch3_start or rank19_eligible")
+	}
+}
+
+func progressionUnlockTags(cfg progressionFactionConfig, targetTier int) []string {
+	factionName := factionDisplayName(cfg.factionID)
+	// Faction.<X>.TierN is only a real gameplay tag for N ∈ [0,5] — see
+	// DA_Atreides.json / DA_Harkonnen.json m_FactionTiers, where Tier 6+
+	// all have m_FactionTierTag.TagName == "None". Tier 5 flips
+	// m_bAllowPromotionThroughReputation to true, after which rep alone
+	// advances the displayed rank. So Tier0–5 + a rep >= threshold[19] is
+	// enough to display rank 19 — no need to write phantom Tier6..19 tags.
+	allTags := []string{
+		cfg.dialogueFlag, cfg.alignedFlag, cfg.metRecruiterFlag,
+		cfg.factionUnlocked, cfg.recruitmentDone,
+		"DialogueFlags.Factions.FactionIntro",
+		"DialogueFlags.Factions.FactionRank1",
+		"DialogueFlags.Factions.FactionRank3",
+		"DialogueFlags.Factions.MetARecruiter",
+		"DialogueFlags.Factions.PlayedAllegianceCinematic",
+		"DialogueFlags.Factions.SeenAnvilCinematic",
+	}
+	if targetTier >= 19 {
+		allTags = append(allTags, "Journey.LandsraadContractsUnlocked")
+	}
+	for tier := 0; tier <= progressionUnlockMaxTier; tier++ {
+		allTags = append(allTags, fmt.Sprintf("Faction.%s.Tier%d", factionName, tier))
+	}
+	return allTags
+}
+
+func resolveProgressionUnlockPlayer(ctx context.Context, actorID int64) (accountID, controllerID int64, flsID string, err error) {
+	if err = globalDB.QueryRow(ctx, `
+		SELECT COALESCE(a.owner_account_id, 0),
+		       COALESCE(ps.player_controller_id, 0)
+		FROM dune.actors a
+		LEFT JOIN dune.player_state ps ON ps.account_id = a.owner_account_id
+		WHERE a.id = $1`, actorID,
+	).Scan(&accountID, &controllerID); err != nil || accountID == 0 {
+		return 0, 0, "", fmt.Errorf("player %d not found or has no account", actorID)
+	}
+	if controllerID == 0 {
+		return 0, 0, "", fmt.Errorf("player %d has no controller actor", actorID)
+	}
+	flsID, err = rawFuncomID(ctx, accountID)
+	if err != nil || flsID == "" {
+		return 0, 0, "", fmt.Errorf("player %d has no FLS ID", actorID)
+	}
+	return accountID, controllerID, flsID, nil
+}
+
+func applyProgressionUnlock(
+	ctx context.Context,
+	accountID, controllerID int64,
+	flsID string,
+	factionID int16,
+	factionName string,
+	targetTier int,
+	journeyNodes, allTags []string,
+) error {
+	tx, err := globalDB.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err = tx.Exec(ctx,
+		`SELECT dune.complete_journey_story_nodes_for_player($1, $2::text[])`,
+		flsID, journeyNodes); err != nil {
+		return fmt.Errorf("complete journey nodes: %w", err)
+	}
+
+	// Align the player with the chosen faction. Required for fresh / unaligned
+	// characters (no player_faction row) — without this the rank UI doesn't
+	// reflect tier changes because the game treats the player as unaligned.
+	// neutral_faction_id = 3 ("None") so this proc takes the upsert branch.
+	if _, err = tx.Exec(ctx,
+		`SELECT dune.change_player_faction($1::bigint, $2::smallint, 3::smallint, NOW()::timestamp)`,
+		controllerID, factionID); err != nil {
+		return fmt.Errorf("change_player_faction: %w", err)
+	}
+
+	if _, err = tx.Exec(ctx,
+		`SELECT dune.update_player_tags($1, $2::text[], '{}'::text[])`, accountID, allTags); err != nil {
+		return fmt.Errorf("update player tags: %w", err)
+	}
+
+	// +1 over the tier threshold: the game UI floors at the threshold
+	// (rep == threshold shows the tier below), so we nudge just over.
+	targetRep := factionTierThresholds[targetTier] + 1
+	if _, err = tx.Exec(ctx,
+		`SELECT dune.set_player_faction_reputation($1, $2, $3)`,
+		controllerID, factionID, targetRep); err != nil {
+		return fmt.Errorf("set faction rep: %w", err)
+	}
+	if _, err = tx.Exec(ctx, factionPlayerComponentRepSQL,
+		controllerID, factionName, targetRep); err != nil {
+		return fmt.Errorf("update FactionPlayerComponent rep: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func formatProgressionUnlockSuccess(
+	preset, faction string,
+	journeyNodeCount int,
+	factionName string,
+	targetTier int,
+	controllerID int64,
+) string {
+	return fmt.Sprintf(
+		"Progression unlock (%s/%s): %d journey nodes completed + %s tier tags 0–%d + rep tier %d on controller %d — takes effect on next login",
+		preset, faction, journeyNodeCount, factionName, progressionUnlockMaxTier, targetTier, controllerID)
+}
+
+func resolveProgressionAccountID(ctx context.Context, actorID int64) (int64, error) {
+	var accountID int64
+	if err := globalDB.QueryRow(ctx,
+		`SELECT COALESCE(owner_account_id, 0) FROM dune.actors WHERE id = $1`,
+		actorID).Scan(&accountID); err != nil || accountID == 0 {
+		return 0, fmt.Errorf("player %d not found or has no account", actorID)
+	}
+	return accountID, nil
+}
+
+func progressionReverseTags(baseTags, nodes []string) []string {
+	allTags := append([]string{}, baseTags...)
+	seen := make(map[string]bool, len(allTags))
+	for _, tag := range allTags {
+		seen[tag] = true
+	}
+	for _, node := range nodes {
+		for _, tag := range tagsForJourneyNodeSubtree(node) {
+			if seen[tag] {
+				continue
+			}
+			seen[tag] = true
+			allTags = append(allTags, tag)
+		}
+	}
+	return allTags
+}
+
+func applyProgressionReverse(ctx context.Context, accountID int64, allTags, nodes []string) (int64, error) {
+	tx, err := globalDB.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err = tx.Exec(ctx,
+		`SELECT dune.update_player_tags($1, '{}'::text[], $2::text[])`,
+		accountID, allTags); err != nil {
+		return 0, fmt.Errorf("remove tags: %w", err)
+	}
+
+	result, err := tx.Exec(ctx, `
+		UPDATE dune.journey_story_node
+		SET complete_condition_state = 'false'::jsonb,
+		    has_pending_reward       = false
+		WHERE account_id = $1
+		  AND story_node_id = ANY($2::text[])`,
+		accountID, nodes)
+	if err != nil {
+		return 0, fmt.Errorf("reset journey nodes: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+func formatProgressionReverseSuccess(preset, faction string, resetNodes int64, removedTags int) string {
+	return fmt.Sprintf(
+		"Reversed progression unlock (%s/%s): reset %d node(s), removed %d tag(s) — takes effect on next login",
+		preset, faction, resetNodes, removedTags)
+}
+
 // cmdProgressionUnlock completes all prerequisite faction story journey nodes,
 // writes the corresponding gameplay tags, and sets reputation to the preset's
 // target tier.
@@ -2317,136 +2796,47 @@ func cmdProgressionUnlock(actorID int64, faction, preset string) Cmd {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
 
-		var factionID int16
-		var dialogueFlag, alignedFlag, metRecruiterFlag, factionUnlocked, recruitmentDone string
-		switch faction {
-		case "atreides":
-			factionID = 1
-			dialogueFlag = "DialogueFlags.Factions.SentToMeetHawat"
-			alignedFlag = "DialogueFlags.Factions.AlignedAtreides"
-			metRecruiterFlag = "DialogueFlags.Factions.MetHawat"
-			factionUnlocked = "Contract.Tracking.AtreidesFactionUnlocked"
-			recruitmentDone = "Contract.Tracking.AtreidesRecruitmentCompleted"
-		case "harkonnen":
-			factionID = 2
-			dialogueFlag = "DialogueFlags.Factions.SentToPiterDeVries"
-			alignedFlag = "DialogueFlags.Factions.AlignedHarkonnen"
-			metRecruiterFlag = "DialogueFlags.Factions.MetPiterDeVries"
-			factionUnlocked = "Contract.Tracking.HarkonnenFactionUnlocked"
-			recruitmentDone = "Contract.Tracking.HarkonnenRecruitmentCompleted"
-		default:
-			return msgMutate{err: fmt.Errorf("faction must be atreides or harkonnen")}
-		}
-
-		var targetTier int
-		switch preset {
-		case "ch3_start":
-			targetTier = 5
-		case "rank19_eligible":
-			targetTier = 19
-		default:
-			return msgMutate{err: fmt.Errorf("preset must be ch3_start or rank19_eligible")}
-		}
-
-		ctx := context.Background()
-
-		var accountID, controllerID int64
-		err := globalDB.QueryRow(ctx, `
-			SELECT COALESCE(a.owner_account_id, 0),
-			       COALESCE(ps.player_controller_id, 0)
-			FROM dune.actors a
-			LEFT JOIN dune.player_state ps ON ps.account_id = a.owner_account_id
-			WHERE a.id = $1`, actorID,
-		).Scan(&accountID, &controllerID)
-		if err != nil || accountID == 0 {
-			return msgMutate{err: fmt.Errorf("player %d not found or has no account", actorID)}
-		}
-		if controllerID == 0 {
-			return msgMutate{err: fmt.Errorf("player %d has no controller actor", actorID)}
-		}
-		flsID, err := rawFuncomID(ctx, accountID)
-		if err != nil || flsID == "" {
-			return msgMutate{err: fmt.Errorf("player %d has no FLS ID", actorID)}
-		}
-
-		journeyNodes := nodesForPreset(faction, preset)
-
-		factionName := factionDisplayName(factionID)
-		// Faction.<X>.TierN is only a real gameplay tag for N ∈ [0,5] — see
-		// DA_Atreides.json / DA_Harkonnen.json m_FactionTiers, where Tier 6+
-		// all have m_FactionTierTag.TagName == "None". Tier 5 flips
-		// m_bAllowPromotionThroughReputation to true, after which rep alone
-		// advances the displayed rank. So Tier0–5 + a rep >= threshold[19] is
-		// enough to display rank 19 — no need to write phantom Tier6..19 tags.
-		const maxTier = 5
-		// Baseline faction-progression tags observed on both rank-up reference
-		// characters (rank 19 Atreides + rank 8 Harkonnen). MetARecruiter,
-		// PlayedAllegianceCinematic, SeenAnvilCinematic, FactionRank1/3 are
-		// faction-neutral; the faction-specific flags are picked above.
-		allTags := []string{
-			dialogueFlag, alignedFlag, metRecruiterFlag,
-			factionUnlocked, recruitmentDone,
-			"DialogueFlags.Factions.FactionIntro",
-			"DialogueFlags.Factions.FactionRank1",
-			"DialogueFlags.Factions.FactionRank3",
-			"DialogueFlags.Factions.MetARecruiter",
-			"DialogueFlags.Factions.PlayedAllegianceCinematic",
-			"DialogueFlags.Factions.SeenAnvilCinematic",
-		}
-		if targetTier >= 19 {
-			allTags = append(allTags, "Journey.LandsraadContractsUnlocked")
-		}
-		for t := 0; t <= maxTier; t++ {
-			allTags = append(allTags, fmt.Sprintf("Faction.%s.Tier%d", factionName, t))
-		}
-
-		tx, err := globalDB.Begin(ctx)
+		cfg, err := progressionFactionConfigFor(faction)
 		if err != nil {
 			return msgMutate{err: err}
 		}
-		defer func() { _ = tx.Rollback(ctx) }()
-
-		if _, err = tx.Exec(ctx,
-			`SELECT dune.complete_journey_story_nodes_for_player($1, $2::text[])`,
-			flsID, journeyNodes); err != nil {
-			return msgMutate{err: fmt.Errorf("complete journey nodes: %w", err)}
-		}
-
-		// Align the player with the chosen faction. Required for fresh / unaligned
-		// characters (no player_faction row) — without this the rank UI doesn't
-		// reflect tier changes because the game treats the player as unaligned.
-		// neutral_faction_id = 3 ("None") so this proc takes the upsert branch.
-		if _, err = tx.Exec(ctx,
-			`SELECT dune.change_player_faction($1::bigint, $2::smallint, 3::smallint, NOW()::timestamp)`,
-			controllerID, factionID); err != nil {
-			return msgMutate{err: fmt.Errorf("change_player_faction: %w", err)}
-		}
-
-		if _, err = tx.Exec(ctx,
-			`SELECT dune.update_player_tags($1, $2::text[], '{}'::text[])`, accountID, allTags); err != nil {
-			return msgMutate{err: fmt.Errorf("update player tags: %w", err)}
-		}
-
-		// +1 over the tier threshold: the game UI floors at the threshold
-		// (rep == threshold shows the tier below), so we nudge just over.
-		targetRep := factionTierThresholds[targetTier] + 1
-		if _, err = tx.Exec(ctx,
-			`SELECT dune.set_player_faction_reputation($1, $2, $3)`,
-			controllerID, factionID, targetRep); err != nil {
-			return msgMutate{err: fmt.Errorf("set faction rep: %w", err)}
-		}
-		if _, err = tx.Exec(ctx, factionPlayerComponentRepSQL,
-			controllerID, factionName, targetRep); err != nil {
-			return msgMutate{err: fmt.Errorf("update FactionPlayerComponent rep: %w", err)}
-		}
-
-		if err := tx.Commit(ctx); err != nil {
+		targetTier, err := progressionTargetTierForPreset(preset)
+		if err != nil {
 			return msgMutate{err: err}
 		}
 
-		return msgMutate{ok: fmt.Sprintf(
-			"Progression unlock (%s/%s): %d journey nodes completed + %s tier tags 0–%d + rep tier %d on controller %d — takes effect on next login",
-			preset, faction, len(journeyNodes), factionName, maxTier, targetTier, controllerID)}
+		journeyNodes := nodesForPreset(faction, preset)
+		factionName := factionDisplayName(cfg.factionID)
+		allTags := progressionUnlockTags(cfg, targetTier)
+
+		ctx := context.Background()
+		accountID, controllerID, flsID, err := resolveProgressionUnlockPlayer(ctx, actorID)
+		if err != nil {
+			return msgMutate{err: err}
+		}
+
+		if err := applyProgressionUnlock(
+			ctx,
+			accountID,
+			controllerID,
+			flsID,
+			cfg.factionID,
+			factionName,
+			targetTier,
+			journeyNodes,
+			allTags,
+		); err != nil {
+			return msgMutate{err: err}
+		}
+
+		return msgMutate{ok: formatProgressionUnlockSuccess(
+			preset,
+			faction,
+			len(journeyNodes),
+			factionName,
+			targetTier,
+			controllerID,
+		)}
 	}
 }
 
@@ -2460,111 +2850,36 @@ func cmdReverseProgressionUnlock(actorID int64, faction, preset string) Cmd {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
 
-		var factionID int16
-		var dialogueFlag, alignedFlag, metRecruiterFlag, factionUnlocked, recruitmentDone string
-		switch faction {
-		case "atreides":
-			factionID = 1
-			dialogueFlag = "DialogueFlags.Factions.SentToMeetHawat"
-			alignedFlag = "DialogueFlags.Factions.AlignedAtreides"
-			metRecruiterFlag = "DialogueFlags.Factions.MetHawat"
-			factionUnlocked = "Contract.Tracking.AtreidesFactionUnlocked"
-			recruitmentDone = "Contract.Tracking.AtreidesRecruitmentCompleted"
-		case "harkonnen":
-			factionID = 2
-			dialogueFlag = "DialogueFlags.Factions.SentToPiterDeVries"
-			alignedFlag = "DialogueFlags.Factions.AlignedHarkonnen"
-			metRecruiterFlag = "DialogueFlags.Factions.MetPiterDeVries"
-			factionUnlocked = "Contract.Tracking.HarkonnenFactionUnlocked"
-			recruitmentDone = "Contract.Tracking.HarkonnenRecruitmentCompleted"
-		default:
-			return msgMutate{err: fmt.Errorf("faction must be atreides or harkonnen")}
+		cfg, err := progressionFactionConfigFor(faction)
+		if err != nil {
+			return msgMutate{err: err}
 		}
-
-		var targetTier int
-		switch preset {
-		case "ch3_start":
-			targetTier = 5
-		case "rank19_eligible":
-			targetTier = 19
-		default:
-			return msgMutate{err: fmt.Errorf("preset must be ch3_start or rank19_eligible")}
+		targetTier, err := progressionTargetTierForPreset(preset)
+		if err != nil {
+			return msgMutate{err: err}
 		}
 
 		ctx := context.Background()
-
-		var accountID int64
-		if err := globalDB.QueryRow(ctx,
-			`SELECT COALESCE(owner_account_id, 0) FROM dune.actors WHERE id = $1`,
-			actorID).Scan(&accountID); err != nil || accountID == 0 {
-			return msgMutate{err: fmt.Errorf("player %d not found or has no account", actorID)}
+		accountID, err := resolveProgressionAccountID(ctx, actorID)
+		if err != nil {
+			return msgMutate{err: err}
 		}
 
-		// Build the exact same tag set the forward function writes so we can remove it.
-		factionName := factionDisplayName(factionID)
-		const maxTier = 5
-		allTags := []string{
-			dialogueFlag, alignedFlag, metRecruiterFlag,
-			factionUnlocked, recruitmentDone,
-			"DialogueFlags.Factions.FactionIntro",
-			"DialogueFlags.Factions.FactionRank1",
-			"DialogueFlags.Factions.FactionRank3",
-			"DialogueFlags.Factions.MetARecruiter",
-			"DialogueFlags.Factions.PlayedAllegianceCinematic",
-			"DialogueFlags.Factions.SeenAnvilCinematic",
-		}
-		if targetTier >= 19 {
-			allTags = append(allTags, "Journey.LandsraadContractsUnlocked")
-		}
-		for t := 0; t <= maxTier; t++ {
-			allTags = append(allTags, fmt.Sprintf("Faction.%s.Tier%d", factionName, t))
-		}
-
-		// Also collect any tags the journey nodes themselves emit on completion.
 		nodes := nodesForPreset(faction, preset)
-		seen := map[string]bool{}
-		for _, t := range allTags {
-			seen[t] = true
-		}
-		for _, node := range nodes {
-			for _, t := range tagsForJourneyNodeSubtree(node) {
-				if !seen[t] {
-					seen[t] = true
-					allTags = append(allTags, t)
-				}
-			}
-		}
+		baseTags := progressionUnlockTags(cfg, targetTier)
+		allTags := progressionReverseTags(baseTags, nodes)
 
-		tx, err := globalDB.Begin(ctx)
+		resetNodes, err := applyProgressionReverse(ctx, accountID, allTags, nodes)
 		if err != nil {
 			return msgMutate{err: err}
 		}
-		defer func() { _ = tx.Rollback(ctx) }()
 
-		if _, err = tx.Exec(ctx,
-			`SELECT dune.update_player_tags($1, '{}'::text[], $2::text[])`,
-			accountID, allTags); err != nil {
-			return msgMutate{err: fmt.Errorf("remove tags: %w", err)}
-		}
-
-		result, err := tx.Exec(ctx, `
-			UPDATE dune.journey_story_node
-			SET complete_condition_state = 'false'::jsonb,
-			    has_pending_reward       = false
-			WHERE account_id = $1
-			  AND story_node_id = ANY($2::text[])`,
-			accountID, nodes)
-		if err != nil {
-			return msgMutate{err: fmt.Errorf("reset journey nodes: %w", err)}
-		}
-
-		if err := tx.Commit(ctx); err != nil {
-			return msgMutate{err: err}
-		}
-
-		return msgMutate{ok: fmt.Sprintf(
-			"Reversed progression unlock (%s/%s): reset %d node(s), removed %d tag(s) — takes effect on next login",
-			preset, faction, result.RowsAffected(), len(allTags))}
+		return msgMutate{ok: formatProgressionReverseSuccess(
+			preset,
+			faction,
+			resetNodes,
+			len(allTags),
+		)}
 	}
 }
 
@@ -2702,6 +3017,15 @@ type msgCharXP struct {
 	err   error
 }
 
+type charXPOutcome struct {
+	newXP        int64
+	newLevel     int64
+	newTotalSP   int64
+	newUnspentSP int64
+	newIntel     int64
+	capped       bool
+}
+
 func cmdFetchCharXP(playerID int64) Cmd {
 	return func() Msg {
 		if globalDB == nil {
@@ -2720,6 +3044,143 @@ func cmdFetchCharXP(playerID int64) Cmd {
 	}
 }
 
+func readCharXPState(ctx context.Context, playerID int64) (currentXP, spentSP int64, err error) {
+	err = globalDB.QueryRow(ctx, `
+		SELECT
+			(fe.components->'FLevelComponent'->1->>'TotalXPEarned')::bigint,
+			COALESCE((
+				SELECT SUM((v->>'SkillPointsSpent')::int)
+				FROM jsonb_each(fe.components->'FLevelComponent'->1->'ModuleData') AS kv(k, v)
+				WHERE k != format('(TagName="%s")',
+					fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName')
+			), 0)
+		FROM dune.fgl_entities fe
+		JOIN dune.actor_fgl_entities afe ON afe.entity_id = fe.entity_id
+		WHERE afe.actor_id = $1 AND afe.slot_name = 'DuneCharacter'`, playerID).Scan(&currentXP, &spentSP)
+	if err != nil {
+		return 0, 0, fmt.Errorf("read current state: %w", err)
+	}
+	return currentXP, spentSP, nil
+}
+
+func resolveControllerIDForPawn(ctx context.Context, playerID int64) (int64, error) {
+	var controllerID int64
+	err := globalDB.QueryRow(ctx, `
+		SELECT player_controller_id FROM dune.player_state
+		WHERE player_pawn_id = $1 LIMIT 1`, playerID).Scan(&controllerID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("resolve controller id: %w", err)
+	}
+	return controllerID, nil
+}
+
+func loadControllerKeystoneIDs(ctx context.Context, controllerID int64) ([]int16, error) {
+	if controllerID == 0 {
+		return nil, nil
+	}
+	rows, err := globalDB.Query(ctx, `
+		SELECT keystone_id FROM dune.purchased_specialization_keystones
+		WHERE player_id = $1::bigint`, controllerID)
+	if err != nil {
+		return nil, fmt.Errorf("read keystones: %w", err)
+	}
+	defer rows.Close()
+
+	ids := make([]int16, 0, 8)
+	for rows.Next() {
+		var id int16
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan keystone: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("scan keystone: %w", err)
+	}
+	return ids, nil
+}
+
+func fetchKeystoneBonusForPawn(ctx context.Context, playerID int64) (int64, error) {
+	controllerID, err := resolveControllerIDForPawn(ctx, playerID)
+	if err != nil {
+		return 0, err
+	}
+	ids, err := loadControllerKeystoneIDs(ctx, controllerID)
+	if err != nil {
+		return 0, err
+	}
+	return keystoneSPBonus(ids), nil
+}
+
+func computeAwardCharXPOutcome(currentXP, spentSP, keystoneBonus, amount int64) charXPOutcome {
+	newXP := currentXP + amount
+	if newXP > maxCharXP {
+		newXP = maxCharXP
+	}
+	newLevel := int64(xpToLevel(newXP))
+	newTotalSP := newLevel + keystoneBonus
+	// Starter job always occupies 1 SP that is excluded from spentSP.
+	newUnspentSP := newTotalSP - spentSP - 1
+	if newUnspentSP < 0 {
+		newUnspentSP = 0
+	}
+	newIntel := intelAtLevel(int(newLevel))
+	return charXPOutcome{
+		newXP:        newXP,
+		newLevel:     newLevel,
+		newTotalSP:   newTotalSP,
+		newUnspentSP: newUnspentSP,
+		newIntel:     newIntel,
+		capped:       newXP == maxCharXP,
+	}
+}
+
+func applyAwardCharXPFLevelUpdate(ctx context.Context, playerID int64, outcome charXPOutcome) error {
+	_, err := globalDB.Exec(ctx, `
+		UPDATE dune.fgl_entities
+		SET components = jsonb_set(jsonb_set(jsonb_set(
+			components,
+			'{FLevelComponent,1,TotalXPEarned}',    to_jsonb($2::bigint)),
+			'{FLevelComponent,1,TotalSkillPoints}',  to_jsonb($3::bigint)),
+			'{FLevelComponent,1,UnspentSkillPoints}', to_jsonb($4::bigint))
+		WHERE entity_id = (
+			SELECT entity_id FROM dune.actor_fgl_entities
+			WHERE actor_id = $1 AND slot_name = 'DuneCharacter'
+		)`, playerID, outcome.newXP, outcome.newTotalSP, outcome.newUnspentSP)
+	if err != nil {
+		return fmt.Errorf("update fgl xp/sp: %w", err)
+	}
+	return nil
+}
+
+func applyAwardCharXPIntelUpdate(ctx context.Context, playerID int64, newIntel int64) error {
+	_, err := globalDB.Exec(ctx, `
+		UPDATE dune.actors
+		SET properties = jsonb_set(
+			properties,
+			'{TechKnowledgePlayerComponent,m_TechKnowledgePoints}',
+			to_jsonb($2::bigint))
+		WHERE id = $1 AND properties ? 'TechKnowledgePlayerComponent'`,
+		playerID, newIntel)
+	if err != nil {
+		return fmt.Errorf("update intel: %w", err)
+	}
+	return nil
+}
+
+func formatAwardCharXPSuccess(playerID int64, outcome charXPOutcome, spentSP int64) string {
+	capped := ""
+	if outcome.capped {
+		capped = " (capped at level 200)"
+	}
+	return fmt.Sprintf(
+		"Player %d → level %d%s | XP %d | SP %d unspent (%d spent) | Intel %d",
+		playerID, outcome.newLevel, capped, outcome.newXP, outcome.newUnspentSP, spentSP, outcome.newIntel)
+}
+
 func cmdAwardCharXP(playerID int64, amount int64) Cmd {
 	return func() Msg {
 		if globalDB == nil {
@@ -2733,104 +3194,29 @@ func cmdAwardCharXP(playerID int64, amount int64) Cmd {
 			return msgMutate{err: err}
 		}
 
-		// Read current XP and count of skill points already spent in the tree.
-		var currentXP, spentSP int64
-		err := globalDB.QueryRow(ctx, `
-			SELECT
-				(fe.components->'FLevelComponent'->1->>'TotalXPEarned')::bigint,
-				COALESCE((
-					SELECT SUM((v->>'SkillPointsSpent')::int)
-					FROM jsonb_each(fe.components->'FLevelComponent'->1->'ModuleData') AS kv(k, v)
-					WHERE k != format('(TagName="%s")',
-						fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName')
-				), 0)
-			FROM dune.fgl_entities fe
-			JOIN dune.actor_fgl_entities afe ON afe.entity_id = fe.entity_id
-			WHERE afe.actor_id = $1 AND afe.slot_name = 'DuneCharacter'`, playerID).Scan(&currentXP, &spentSP)
+		currentXP, spentSP, err := readCharXPState(ctx, playerID)
 		if err != nil {
-			return msgMutate{err: fmt.Errorf("read current state: %w", err)}
+			return msgMutate{err: err}
 		}
 
-		// Resolve controller id from the pawn id so we can read purchased
-		// keystones (which are keyed by controller id). A missing player_state
-		// row means no keystones could have been purchased — treat bonus as 0.
-		var keystoneBonus int64
-		var controllerID int64
-		err = globalDB.QueryRow(ctx, `
-			SELECT player_controller_id FROM dune.player_state
-			WHERE player_pawn_id = $1 LIMIT 1`, playerID).Scan(&controllerID)
-		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return msgMutate{err: fmt.Errorf("resolve controller id: %w", err)}
-		}
-		if controllerID != 0 {
-			rows, err := globalDB.Query(ctx, `
-				SELECT keystone_id FROM dune.purchased_specialization_keystones
-				WHERE player_id = $1::bigint`, controllerID)
-			if err != nil {
-				return msgMutate{err: fmt.Errorf("read keystones: %w", err)}
-			}
-			var ids []int16
-			for rows.Next() {
-				var id int16
-				if err := rows.Scan(&id); err != nil {
-					rows.Close()
-					return msgMutate{err: fmt.Errorf("scan keystone: %w", err)}
-				}
-				ids = append(ids, id)
-			}
-			rows.Close()
-			keystoneBonus = keystoneSPBonus(ids)
+		keystoneBonus, err := fetchKeystoneBonusForPawn(ctx, playerID)
+		if err != nil {
+			return msgMutate{err: err}
 		}
 
-		newXP := currentXP + amount
-		if newXP > maxCharXP {
-			newXP = maxCharXP
-		}
-		newLevel := int64(xpToLevel(newXP))
-		newTotalSP := newLevel + keystoneBonus
-		// Starter job always occupies 1 SP that is excluded from spentSP.
-		newUnspentSP := newTotalSP - spentSP - 1
-		if newUnspentSP < 0 {
-			newUnspentSP = 0
-		}
-		newIntel := intelAtLevel(int(newLevel))
+		outcome := computeAwardCharXPOutcome(currentXP, spentSP, keystoneBonus, amount)
 
 		// Update FLevelComponent: XP + both skill point fields.
-		_, err = globalDB.Exec(ctx, `
-			UPDATE dune.fgl_entities
-			SET components = jsonb_set(jsonb_set(jsonb_set(
-				components,
-				'{FLevelComponent,1,TotalXPEarned}',    to_jsonb($2::bigint)),
-				'{FLevelComponent,1,TotalSkillPoints}',  to_jsonb($3::bigint)),
-				'{FLevelComponent,1,UnspentSkillPoints}', to_jsonb($4::bigint))
-			WHERE entity_id = (
-				SELECT entity_id FROM dune.actor_fgl_entities
-				WHERE actor_id = $1 AND slot_name = 'DuneCharacter'
-			)`, playerID, newXP, newTotalSP, newUnspentSP)
-		if err != nil {
-			return msgMutate{err: fmt.Errorf("update fgl xp/sp: %w", err)}
+		if err := applyAwardCharXPFLevelUpdate(ctx, playerID, outcome); err != nil {
+			return msgMutate{err: err}
 		}
 
 		// Update intel points on the PlayerCharacter actor.
-		_, err = globalDB.Exec(ctx, `
-			UPDATE dune.actors
-			SET properties = jsonb_set(
-				properties,
-				'{TechKnowledgePlayerComponent,m_TechKnowledgePoints}',
-				to_jsonb($2::bigint))
-			WHERE id = $1 AND properties ? 'TechKnowledgePlayerComponent'`,
-			playerID, newIntel)
-		if err != nil {
-			return msgMutate{err: fmt.Errorf("update intel: %w", err)}
+		if err := applyAwardCharXPIntelUpdate(ctx, playerID, outcome.newIntel); err != nil {
+			return msgMutate{err: err}
 		}
 
-		capped := ""
-		if newXP == maxCharXP {
-			capped = " (capped at level 200)"
-		}
-		return msgMutate{ok: fmt.Sprintf(
-			"Player %d → level %d%s | XP %d | SP %d unspent (%d spent) | Intel %d",
-			playerID, newLevel, capped, newXP, newUnspentSP, spentSP, newIntel)}
+		return msgMutate{ok: formatAwardCharXPSuccess(playerID, outcome, spentSP)}
 	}
 }
 
@@ -3012,37 +3398,25 @@ func keystoneSPBonus(ids []int16) int64 {
 	return total
 }
 
-func cmdGrantAllKeystones(playerID int64) Cmd {
-	return func() Msg {
-		if globalDB == nil {
-			return msgMutate{err: fmt.Errorf("not connected")}
-		}
-		ctx := context.Background()
-
-		if err := checkPlayerOffline(ctx, playerID); err != nil {
-			return msgMutate{err: err}
-		}
-
-		var err error
-		_, err = globalDB.Exec(ctx, `
+func insertAllPurchasedKeystones(ctx context.Context, playerID int64) error {
+	_, err := globalDB.Exec(ctx, `
 			INSERT INTO dune.purchased_specialization_keystones (player_id, keystone_id)
 			SELECT $1::bigint, generate_series(1, 205)
 			ON CONFLICT DO NOTHING`, playerID)
-		if err != nil {
-			return msgMutate{err: err}
-		}
+	return err
+}
 
-		// Compute the SP bonus all 205 purchased keystones should give.
-		allIDs := make([]int16, 205)
-		for i := range allIDs {
-			allIDs[i] = int16(i + 1)
-		}
-		keystoneBonus := keystoneSPBonus(allIDs)
+func allKeystoneIDs() []int16 {
+	ids := make([]int16, 205)
+	for i := range ids {
+		ids[i] = int16(i + 1)
+	}
+	return ids
+}
 
-		// Read XP, current TotalSkillPoints, and SP spent in non-starter modules.
-		// Uses pawn actor id (purchased_specialization_keystones uses controller id).
-		var xp, currentTotal, spentSP int64
-		err = globalDB.QueryRow(ctx, `
+func readLevelComponentSkillState(ctx context.Context, playerID int64) (int64, int64, int64, error) {
+	var xp, currentTotal, spentSP int64
+	err := globalDB.QueryRow(ctx, `
 			SELECT
 				(fe.components->'FLevelComponent'->1->>'TotalXPEarned')::bigint,
 				(fe.components->'FLevelComponent'->1->>'TotalSkillPoints')::bigint,
@@ -3059,25 +3433,26 @@ func cmdGrantAllKeystones(playerID int64) Cmd {
 				SELECT player_pawn_id FROM dune.player_state
 				WHERE player_controller_id = $1 LIMIT 1
 			  )`, playerID).Scan(&xp, &currentTotal, &spentSP)
-		if err != nil {
-			return msgMutate{err: fmt.Errorf("read FLevelComponent: %w", err)}
-		}
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("read FLevelComponent: %w", err)
+	}
+	return xp, currentTotal, spentSP, nil
+}
 
-		level := int64(xpToLevel(xp))
-		expectedTotal := level + keystoneBonus
-		// UnspentSkillPoints = total - non-starter spent - 1 (starter job always occupies 1 SP).
-		expectedUnspent := expectedTotal - spentSP - 1
-		if expectedUnspent < 0 {
-			expectedUnspent = 0
-		}
+func grantAllKeystoneTargets(xp, spentSP int64) (int64, int64, int64) {
+	keystoneBonus := keystoneSPBonus(allKeystoneIDs())
+	level := int64(xpToLevel(xp))
+	expectedTotal := level + keystoneBonus
+	// UnspentSkillPoints = total - non-starter spent - 1 (starter job always occupies 1 SP).
+	expectedUnspent := expectedTotal - spentSP - 1
+	if expectedUnspent < 0 {
+		expectedUnspent = 0
+	}
+	return expectedTotal, expectedUnspent, keystoneBonus
+}
 
-		if currentTotal >= expectedTotal {
-			return msgMutate{ok: fmt.Sprintf(
-				"Granted all keystones to player %d — SP already correct (%d total, %d unspent)",
-				playerID, currentTotal, expectedUnspent)}
-		}
-
-		_, err = globalDB.Exec(ctx, `
+func updateLevelComponentSkillPoints(ctx context.Context, playerID, expectedTotal, expectedUnspent int64) error {
+	_, err := globalDB.Exec(ctx, `
 			UPDATE dune.fgl_entities
 			SET components = jsonb_set(jsonb_set(
 				components,
@@ -3093,8 +3468,44 @@ func cmdGrantAllKeystones(playerID int64) Cmd {
 					WHERE player_controller_id = $1 LIMIT 1
 				  )
 			)`, playerID, expectedTotal, expectedUnspent)
+	if err != nil {
+		return fmt.Errorf("update skill points: %w", err)
+	}
+	return nil
+}
+
+func cmdGrantAllKeystones(playerID int64) Cmd {
+	return func() Msg {
+		if globalDB == nil {
+			return msgMutate{err: fmt.Errorf("not connected")}
+		}
+		ctx := context.Background()
+
+		if err := checkPlayerOffline(ctx, playerID); err != nil {
+			return msgMutate{err: err}
+		}
+
+		if err := insertAllPurchasedKeystones(ctx, playerID); err != nil {
+			return msgMutate{err: err}
+		}
+
+		// Read XP, current TotalSkillPoints, and SP spent in non-starter modules.
+		// Uses pawn actor id (purchased_specialization_keystones uses controller id).
+		xp, currentTotal, spentSP, err := readLevelComponentSkillState(ctx, playerID)
 		if err != nil {
-			return msgMutate{err: fmt.Errorf("update skill points: %w", err)}
+			return msgMutate{err: err}
+		}
+
+		expectedTotal, expectedUnspent, keystoneBonus := grantAllKeystoneTargets(xp, spentSP)
+
+		if currentTotal >= expectedTotal {
+			return msgMutate{ok: fmt.Sprintf(
+				"Granted all keystones to player %d — SP already correct (%d total, %d unspent)",
+				playerID, currentTotal, expectedUnspent)}
+		}
+
+		if err := updateLevelComponentSkillPoints(ctx, playerID, expectedTotal, expectedUnspent); err != nil {
+			return msgMutate{err: err}
 		}
 
 		return msgMutate{ok: fmt.Sprintf(
@@ -3262,33 +3673,24 @@ func cmdGetPlayerVehicles(controllerID int64) Cmd {
 	}
 }
 
-func cmdRepairItem(itemID int64) Cmd {
-	return func() Msg {
-		if globalDB == nil {
-			return msgMutate{err: fmt.Errorf("not connected")}
-		}
-		ctx := context.Background()
-
-		// Derive owning player from item → inventory → actor (pawn) so we can gate Offline.
-		var pawnID int64
-		err := globalDB.QueryRow(ctx, `
+func lookupRepairItemOwner(ctx context.Context, itemID int64) (int64, error) {
+	var pawnID int64
+	err := globalDB.QueryRow(ctx, `
 			SELECT inv.actor_id
 			FROM dune.items i
 			JOIN dune.inventories inv ON inv.id = i.inventory_id
 			WHERE i.id = $1::bigint`, itemID).Scan(&pawnID)
-		if errors.Is(err, pgx.ErrNoRows) {
-			return msgMutate{err: fmt.Errorf("item %d not found", itemID)}
-		}
-		if err != nil {
-			return msgMutate{err: fmt.Errorf("look up item owner: %w", err)}
-		}
-		if err := checkPlayerOffline(ctx, pawnID); err != nil {
-			return msgMutate{err: err}
-		}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, fmt.Errorf("item %d not found", itemID)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("look up item owner: %w", err)
+	}
+	return pawnID, nil
+}
 
-		// Write both fields: Current-only gets clamped to surviving Decayed on reload.
-		// Fallback target = 100.0 covers the 0-100 gear scale when MaxDurability is absent.
-		res, err := globalDB.Exec(ctx, `
+func repairItemDurability(ctx context.Context, itemID int64) (int64, error) {
+	res, err := globalDB.Exec(ctx, `
 			UPDATE dune.items i
 			SET stats = jsonb_set(
 				jsonb_set(i.stats,
@@ -3310,182 +3712,298 @@ func cmdRepairItem(itemID int64) Cmd {
 				abs(COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0) - t.val) > 0.01
 				OR abs(COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0) - t.val) > 0.01
 			  )`, itemID)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected(), nil
+}
+
+func itemHasDurabilityStats(ctx context.Context, itemID int64) (bool, error) {
+	var hasDurability bool
+	if err := globalDB.QueryRow(ctx, `
+				SELECT stats ? 'FItemStackAndDurabilityStats'
+				FROM dune.items WHERE id = $1::bigint`, itemID).Scan(&hasDurability); err != nil {
+		return false, fmt.Errorf("check item: %w", err)
+	}
+	return hasDurability, nil
+}
+
+func repairItemNoChangeMessage(itemID int64, hasDurability bool) msgMutate {
+	if !hasDurability {
+		return msgMutate{err: fmt.Errorf("item %d has no durability field", itemID)}
+	}
+	return msgMutate{ok: fmt.Sprintf("Item %d already at full durability", itemID)}
+}
+
+func repairItemSuccessMessage(itemID int64) msgMutate {
+	return msgMutate{ok: fmt.Sprintf("Repaired item %d — relog to see in-game", itemID)}
+}
+
+func cmdRepairItem(itemID int64) Cmd {
+	return func() Msg {
+		if globalDB == nil {
+			return msgMutate{err: fmt.Errorf("not connected")}
+		}
+		ctx := context.Background()
+
+		// Derive owning player from item → inventory → actor (pawn) so we can gate Offline.
+		pawnID, err := lookupRepairItemOwner(ctx, itemID)
+		if err != nil {
+			return msgMutate{err: err}
+		}
+		if err := checkPlayerOffline(ctx, pawnID); err != nil {
+			return msgMutate{err: err}
+		}
+
+		// Write both fields: Current-only gets clamped to surviving Decayed on reload.
+		// Fallback target = 100.0 covers the 0-100 gear scale when MaxDurability is absent.
+		rowsAffected, err := repairItemDurability(ctx, itemID)
 		if err != nil {
 			return msgMutate{err: fmt.Errorf("repair item: %w", err)}
 		}
-		if res.RowsAffected() == 0 {
+		if rowsAffected == 0 {
 			// Item exists (owner lookup succeeded). Either no durability field, or already at ceiling.
-			var hasDur bool
-			if err := globalDB.QueryRow(ctx, `
-				SELECT stats ? 'FItemStackAndDurabilityStats'
-				FROM dune.items WHERE id = $1::bigint`, itemID).Scan(&hasDur); err != nil {
-				return msgMutate{err: fmt.Errorf("check item: %w", err)}
+			hasDurability, err := itemHasDurabilityStats(ctx, itemID)
+			if err != nil {
+				return msgMutate{err: err}
 			}
-			if !hasDur {
-				return msgMutate{err: fmt.Errorf("item %d has no durability field", itemID)}
-			}
-			return msgMutate{ok: fmt.Sprintf("Item %d already at full durability", itemID)}
+			return repairItemNoChangeMessage(itemID, hasDurability)
 		}
-		return msgMutate{ok: fmt.Sprintf("Repaired item %d — relog to see in-game", itemID)}
+		return repairItemSuccessMessage(itemID)
 	}
 }
 
 // Carried inventories: backpack, equipment, emote wheel, equipped weapons, action wheel, bank.
 var repairGearInventoryTypes = []int32{0, 1, 14, 15, 27, 30}
 
+type repairCandidate struct {
+	id     int64
+	target float64
+}
+
+func parseDurabilityText(value pgtype.Text) float64 {
+	if !value.Valid {
+		return 0
+	}
+	parsed, _ := strconv.ParseFloat(value.String, 64)
+	return parsed
+}
+
+func repairTargetForItem(templateID string, maxDurability pgtype.Text) float64 {
+	// Target priority: catalog (vehicle modules stored as items) → stats.MaxDurability → 100.
+	if value, ok := itemMaxDurability(templateID); ok && value > 0 {
+		return value
+	}
+	if maxDurability.Valid {
+		if value, err := strconv.ParseFloat(maxDurability.String, 64); err == nil && value > 0 {
+			return value
+		}
+	}
+	return 100.0
+}
+
+func buildRepairCandidate(
+	id int64,
+	templateID string,
+	maxDurability, currentDurability, decayedDurability pgtype.Text,
+) (repairCandidate, bool) {
+	target := repairTargetForItem(templateID, maxDurability)
+	current := parseDurabilityText(currentDurability)
+	decayed := parseDurabilityText(decayedDurability)
+	if math.Abs(current-target) < 0.01 && math.Abs(decayed-target) < 0.01 {
+		return repairCandidate{}, false
+	}
+	return repairCandidate{id: id, target: target}, true
+}
+
+func loadPlayerGearRepairCandidates(ctx context.Context, playerID int64) ([]repairCandidate, int, error) {
+	rows, err := globalDB.Query(ctx, `
+		SELECT i.id, i.template_id,
+		       (i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability'),
+		       (i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability'),
+		       (i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')
+		FROM dune.items i
+		JOIN dune.inventories inv ON inv.id = i.inventory_id
+		WHERE inv.actor_id = $1::bigint
+		  AND inv.inventory_type = ANY($2::int[])
+		  AND i.stats ? 'FItemStackAndDurabilityStats'`,
+		playerID, repairGearInventoryTypes)
+	if err != nil {
+		return nil, 0, fmt.Errorf("scan items: %w", err)
+	}
+	defer rows.Close()
+
+	toRepair := make([]repairCandidate, 0, 64)
+	scanned := 0
+	for rows.Next() {
+		scanned++
+
+		var id int64
+		var templateID string
+		var maxDurability, currentDurability, decayedDurability pgtype.Text
+		if err := rows.Scan(&id, &templateID, &maxDurability, &currentDurability, &decayedDurability); err != nil {
+			return nil, scanned, fmt.Errorf("scan item: %w", err)
+		}
+
+		candidate, needsRepair := buildRepairCandidate(id, templateID, maxDurability, currentDurability, decayedDurability)
+		if needsRepair {
+			toRepair = append(toRepair, candidate)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("scan rows: %w", err)
+	}
+
+	return toRepair, scanned, nil
+}
+
+func validateRepairPlayerGearInput(playerID int64) error {
+	if globalDB == nil {
+		return fmt.Errorf("not connected")
+	}
+	if playerID == 0 {
+		return fmt.Errorf("player ID required")
+	}
+	return nil
+}
+
+type gearRepairRunResult struct {
+	repaired int
+	err      error
+}
+
+func runPlayerGearRepairs(ctx context.Context, toRepair []repairCandidate) gearRepairRunResult {
+	tx, err := globalDB.Begin(ctx)
+	if err != nil {
+		return gearRepairRunResult{err: fmt.Errorf("begin tx: %w", err)}
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	repaired := 0
+	for _, rc := range toRepair {
+		_, err := tx.Exec(ctx, `
+			UPDATE dune.items
+			SET stats = jsonb_set(
+				jsonb_set(stats,
+					'{FItemStackAndDurabilityStats,1,CurrentDurability}',
+					to_jsonb($2::float8), true),
+				'{FItemStackAndDurabilityStats,1,DecayedMaxDurability}',
+				to_jsonb($2::float8), true)
+			WHERE id = $1::bigint`, rc.id, rc.target)
+		if err != nil {
+			return gearRepairRunResult{
+				repaired: repaired,
+				err:      fmt.Errorf("repair item %d: %w", rc.id, err),
+			}
+		}
+		repaired++
+	}
+	if err := tx.Commit(ctx); err != nil {
+		// Keep the legacy response shape for commit failures: no repaired count.
+		return gearRepairRunResult{err: fmt.Errorf("commit: %w", err)}
+	}
+	return gearRepairRunResult{repaired: repaired}
+}
+
 func cmdRepairPlayerGear(playerID int64) Cmd {
 	return func() Msg {
-		if globalDB == nil {
-			return msgRepairGear{err: fmt.Errorf("not connected")}
-		}
-		if playerID == 0 {
-			return msgRepairGear{err: fmt.Errorf("player ID required")}
+		if err := validateRepairPlayerGearInput(playerID); err != nil {
+			return msgRepairGear{err: err}
 		}
 		ctx := context.Background()
 		if err := checkPlayerOffline(ctx, playerID); err != nil {
 			return msgRepairGear{err: err}
 		}
 
-		rows, err := globalDB.Query(ctx, `
-			SELECT i.id, i.template_id,
-			       (i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability'),
-			       (i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability'),
-			       (i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')
-			FROM dune.items i
-			JOIN dune.inventories inv ON inv.id = i.inventory_id
-			WHERE inv.actor_id = $1::bigint
-			  AND inv.inventory_type = ANY($2::int[])
-			  AND i.stats ? 'FItemStackAndDurabilityStats'`,
-			playerID, repairGearInventoryTypes)
+		toRepair, scanned, err := loadPlayerGearRepairCandidates(ctx, playerID)
 		if err != nil {
-			return msgRepairGear{err: fmt.Errorf("scan items: %w", err)}
-		}
-		defer rows.Close()
-
-		type repairCandidate struct {
-			id     int64
-			target float64
-		}
-		var toRepair []repairCandidate
-		scanned := 0
-		for rows.Next() {
-			scanned++
-			var id int64
-			var templateID string
-			var maxStr, curStr, decayedStr pgtype.Text
-			if err := rows.Scan(&id, &templateID, &maxStr, &curStr, &decayedStr); err != nil {
-				return msgRepairGear{scanned: scanned, err: fmt.Errorf("scan item: %w", err)}
-			}
-
-			// Target priority: catalog (vehicle modules stored as items) → stats.MaxDurability → 100.
-			var target float64
-			if v, ok := itemMaxDurability(templateID); ok && v > 0 {
-				target = v
-			} else if maxStr.Valid {
-				if v, perr := strconv.ParseFloat(maxStr.String, 64); perr == nil && v > 0 {
-					target = v
-				} else {
-					target = 100.0
-				}
-			} else {
-				target = 100.0
-			}
-
-			cur := 0.0
-			if curStr.Valid {
-				cur, _ = strconv.ParseFloat(curStr.String, 64)
-			}
-			decayed := 0.0
-			if decayedStr.Valid {
-				decayed, _ = strconv.ParseFloat(decayedStr.String, 64)
-			}
-			if math.Abs(cur-target) < 0.01 && math.Abs(decayed-target) < 0.01 {
-				continue
-			}
-			toRepair = append(toRepair, repairCandidate{id: id, target: target})
-		}
-		if err := rows.Err(); err != nil {
-			return msgRepairGear{err: fmt.Errorf("scan rows: %w", err)}
+			return msgRepairGear{scanned: scanned, err: err}
 		}
 
-		tx, err := globalDB.Begin(ctx)
-		if err != nil {
-			return msgRepairGear{scanned: scanned, err: fmt.Errorf("begin tx: %w", err)}
+		run := runPlayerGearRepairs(ctx, toRepair)
+		if run.err != nil {
+			return msgRepairGear{repaired: run.repaired, scanned: scanned, err: run.err}
 		}
-		defer func() { _ = tx.Rollback(ctx) }()
-
-		repaired := 0
-		for _, rc := range toRepair {
-			_, err := tx.Exec(ctx, `
-				UPDATE dune.items
-				SET stats = jsonb_set(
-					jsonb_set(stats,
-						'{FItemStackAndDurabilityStats,1,CurrentDurability}',
-						to_jsonb($2::float8), true),
-					'{FItemStackAndDurabilityStats,1,DecayedMaxDurability}',
-					to_jsonb($2::float8), true)
-				WHERE id = $1::bigint`, rc.id, rc.target)
-			if err != nil {
-				return msgRepairGear{repaired: repaired, scanned: scanned, err: fmt.Errorf("repair item %d: %w", rc.id, err)}
-			}
-			repaired++
-		}
-		if err := tx.Commit(ctx); err != nil {
-			return msgRepairGear{scanned: scanned, err: fmt.Errorf("commit: %w", err)}
-		}
-		return msgRepairGear{repaired: repaired, scanned: scanned}
+		return msgRepairGear{repaired: run.repaired, scanned: scanned}
 	}
 }
 
-func cmdRepairVehicle(playerID, vehicleID int64) Cmd {
-	return func() Msg {
-		if globalDB == nil {
-			return msgRepairVehicle{err: fmt.Errorf("not connected")}
-		}
-		if playerID == 0 {
-			return msgRepairVehicle{err: fmt.Errorf("player ID required")}
-		}
-		ctx := context.Background()
-		if err := checkPlayerOffline(ctx, playerID); err != nil {
-			return msgRepairVehicle{err: err}
-		}
+func validateRepairVehicleInput(playerID int64) error {
+	if globalDB == nil {
+		return fmt.Errorf("not connected")
+	}
+	if playerID == 0 {
+		return fmt.Errorf("player ID required")
+	}
+	return nil
+}
 
-		rows, err := globalDB.Query(ctx, `
+type vehicleModule struct {
+	id         int64
+	templateID string
+}
+
+func loadVehicleModules(ctx context.Context, vehicleID int64) ([]vehicleModule, error) {
+	rows, err := globalDB.Query(ctx, `
 			SELECT id, template_id
 			FROM dune.vehicle_modules
 			WHERE vehicle_id = $1::bigint`, vehicleID)
-		if err != nil {
-			return msgRepairVehicle{err: fmt.Errorf("scan modules: %w", err)}
-		}
-		defer rows.Close()
+	if err != nil {
+		return nil, fmt.Errorf("scan modules: %w", err)
+	}
+	defer rows.Close()
 
-		type moduleRow struct {
-			id         int64
-			templateID string
+	var modules []vehicleModule
+	for rows.Next() {
+		var module vehicleModule
+		if err := rows.Scan(&module.id, &module.templateID); err != nil {
+			return nil, fmt.Errorf("scan module: %w", err)
 		}
-		var modules []moduleRow
-		for rows.Next() {
-			var m moduleRow
-			if err := rows.Scan(&m.id, &m.templateID); err != nil {
-				return msgRepairVehicle{err: fmt.Errorf("scan module: %w", err)}
-			}
-			modules = append(modules, m)
-		}
-		if err := rows.Err(); err != nil {
-			return msgRepairVehicle{err: err}
-		}
+		modules = append(modules, module)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return modules, nil
+}
 
-		total := len(modules)
-		repaired := 0
-		skipped := 0
-		for _, m := range modules {
-			target, ok := itemMaxDurability(m.templateID)
-			if !ok || target <= 0 {
-				skipped++
-				continue
-			}
-			// Both fields must be written — Current-only is clamped to surviving Decayed on reload.
-			_, err := globalDB.Exec(ctx, `
+type vehicleRepairSummary struct {
+	repaired int
+	skipped  int
+	total    int
+	err      error
+}
+
+func vehicleRepairTarget(templateID string) (float64, bool) {
+	target, ok := itemMaxDurability(templateID)
+	if !ok || target <= 0 {
+		return 0, false
+	}
+	return target, true
+}
+
+func runVehicleModuleRepairs(
+	modules []vehicleModule,
+	update func(module vehicleModule, target float64) error,
+) vehicleRepairSummary {
+	summary := vehicleRepairSummary{total: len(modules)}
+	for _, module := range modules {
+		target, ok := vehicleRepairTarget(module.templateID)
+		if !ok {
+			summary.skipped++
+			continue
+		}
+		if err := update(module, target); err != nil {
+			summary.err = fmt.Errorf("repair module %d: %w", module.id, err)
+			return summary
+		}
+		summary.repaired++
+	}
+	return summary
+}
+
+func updateVehicleModuleDurability(ctx context.Context, moduleID int64, target float64) error {
+	_, err := globalDB.Exec(ctx, `
 				UPDATE dune.vehicle_modules
 				SET stats = jsonb_set(
 					jsonb_set(stats,
@@ -3493,13 +4011,30 @@ func cmdRepairVehicle(playerID, vehicleID int64) Cmd {
 						to_jsonb($2::float8), true),
 					'{FVehicleModuleDurabilityStats,1,DecayedMaxDurability}',
 					to_jsonb($2::float8), true)
-				WHERE id = $1::bigint`, m.id, target)
-			if err != nil {
-				return msgRepairVehicle{repaired: repaired, skipped: skipped, total: total, err: fmt.Errorf("repair module %d: %w", m.id, err)}
-			}
-			repaired++
+				WHERE id = $1::bigint`, moduleID, target)
+	return err
+}
+
+func cmdRepairVehicle(playerID, vehicleID int64) Cmd {
+	return func() Msg {
+		if err := validateRepairVehicleInput(playerID); err != nil {
+			return msgRepairVehicle{err: err}
 		}
-		return msgRepairVehicle{repaired: repaired, skipped: skipped, total: total}
+		ctx := context.Background()
+		if err := checkPlayerOffline(ctx, playerID); err != nil {
+			return msgRepairVehicle{err: err}
+		}
+
+		modules, err := loadVehicleModules(ctx, vehicleID)
+		if err != nil {
+			return msgRepairVehicle{err: err}
+		}
+
+		summary := runVehicleModuleRepairs(modules, func(module vehicleModule, target float64) error {
+			// Both fields must be written — Current-only is clamped to surviving Decayed on reload.
+			return updateVehicleModuleDurability(ctx, module.id, target)
+		})
+		return msgRepairVehicle(summary)
 	}
 }
 

--- a/cmd/dune-admin/db_cmd_award_char_xp_test.go
+++ b/cmd/dune-admin/db_cmd_award_char_xp_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComputeAwardCharXPOutcome(t *testing.T) {
+	t.Parallel()
+
+	t.Run("caps xp and marks capped", func(t *testing.T) {
+		t.Parallel()
+		outcome := computeAwardCharXPOutcome(maxCharXP-10, 5, 3, 99)
+		if outcome.newXP != maxCharXP {
+			t.Fatalf("expected capped xp %d, got %d", maxCharXP, outcome.newXP)
+		}
+		if !outcome.capped {
+			t.Fatalf("expected capped=true")
+		}
+		if outcome.newTotalSP != outcome.newLevel+3 {
+			t.Fatalf("expected total SP to include keystone bonus, got level=%d total=%d", outcome.newLevel, outcome.newTotalSP)
+		}
+	})
+
+	t.Run("clamps unspent to zero", func(t *testing.T) {
+		t.Parallel()
+		outcome := computeAwardCharXPOutcome(0, 999, 0, 0)
+		if outcome.newUnspentSP != 0 {
+			t.Fatalf("expected unspent SP clamp to 0, got %d", outcome.newUnspentSP)
+		}
+		if outcome.capped {
+			t.Fatalf("expected capped=false")
+		}
+	})
+}
+
+func TestFormatAwardCharXPSuccess(t *testing.T) {
+	t.Parallel()
+
+	outcome := charXPOutcome{
+		newXP:        1234,
+		newLevel:     42,
+		newUnspentSP: 7,
+		newIntel:     99,
+		capped:       true,
+	}
+	msg := formatAwardCharXPSuccess(777, outcome, 11)
+	if !strings.Contains(msg, "Player 777") ||
+		!strings.Contains(msg, "level 42 (capped at level 200)") ||
+		!strings.Contains(msg, "XP 1234") ||
+		!strings.Contains(msg, "SP 7 unspent (11 spent)") ||
+		!strings.Contains(msg, "Intel 99") {
+		t.Fatalf("unexpected message: %q", msg)
+	}
+}
+
+func TestLoadControllerKeystoneIDs_NoController(t *testing.T) {
+	t.Parallel()
+
+	ids, err := loadControllerKeystoneIDs(t.Context(), 0)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if ids != nil {
+		t.Fatalf("expected nil ids, got %#v", ids)
+	}
+}

--- a/cmd/dune-admin/db_cmd_give_item_test.go
+++ b/cmd/dune-admin/db_cmd_give_item_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestValidateGiveItemInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		playerID  int64
+		template  string
+		qty       int64
+		wantTpl   string
+		wantError string
+	}{
+		{name: "valid", playerID: 123, template: "  Dune.Item  ", qty: 2, wantTpl: "Dune.Item"},
+		{name: "missing-player", playerID: 0, template: "x", qty: 1, wantError: "player ID required"},
+		{name: "missing-template", playerID: 1, template: "   ", qty: 1, wantError: "item template required"},
+		{name: "invalid-qty", playerID: 1, template: "x", qty: 0, wantError: "quantity must be > 0"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := validateGiveItemInput(tt.playerID, tt.template, tt.qty)
+			if tt.wantError != "" {
+				if err == nil || err.Error() != tt.wantError {
+					t.Fatalf("expected error %q, got %v", tt.wantError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantTpl {
+				t.Fatalf("expected template %q, got %q", tt.wantTpl, got)
+			}
+		})
+	}
+}
+
+func TestPlanGiveItemStacks(t *testing.T) {
+	t.Parallel()
+
+	stacks := []giveItemStackSlot{
+		{id: 1, size: 8},
+		{id: 2, size: 10},
+		{id: 3, size: 2},
+	}
+	updates, created := planGiveItemStacks(17, 10, stacks)
+
+	if len(updates) != 2 {
+		t.Fatalf("expected 2 updates, got %d", len(updates))
+	}
+	if updates[0].id != 1 || updates[0].add != 2 {
+		t.Fatalf("unexpected first update: %+v", updates[0])
+	}
+	if updates[1].id != 3 || updates[1].add != 8 {
+		t.Fatalf("unexpected second update: %+v", updates[1])
+	}
+	if len(created) != 1 || created[0] != 7 {
+		t.Fatalf("unexpected created stacks: %#v", created)
+	}
+}
+
+func TestPlanGiveItemStacks_NoStacking(t *testing.T) {
+	t.Parallel()
+
+	updates, created := planGiveItemStacks(3, 1, []giveItemStackSlot{{id: 1, size: 1}})
+	if len(updates) != 0 {
+		t.Fatalf("expected no updates, got %#v", updates)
+	}
+	if len(created) != 3 || created[0] != 1 || created[1] != 1 || created[2] != 1 {
+		t.Fatalf("unexpected created stacks: %#v", created)
+	}
+}
+
+func TestEnsureGiveItemSlotCapacity(t *testing.T) {
+	t.Parallel()
+
+	inv := giveItemInventory{maxSlots: 5, hasSlotCap: true}
+	state := giveItemInventoryState{usedSlots: 3}
+	if err := ensureGiveItemSlotCapacity(inv, state, 2); err != nil {
+		t.Fatalf("expected capacity to fit, got %v", err)
+	}
+	if err := ensureGiveItemSlotCapacity(inv, state, 3); err == nil {
+		t.Fatalf("expected slot-capacity error")
+	}
+}
+
+func TestInventoryItemVolume(t *testing.T) {
+	oldItemData := itemData
+	itemData = itemDataFile{
+		DefaultVolume: 2.5,
+		Items: map[string]itemRule{
+			"dune.item.known": {Volume: 1.25},
+			"dune.item.zero":  {Volume: 0},
+		},
+	}
+	t.Cleanup(func() { itemData = oldItemData })
+
+	override := pgtype.Float8{Float64: 3.0, Valid: true}
+	if got := inventoryItemVolume("any", override); got != 3.0 {
+		t.Fatalf("expected override volume 3.0, got %v", got)
+	}
+	if got := inventoryItemVolume("Dune.Item.Known", pgtype.Float8{}); got != 1.25 {
+		t.Fatalf("expected known-rule volume 1.25, got %v", got)
+	}
+	if got := inventoryItemVolume("Dune.Item.Zero", pgtype.Float8{}); got != 0 {
+		t.Fatalf("expected zero volume from rule, got %v", got)
+	}
+	if got := inventoryItemVolume("Dune.Item.Unknown", pgtype.Float8{}); got != 2.5 {
+		t.Fatalf("expected default volume 2.5, got %v", got)
+	}
+}
+
+func TestFormatGiveItemResult(t *testing.T) {
+	t.Parallel()
+
+	got := formatGiveItemResult(42, "Dune.Item", 3, 1, 2)
+	want := "Added 3 × Dune.Item to player 42 (1 stack(s) topped up, 2 new stack(s))"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestEnsureGiveItemVolumeCapacity(t *testing.T) {
+	oldItemData := itemData
+	itemData = itemDataFile{
+		Items: map[string]itemRule{
+			"dune.item": {Volume: 2},
+		},
+	}
+	t.Cleanup(func() { itemData = oldItemData })
+
+	inv := giveItemInventory{hasVolumeCap: true, maxVolume: 10}
+	state := giveItemInventoryState{usedVolume: 4}
+
+	if err := ensureGiveItemVolumeCapacity(t.Context(), inv, state, "Dune.Item", 3); err != nil {
+		t.Fatalf("expected capacity to fit, got %v", err)
+	}
+	err := ensureGiveItemVolumeCapacity(t.Context(), inv, state, "Dune.Item", 4)
+	if err == nil {
+		t.Fatalf("expected volume-capacity error")
+	}
+}
+
+func TestMaxItemsByVolume(t *testing.T) {
+	t.Parallel()
+
+	if got := maxItemsByVolume(100, 40, 15); got != 4 {
+		t.Fatalf("expected 4 items by volume, got %d", got)
+	}
+	if got := maxItemsByVolume(100, 140, 10); got != 0 {
+		t.Fatalf("expected clamped 0 items by volume, got %d", got)
+	}
+}
+
+func TestRequiredStackCount(t *testing.T) {
+	t.Parallel()
+
+	if got := requiredStackCount(10, 3); got != 4 {
+		t.Fatalf("expected 4 required stacks, got %d", got)
+	}
+	if got := requiredStackCount(1, 1); got != 1 {
+		t.Fatalf("expected 1 required stack, got %d", got)
+	}
+}

--- a/cmd/dune-admin/db_cmd_grant_all_keystones_test.go
+++ b/cmd/dune-admin/db_cmd_grant_all_keystones_test.go
@@ -1,0 +1,41 @@
+package main
+
+import "testing"
+
+func TestAllKeystoneIDs(t *testing.T) {
+	t.Parallel()
+
+	ids := allKeystoneIDs()
+	if len(ids) != 205 {
+		t.Fatalf("expected 205 keystone ids, got %d", len(ids))
+	}
+	if ids[0] != 1 || ids[len(ids)-1] != 205 {
+		t.Fatalf("unexpected ID bounds: first=%d last=%d", ids[0], ids[len(ids)-1])
+	}
+	for i, id := range ids {
+		if int(id) != i+1 {
+			t.Fatalf("unexpected id sequence at index %d: got %d", i, id)
+		}
+	}
+}
+
+func TestGrantAllKeystoneTargets(t *testing.T) {
+	t.Parallel()
+
+	bonus := keystoneSPBonus(allKeystoneIDs())
+	expectedTotal, expectedUnspent, gotBonus := grantAllKeystoneTargets(0, 0)
+	if gotBonus != bonus {
+		t.Fatalf("expected bonus %d, got %d", bonus, gotBonus)
+	}
+	if expectedTotal != bonus {
+		t.Fatalf("expected total skill points %d at xp=0, got %d", bonus, expectedTotal)
+	}
+	if expectedUnspent != expectedTotal-1 {
+		t.Fatalf("expected unspent=%d, got %d", expectedTotal-1, expectedUnspent)
+	}
+
+	_, expectedUnspent, _ = grantAllKeystoneTargets(0, 99999)
+	if expectedUnspent != 0 {
+		t.Fatalf("expected negative unspent to clamp to 0, got %d", expectedUnspent)
+	}
+}

--- a/cmd/dune-admin/db_cmd_progression_unlock_test.go
+++ b/cmd/dune-admin/db_cmd_progression_unlock_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProgressionFactionConfigFor(t *testing.T) {
+	t.Parallel()
+
+	atreides, err := progressionFactionConfigFor("atreides")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if atreides.factionID != 1 || atreides.alignedFlag != "DialogueFlags.Factions.AlignedAtreides" {
+		t.Fatalf("unexpected atreides config: %+v", atreides)
+	}
+
+	if _, err := progressionFactionConfigFor("unknown"); err == nil {
+		t.Fatalf("expected error for unknown faction")
+	}
+}
+
+func TestProgressionTargetTierForPreset(t *testing.T) {
+	t.Parallel()
+
+	if tier, err := progressionTargetTierForPreset("ch3_start"); err != nil || tier != 5 {
+		t.Fatalf("expected ch3_start => 5, got tier=%d err=%v", tier, err)
+	}
+	if tier, err := progressionTargetTierForPreset("rank19_eligible"); err != nil || tier != 19 {
+		t.Fatalf("expected rank19_eligible => 19, got tier=%d err=%v", tier, err)
+	}
+	if _, err := progressionTargetTierForPreset("bad"); err == nil {
+		t.Fatalf("expected error for bad preset")
+	}
+}
+
+func TestProgressionUnlockTags(t *testing.T) {
+	t.Parallel()
+
+	cfg, _ := progressionFactionConfigFor("atreides")
+	tags := progressionUnlockTags(cfg, 19)
+
+	required := []string{
+		"DialogueFlags.Factions.SentToMeetHawat",
+		"DialogueFlags.Factions.AlignedAtreides",
+		"Journey.LandsraadContractsUnlocked",
+		"Faction.Atreides.Tier0",
+		"Faction.Atreides.Tier5",
+	}
+	for _, tag := range required {
+		if !containsString(tags, tag) {
+			t.Fatalf("expected tag %q in output: %#v", tag, tags)
+		}
+	}
+	if containsString(tags, "Faction.Atreides.Tier6") {
+		t.Fatalf("did not expect Tier6 tag in output")
+	}
+}
+
+func TestFormatProgressionUnlockSuccess(t *testing.T) {
+	t.Parallel()
+
+	msg := formatProgressionUnlockSuccess("ch3_start", "atreides", 12, "Atreides", 5, 777)
+	expectParts := []string{
+		"Progression unlock (ch3_start/atreides)",
+		"12 journey nodes completed",
+		"Atreides tier tags 0–5",
+		"rep tier 5 on controller 777",
+	}
+	for _, part := range expectParts {
+		if !strings.Contains(msg, part) {
+			t.Fatalf("expected message to contain %q, got %q", part, msg)
+		}
+	}
+}
+
+func TestProgressionReverseTags(t *testing.T) {
+	t.Parallel()
+
+	base := []string{"A", "B"}
+	got := progressionReverseTags(base, []string{"unknown.node"})
+	if len(got) != 2 || got[0] != "A" || got[1] != "B" {
+		t.Fatalf("expected base tags unchanged for unknown node, got %#v", got)
+	}
+}
+
+func TestFormatProgressionReverseSuccess(t *testing.T) {
+	t.Parallel()
+
+	msg := formatProgressionReverseSuccess("rank19_eligible", "harkonnen", 7, 19)
+	expectParts := []string{
+		"Reversed progression unlock (rank19_eligible/harkonnen)",
+		"reset 7 node(s)",
+		"removed 19 tag(s)",
+	}
+	for _, part := range expectParts {
+		if !strings.Contains(msg, part) {
+			t.Fatalf("expected message to contain %q, got %q", part, msg)
+		}
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/dune-admin/db_cmd_repair_item_test.go
+++ b/cmd/dune-admin/db_cmd_repair_item_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestRepairItemNoChangeMessage(t *testing.T) {
+	t.Parallel()
+
+	msg := repairItemNoChangeMessage(42, false)
+	if msg.err == nil || msg.err.Error() != "item 42 has no durability field" {
+		t.Fatalf("expected no-durability error, got %+v", msg)
+	}
+
+	msg = repairItemNoChangeMessage(42, true)
+	if msg.err != nil {
+		t.Fatalf("expected success message, got error %v", msg.err)
+	}
+	if msg.ok != "Item 42 already at full durability" {
+		t.Fatalf("unexpected success message: %q", msg.ok)
+	}
+}
+
+func TestRepairItemSuccessMessage(t *testing.T) {
+	t.Parallel()
+
+	msg := repairItemSuccessMessage(99)
+	if msg.err != nil {
+		t.Fatalf("expected nil error, got %v", msg.err)
+	}
+	if msg.ok != "Repaired item 99 — relog to see in-game" {
+		t.Fatalf("unexpected success message: %q", msg.ok)
+	}
+}

--- a/cmd/dune-admin/db_cmd_repair_player_gear_test.go
+++ b/cmd/dune-admin/db_cmd_repair_player_gear_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func floatPtr(v float64) *float64 {
+	return &v
+}
+
+func TestParseDurabilityText(t *testing.T) {
+	t.Parallel()
+
+	if got := parseDurabilityText(pgtype.Text{}); got != 0 {
+		t.Fatalf("expected invalid text to parse as 0, got %v", got)
+	}
+	if got := parseDurabilityText(pgtype.Text{String: "12.5", Valid: true}); got != 12.5 {
+		t.Fatalf("expected 12.5, got %v", got)
+	}
+	if got := parseDurabilityText(pgtype.Text{String: "not-a-number", Valid: true}); got != 0 {
+		t.Fatalf("expected parse failure to fall back to 0, got %v", got)
+	}
+}
+
+func TestRepairTargetForItem(t *testing.T) {
+	originalItemData := itemData
+	itemData = itemDataFile{
+		Items: map[string]itemRule{
+			"dune.item.catalog": {MaxDurability: floatPtr(250)},
+		},
+	}
+	t.Cleanup(func() { itemData = originalItemData })
+
+	tests := []struct {
+		name       string
+		templateID string
+		maxText    pgtype.Text
+		want       float64
+	}{
+		{
+			name:       "catalog value wins",
+			templateID: "Dune.Item.Catalog",
+			maxText:    pgtype.Text{String: "125", Valid: true},
+			want:       250,
+		},
+		{
+			name:       "falls back to max durability text",
+			templateID: "Dune.Item.Unknown",
+			maxText:    pgtype.Text{String: "125", Valid: true},
+			want:       125,
+		},
+		{
+			name:       "invalid max durability text",
+			templateID: "Dune.Item.Unknown",
+			maxText:    pgtype.Text{String: "oops", Valid: true},
+			want:       100,
+		},
+		{
+			name:       "missing max durability text",
+			templateID: "Dune.Item.Unknown",
+			maxText:    pgtype.Text{},
+			want:       100,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := repairTargetForItem(tt.templateID, tt.maxText); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestBuildRepairCandidate(t *testing.T) {
+	originalItemData := itemData
+	itemData = itemDataFile{
+		Items: map[string]itemRule{
+			"dune.item.catalog": {MaxDurability: floatPtr(250)},
+		},
+	}
+	t.Cleanup(func() { itemData = originalItemData })
+
+	tests := []struct {
+		name          string
+		itemID        int64
+		templateID    string
+		maxDurability pgtype.Text
+		current       pgtype.Text
+		decayed       pgtype.Text
+		wantNeedsFix  bool
+		wantTarget    float64
+	}{
+		{
+			name:          "already at target",
+			itemID:        1,
+			templateID:    "Dune.Item.Unknown",
+			maxDurability: pgtype.Text{String: "100", Valid: true},
+			current:       pgtype.Text{String: "100", Valid: true},
+			decayed:       pgtype.Text{String: "100", Valid: true},
+			wantNeedsFix:  false,
+		},
+		{
+			name:          "needs repair by current durability",
+			itemID:        2,
+			templateID:    "Dune.Item.Unknown",
+			maxDurability: pgtype.Text{String: "100", Valid: true},
+			current:       pgtype.Text{String: "75", Valid: true},
+			decayed:       pgtype.Text{String: "100", Valid: true},
+			wantNeedsFix:  true,
+			wantTarget:    100,
+		},
+		{
+			name:          "catalog durability target",
+			itemID:        3,
+			templateID:    "Dune.Item.Catalog",
+			maxDurability: pgtype.Text{String: "100", Valid: true},
+			current:       pgtype.Text{String: "150", Valid: true},
+			decayed:       pgtype.Text{String: "150", Valid: true},
+			wantNeedsFix:  true,
+			wantTarget:    250,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			candidate, needsFix := buildRepairCandidate(tt.itemID, tt.templateID, tt.maxDurability, tt.current, tt.decayed)
+			if needsFix != tt.wantNeedsFix {
+				t.Fatalf("expected needsFix=%v, got %v", tt.wantNeedsFix, needsFix)
+			}
+			if !needsFix {
+				return
+			}
+			if candidate.id != tt.itemID {
+				t.Fatalf("expected item ID %d, got %d", tt.itemID, candidate.id)
+			}
+			if math.Abs(candidate.target-tt.wantTarget) > 0.0001 {
+				t.Fatalf("expected target %.4f, got %.4f", tt.wantTarget, candidate.target)
+			}
+		})
+	}
+}
+
+func TestValidateRepairPlayerGearInput(t *testing.T) {
+	originalDB := globalDB
+	t.Cleanup(func() { globalDB = originalDB })
+
+	globalDB = nil
+	if err := validateRepairPlayerGearInput(42); err == nil || err.Error() != "not connected" {
+		t.Fatalf("expected not connected error, got %v", err)
+	}
+
+	globalDB = &pgxpool.Pool{}
+	if err := validateRepairPlayerGearInput(0); err == nil || err.Error() != "player ID required" {
+		t.Fatalf("expected player ID required error, got %v", err)
+	}
+	if err := validateRepairPlayerGearInput(42); err != nil {
+		t.Fatalf("expected valid input, got %v", err)
+	}
+}

--- a/cmd/dune-admin/db_cmd_repair_vehicle_test.go
+++ b/cmd/dune-admin/db_cmd_repair_vehicle_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestValidateRepairVehicleInput(t *testing.T) {
+	originalDB := globalDB
+	t.Cleanup(func() { globalDB = originalDB })
+
+	globalDB = nil
+	if err := validateRepairVehicleInput(42); err == nil || err.Error() != "not connected" {
+		t.Fatalf("expected not connected error, got %v", err)
+	}
+
+	globalDB = &pgxpool.Pool{}
+	if err := validateRepairVehicleInput(0); err == nil || err.Error() != "player ID required" {
+		t.Fatalf("expected player ID required error, got %v", err)
+	}
+	if err := validateRepairVehicleInput(42); err != nil {
+		t.Fatalf("expected valid input, got %v", err)
+	}
+}
+
+func TestVehicleRepairTarget(t *testing.T) {
+	originalItemData := itemData
+	itemData = itemDataFile{
+		Items: map[string]itemRule{
+			"dune.vehicle.catalog": {MaxDurability: floatPtr(300)},
+		},
+	}
+	t.Cleanup(func() { itemData = originalItemData })
+
+	target, ok := vehicleRepairTarget("Dune.Vehicle.Catalog")
+	if !ok || target != 300 {
+		t.Fatalf("expected catalog target=300, ok=true, got target=%v ok=%v", target, ok)
+	}
+
+	if target, ok = vehicleRepairTarget("Dune.Vehicle.Unknown"); ok || target != 0 {
+		t.Fatalf("expected unknown template to be skipped, got target=%v ok=%v", target, ok)
+	}
+}
+
+func TestRunVehicleModuleRepairs(t *testing.T) {
+	originalItemData := itemData
+	itemData = itemDataFile{
+		Items: map[string]itemRule{
+			"dune.vehicle.repairable": {MaxDurability: floatPtr(125)},
+		},
+	}
+	t.Cleanup(func() { itemData = originalItemData })
+
+	modules := []vehicleModule{
+		{id: 1, templateID: "Dune.Vehicle.Repairable"},
+		{id: 2, templateID: "Dune.Vehicle.Missing"},
+		{id: 3, templateID: "Dune.Vehicle.Repairable"},
+	}
+
+	var repairedIDs []int64
+	summary := runVehicleModuleRepairs(modules, func(module vehicleModule, target float64) error {
+		if target != 125 {
+			t.Fatalf("expected target 125, got %v", target)
+		}
+		repairedIDs = append(repairedIDs, module.id)
+		return nil
+	})
+	if summary.err != nil {
+		t.Fatalf("unexpected error: %v", summary.err)
+	}
+	if summary.total != 3 || summary.repaired != 2 || summary.skipped != 1 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if len(repairedIDs) != 2 || repairedIDs[0] != 1 || repairedIDs[1] != 3 {
+		t.Fatalf("unexpected repaired IDs: %v", repairedIDs)
+	}
+}
+
+func TestRunVehicleModuleRepairs_StopsOnError(t *testing.T) {
+	originalItemData := itemData
+	itemData = itemDataFile{
+		Items: map[string]itemRule{
+			"dune.vehicle.repairable": {MaxDurability: floatPtr(125)},
+		},
+	}
+	t.Cleanup(func() { itemData = originalItemData })
+
+	modules := []vehicleModule{
+		{id: 10, templateID: "Dune.Vehicle.Repairable"},
+		{id: 11, templateID: "Dune.Vehicle.Repairable"},
+		{id: 12, templateID: "Dune.Vehicle.Missing"},
+	}
+
+	failErr := errors.New("boom")
+	summary := runVehicleModuleRepairs(modules, func(module vehicleModule, _ float64) error {
+		if module.id == 11 {
+			return failErr
+		}
+		return nil
+	})
+	if summary.err == nil {
+		t.Fatalf("expected repair error")
+	}
+	if summary.err.Error() != "repair module 11: boom" {
+		t.Fatalf("unexpected error: %v", summary.err)
+	}
+	if summary.total != 3 || summary.repaired != 1 || summary.skipped != 0 {
+		t.Fatalf("unexpected summary after failure: %+v", summary)
+	}
+}

--- a/cmd/dune-admin/db_cmd_reverse_contracts_test.go
+++ b/cmd/dune-admin/db_cmd_reverse_contracts_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestValidateContractMutationInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		accountID int64
+		contracts []string
+		wantError string
+	}{
+		{name: "valid", accountID: 10, contracts: []string{"DA_CT_A"}},
+		{name: "missing-account", accountID: 0, contracts: []string{"DA_CT_A"}, wantError: "account ID required"},
+		{name: "missing-contracts", accountID: 10, contracts: nil, wantError: "at least one contract required"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateContractMutationInput(tt.accountID, tt.contracts)
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantError {
+				t.Fatalf("expected error %q, got %v", tt.wantError, err)
+			}
+		})
+	}
+}
+
+func TestBuildContractRemovalSet(t *testing.T) {
+	originalTagsData := tagsData
+	tagsData = tagsDataFile{
+		ContractAliases: map[string]string{
+			"shortA": "DA_CT_A",
+		},
+		ContractTags: map[string][]string{
+			"DA_CT_A": {"Tag.A", "Tag.B"},
+			"DA_CT_B": {"Tag.B", "Tag.C"},
+		},
+		ContractSkillGrants: map[string][]string{
+			"DA_CT_A": {"Skills.Key.A", "Skills.Key.B"},
+			"DA_CT_B": {"Skills.Key.B", "Skills.Key.C"},
+		},
+	}
+	t.Cleanup(func() { tagsData = originalTagsData })
+
+	set, err := buildContractRemovalSet([]string{"shortA", "DA_CT_B", "shortA"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantResolved := []string{"DA_CT_A", "DA_CT_B", "DA_CT_A"}
+	if !reflect.DeepEqual(set.resolvedNames, wantResolved) {
+		t.Fatalf("unexpected resolved names: %#v", set.resolvedNames)
+	}
+
+	wantTags := []string{"Tag.A", "Tag.B", "Tag.C"}
+	if !reflect.DeepEqual(set.removeTags, wantTags) {
+		t.Fatalf("unexpected remove tags: %#v", set.removeTags)
+	}
+
+	wantSkills := []string{"Skills.Key.A", "Skills.Key.B", "Skills.Key.C"}
+	if !reflect.DeepEqual(set.removeSkills, wantSkills) {
+		t.Fatalf("unexpected remove skills: %#v", set.removeSkills)
+	}
+}
+
+func TestBuildContractRemovalSet_UnknownContract(t *testing.T) {
+	originalTagsData := tagsData
+	tagsData = tagsDataFile{
+		ContractAliases: map[string]string{},
+		ContractTags:    map[string][]string{},
+	}
+	t.Cleanup(func() { tagsData = originalTagsData })
+
+	_, err := buildContractRemovalSet([]string{"missing"})
+	if err == nil {
+		t.Fatal("expected unknown contract error")
+	}
+}
+
+func TestContractBatchSummary(t *testing.T) {
+	t.Parallel()
+
+	if got := contractBatchSummary([]string{"DA_CT_SINGLE"}); got != "DA_CT_SINGLE" {
+		t.Fatalf("unexpected single summary: %q", got)
+	}
+	if got := contractBatchSummary([]string{"A", "B"}); got != "2 contracts" {
+		t.Fatalf("unexpected multi summary: %q", got)
+	}
+}
+
+func TestRemoveContractTags_NoTagsIsNoop(t *testing.T) {
+	t.Parallel()
+
+	if err := removeContractTags(context.Background(), 123, nil); err != nil {
+		t.Fatalf("expected no-op nil tags, got %v", err)
+	}
+}
+
+func TestStripContractSkillBlocks_NoopCases(t *testing.T) {
+	t.Parallel()
+
+	if stripped, err := stripContractSkillBlocks(context.Background(), 0, []string{"Skills.Key.A"}); err != nil || stripped != 0 {
+		t.Fatalf("expected pawn 0 no-op, stripped=%d err=%v", stripped, err)
+	}
+	if stripped, err := stripContractSkillBlocks(context.Background(), 10, nil); err != nil || stripped != 0 {
+		t.Fatalf("expected empty skills no-op, stripped=%d err=%v", stripped, err)
+	}
+}
+
+func TestApplyContractSkillGrants_NoSkillsIsNoop(t *testing.T) {
+	t.Parallel()
+
+	extra, err := applyContractSkillGrants(context.Background(), 123, nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if extra != "" {
+		t.Fatalf("expected empty extra string, got %q", extra)
+	}
+}
+
+func TestContractShortNames(t *testing.T) {
+	t.Parallel()
+
+	got := contractShortNames([]string{"DA_CT_Trainer", "NoPrefix"})
+	want := []string{"Trainer", "NoPrefix"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected short names: %#v", got)
+	}
+}

--- a/cmd/dune-admin/db_cmd_run_sql_test.go
+++ b/cmd/dune-admin/db_cmd_run_sql_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatSQLRow(t *testing.T) {
+	t.Parallel()
+
+	row := formatSQLRow([]any{int64(7), "name", nil})
+	if row != "7 │ name │ <nil>" {
+		t.Fatalf("unexpected row format: %q", row)
+	}
+}
+
+func TestBuildSQLResult(t *testing.T) {
+	t.Parallel()
+
+	result := buildSQLResult(
+		[]string{"id", "name"},
+		[][]any{
+			{int64(1), "alpha"},
+			{int64(2), "beta"},
+		},
+		false,
+	)
+	if !strings.Contains(result, "id │ name\n") {
+		t.Fatalf("expected header line in result: %q", result)
+	}
+	if !strings.Contains(result, "1 │ alpha\n") || !strings.Contains(result, "2 │ beta\n") {
+		t.Fatalf("expected row lines in result: %q", result)
+	}
+	if strings.Contains(result, "limited to 200 rows") {
+		t.Fatalf("did not expect truncation marker in non-truncated result")
+	}
+
+	truncated := buildSQLResult([]string{"id"}, [][]any{{1}}, true)
+	if !strings.Contains(truncated, "… (limited to 200 rows)\n") {
+		t.Fatalf("expected truncation marker in truncated result: %q", truncated)
+	}
+}

--- a/cmd/dune-admin/db_cmd_sample_table_test.go
+++ b/cmd/dune-admin/db_cmd_sample_table_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestSampleTableQuery(t *testing.T) {
+	t.Parallel()
+
+	origSchema := dbSchema
+	t.Cleanup(func() { dbSchema = origSchema })
+	dbSchema = "dune"
+
+	query := sampleTableQuery(`items"; DROP TABLE dune.items; --`, 25)
+	want := `SELECT * FROM "dune"."items""; DROP TABLE dune.items; --" LIMIT 25`
+	if query != want {
+		t.Fatalf("unexpected query sanitization\nwant: %q\ngot:  %q", want, query)
+	}
+}
+
+func TestFormatSampleRow(t *testing.T) {
+	t.Parallel()
+
+	row := formatSampleRow([]any{int64(1), "alpha", nil, true})
+	want := []string{"1", "alpha", "<nil>", "true"}
+	if len(row) != len(want) {
+		t.Fatalf("unexpected row length: got %d want %d", len(row), len(want))
+	}
+	for i := range want {
+		if row[i] != want[i] {
+			t.Fatalf("unexpected row[%d]: got %q want %q", i, row[i], want[i])
+		}
+	}
+}

--- a/cmd/dune-admin/db_cmd_set_starter_class_test.go
+++ b/cmd/dune-admin/db_cmd_set_starter_class_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveStarterClassAbility(t *testing.T) {
+	originalTagsData := tagsData
+	t.Cleanup(func() { tagsData = originalTagsData })
+
+	tagsData = tagsDataFile{
+		JobSkillBlocks: map[string][]string{
+			"Trooper": {"Skills.Key.Trooper1"},
+		},
+	}
+
+	ability, err := resolveStarterClassAbility("Trooper")
+	if err != nil {
+		t.Fatalf("unexpected error resolving known job: %v", err)
+	}
+	if ability != "Skills.Ability.SuspensorGrenade_Reduction" {
+		t.Fatalf("unexpected starter ability: %q", ability)
+	}
+
+	if _, err := resolveStarterClassAbility("Unknown"); err == nil {
+		t.Fatalf("expected error for unknown job")
+	}
+}
+
+func TestStarterKeysToRemove(t *testing.T) {
+	t.Parallel()
+
+	if keys := starterKeysToRemove("", "Trooper"); len(keys) != 0 {
+		t.Fatalf("expected no keys when old starter is empty, got %#v", keys)
+	}
+	if keys := starterKeysToRemove("Skills.Key.Trooper1", "Trooper"); len(keys) != 0 {
+		t.Fatalf("expected no keys when switching to same job, got %#v", keys)
+	}
+
+	keys := starterKeysToRemove("Skills.Key.Mentat1", "Trooper")
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys to remove, got %#v", keys)
+	}
+	if keys[0] != `(TagName="Skills.Key.Mentat1")` {
+		t.Fatalf("unexpected starter key removal: %q", keys[0])
+	}
+	if keys[1] != `(TagName="Skills.Ability.PoisonCapsuleLauncher")` {
+		t.Fatalf("unexpected ability key removal: %q", keys[1])
+	}
+}
+
+func TestStarterClassTagAndKeys(t *testing.T) {
+	t.Parallel()
+
+	tag, starterKey, abilityKey := starterClassTagAndKeys("Trooper", "Skills.Ability.SuspensorGrenade_Reduction")
+	if tag != "Skills.Key.Trooper1" {
+		t.Fatalf("unexpected starter tag: %q", tag)
+	}
+	if starterKey != `(TagName="Skills.Key.Trooper1")` {
+		t.Fatalf("unexpected starter key: %q", starterKey)
+	}
+	if abilityKey != `(TagName="Skills.Ability.SuspensorGrenade_Reduction")` {
+		t.Fatalf("unexpected ability key: %q", abilityKey)
+	}
+}
+
+func TestFormatStarterClassMessage(t *testing.T) {
+	t.Parallel()
+
+	msg := formatStarterClassMessage("Trooper", "Skills.Key.Trooper1", "Skills.Ability.SuspensorGrenade_Reduction", 2)
+	if !strings.Contains(msg, "Starter class set to Trooper") ||
+		!strings.Contains(msg, "Skills.Key.Trooper1 + Skills.Ability.SuspensorGrenade_Reduction active") ||
+		!strings.Contains(msg, "cleared previous starter (2 module(s))") {
+		t.Fatalf("unexpected message: %q", msg)
+	}
+}

--- a/cmd/dune-admin/handlers_bases.go
+++ b/cmd/dune-admin/handlers_bases.go
@@ -79,77 +79,56 @@ func handleListBases(w http.ResponseWriter, _ *http.Request) {
 	jsonOK(w, rows)
 }
 
-func handleExportBase(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
-	if err != nil {
-		jsonErr(w, fmt.Errorf("invalid id"), 400)
-		return
-	}
-	if globalDB == nil {
-		jsonErr(w, fmt.Errorf("not connected"), 500)
-		return
-	}
-	ctx := context.Background()
+type rawBaseInstance struct {
+	buildingType  string
+	transform     []float32
+	ownerEntityID int64
+}
 
-	iRows, err := globalDB.Query(ctx, `
+type rawBasePlaceable struct {
+	buildingType string
+	location     string
+	rotation     string
+	properties   map[string]any
+}
+
+func parseBasePathID(id string) (int64, error) {
+	parsedID, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid id")
+	}
+	return parsedID, nil
+}
+
+func queryBaseExportInstances(ctx context.Context, id int64) ([]rawBaseInstance, error) {
+	rows, err := globalDB.Query(ctx, `
 		SELECT building_type, transform, owner_entity_id
 		FROM dune.building_instances
 		WHERE building_id = $1`, id)
 	if err != nil {
-		jsonErr(w, fmt.Errorf("query instances: %w", err), 500)
-		return
+		return nil, fmt.Errorf("query instances: %w", err)
 	}
-	defer iRows.Close()
+	defer rows.Close()
 
-	type rawInstance struct {
-		btype         string
-		t             []float32
-		ownerEntityID int64
-	}
-	var raws []rawInstance
-	for iRows.Next() {
-		var ri rawInstance
-		if err := iRows.Scan(&ri.btype, &ri.t, &ri.ownerEntityID); err != nil {
+	raws := make([]rawBaseInstance, 0, 32)
+	for rows.Next() {
+		var ri rawBaseInstance
+		if err := rows.Scan(&ri.buildingType, &ri.transform, &ri.ownerEntityID); err != nil {
 			continue
 		}
-		if len(ri.t) < 7 {
+		if len(ri.transform) < 7 {
 			continue
 		}
 		raws = append(raws, ri)
 	}
-	if err := iRows.Err(); err != nil {
-		jsonErr(w, fmt.Errorf("read instances: %w", err), 500)
-		return
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read instances: %w", err)
 	}
-	if len(raws) == 0 {
-		jsonErr(w, fmt.Errorf("building %d not found or empty", id), 404)
-		return
-	}
+	return raws, nil
+}
 
-	ownerEntityID := raws[0].ownerEntityID
-
-	var sumX, sumY, sumZ float64
-	for _, ri := range raws {
-		sumX += float64(ri.t[0])
-		sumY += float64(ri.t[1])
-		sumZ += float64(ri.t[2])
-	}
-	n := float64(len(raws))
-	cx, cy, cz := sumX/n, sumY/n, sumZ/n
-
-	instances := make([]blueprintInstance, 0, len(raws))
-	for _, ri := range raws {
-		qx, qy, qz, qw := float64(ri.t[3]), float64(ri.t[4]), float64(ri.t[5]), float64(ri.t[6])
-		instances = append(instances, blueprintInstance{
-			BuildingType: ri.btype,
-			X:            float64(ri.t[0]) - cx,
-			Y:            float64(ri.t[1]) - cy,
-			Z:            float64(ri.t[2]) - cz,
-			Rotation:     quatToYaw(qx, qy, qz, qw),
-		})
-	}
-
-	pRows, err := globalDB.Query(ctx, `
+func queryBaseExportPlaceables(ctx context.Context, ownerEntityID int64) ([]rawBasePlaceable, error) {
+	rows, err := globalDB.Query(ctx, `
 		SELECT p.building_type,
 		       (a.transform).location::text,
 		       (a.transform).rotation::text,
@@ -158,83 +137,126 @@ func handleExportBase(w http.ResponseWriter, r *http.Request) {
 		JOIN dune.actors a ON a.id = p.id
 		WHERE p.owner_entity_id = $1`, ownerEntityID)
 	if err != nil {
-		jsonErr(w, fmt.Errorf("query placeables: %w", err), 500)
-		return
+		return nil, fmt.Errorf("query placeables: %w", err)
 	}
-	defer pRows.Close()
+	defer rows.Close()
 
-	var placeables []blueprintPlaceable
-	var pentashields []blueprintPentashield
-
-	for pRows.Next() {
-		var btype, locStr, rotStr string
-		var props map[string]any
-		if err := pRows.Scan(&btype, &locStr, &rotStr, &props); err != nil {
+	raws := make([]rawBasePlaceable, 0, 32)
+	for rows.Next() {
+		var rp rawBasePlaceable
+		if err := rows.Scan(&rp.buildingType, &rp.location, &rp.rotation, &rp.properties); err != nil {
 			continue
 		}
-		// Totem is base-specific (land claim anchor) — never export it.
-		if btype == "Totem_Placeable" {
-			continue
-		}
-		lx, ly, lz, locErr := parseVec3(locStr)
-		qx, qy, qz, qw, rotErr := parseVec4(rotStr)
-		if locErr != nil || rotErr != nil {
-			continue
-		}
-		rx, ry, rz := quatToEuler(qx, qy, qz, qw)
+		raws = append(raws, rp)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read placeables: %w", err)
+	}
+	return raws, nil
+}
 
-		if strings.Contains(btype, "PentashieldSurface") {
-			// Only include pentashield placeables if scale data is present;
-			// a zero scale means the server has no data and would crash on import.
-			scale := [3]int{0, 0, 0}
-			found := false
-			if props != nil {
-				if inner, ok := props[strings.TrimSuffix(btype, "_Placeable")+"_C"].(map[string]any); ok {
-					if sv, ok := inner["m_Scale"].([]any); ok && len(sv) >= 3 {
-						for i := range 3 {
-							if f, ok := sv[i].(float64); ok {
-								scale[i] = int(f)
-							}
-						}
-						found = true
-					}
-				}
-			}
-			if !found {
-				continue
-			}
-			idx := len(placeables)
-			placeables = append(placeables, blueprintPlaceable{
-				BuildingType: btype,
-				X:            lx - cx,
-				Y:            ly - cy,
-				Z:            lz - cz,
-				RX:           rx,
-				RY:           ry,
-				RZ:           rz,
-			})
-			pentashields = append(pentashields, blueprintPentashield{
-				PlaceableID: idx,
-				Scale:       scale,
-			})
-			continue
-		}
+func calculateBaseCentroid(raws []rawBaseInstance) (float64, float64, float64) {
+	var sumX, sumY, sumZ float64
+	for _, ri := range raws {
+		sumX += float64(ri.transform[0])
+		sumY += float64(ri.transform[1])
+		sumZ += float64(ri.transform[2])
+	}
+	n := float64(len(raws))
+	return sumX / n, sumY / n, sumZ / n
+}
 
-		placeables = append(placeables, blueprintPlaceable{
-			BuildingType: btype,
-			X:            lx - cx,
-			Y:            ly - cy,
-			Z:            lz - cz,
-			RX:           rx,
-			RY:           ry,
-			RZ:           rz,
+func buildBlueprintInstances(raws []rawBaseInstance, cx, cy, cz float64) []blueprintInstance {
+	instances := make([]blueprintInstance, 0, len(raws))
+	for _, ri := range raws {
+		qx, qy, qz, qw := float64(ri.transform[3]), float64(ri.transform[4]), float64(ri.transform[5]), float64(ri.transform[6])
+		instances = append(instances, blueprintInstance{
+			BuildingType: ri.buildingType,
+			X:            float64(ri.transform[0]) - cx,
+			Y:            float64(ri.transform[1]) - cy,
+			Z:            float64(ri.transform[2]) - cz,
+			Rotation:     quatToYaw(qx, qy, qz, qw),
 		})
 	}
-	if err := pRows.Err(); err != nil {
-		jsonErr(w, fmt.Errorf("read placeables: %w", err), 500)
-		return
-	}
+	return instances
+}
 
+func extractPentashieldScale(buildingType string, props map[string]any) ([3]int, bool) {
+	var scale [3]int
+	if props == nil {
+		return scale, false
+	}
+	inner, ok := props[strings.TrimSuffix(buildingType, "_Placeable")+"_C"].(map[string]any)
+	if !ok {
+		return scale, false
+	}
+	scaleValues, ok := inner["m_Scale"].([]any)
+	if !ok || len(scaleValues) < 3 {
+		return scale, false
+	}
+	for i := 0; i < 3; i++ {
+		value, ok := scaleValues[i].(float64)
+		if !ok {
+			return scale, false
+		}
+		scale[i] = int(value)
+	}
+	return scale, true
+}
+
+func convertExportPlaceable(raw rawBasePlaceable, cx, cy, cz float64, placeableID int) (blueprintPlaceable, *blueprintPentashield, bool) {
+	if raw.buildingType == "Totem_Placeable" {
+		return blueprintPlaceable{}, nil, false
+	}
+	lx, ly, lz, locErr := parseVec3(raw.location)
+	qx, qy, qz, qw, rotErr := parseVec4(raw.rotation)
+	if locErr != nil || rotErr != nil {
+		return blueprintPlaceable{}, nil, false
+	}
+	rx, ry, rz := quatToEuler(qx, qy, qz, qw)
+	placeable := blueprintPlaceable{
+		BuildingType: raw.buildingType,
+		X:            lx - cx,
+		Y:            ly - cy,
+		Z:            lz - cz,
+		RX:           rx,
+		RY:           ry,
+		RZ:           rz,
+	}
+	if !strings.Contains(raw.buildingType, "PentashieldSurface") {
+		return placeable, nil, true
+	}
+	scale, ok := extractPentashieldScale(raw.buildingType, raw.properties)
+	if !ok {
+		return blueprintPlaceable{}, nil, false
+	}
+	return placeable, &blueprintPentashield{PlaceableID: placeableID, Scale: scale}, true
+}
+
+func buildBlueprintPlaceables(raws []rawBasePlaceable, cx, cy, cz float64) ([]blueprintPlaceable, []blueprintPentashield) {
+	placeables := make([]blueprintPlaceable, 0, len(raws))
+	pentashields := make([]blueprintPentashield, 0, len(raws))
+	for _, raw := range raws {
+		nextID := len(placeables)
+		placeable, pentashield, ok := convertExportPlaceable(raw, cx, cy, cz, nextID)
+		if !ok {
+			continue
+		}
+		placeables = append(placeables, placeable)
+		if pentashield != nil {
+			pentashields = append(pentashields, *pentashield)
+		}
+	}
+	return placeables, pentashields
+}
+
+func writeExportBaseResponse(
+	w http.ResponseWriter,
+	id int64,
+	instances []blueprintInstance,
+	placeables []blueprintPlaceable,
+	pentashields []blueprintPentashield,
+) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="base_%d.json"`, id))
 	jsonOK(w, blueprintFile{
@@ -242,4 +264,38 @@ func handleExportBase(w http.ResponseWriter, r *http.Request) {
 		Placeables:   placeables,
 		Pentashields: pentashields,
 	})
+}
+
+func handleExportBase(w http.ResponseWriter, r *http.Request) {
+	id, err := parseBasePathID(r.PathValue("id"))
+	if err != nil {
+		jsonErr(w, err, 400)
+		return
+	}
+	if globalDB == nil {
+		jsonErr(w, fmt.Errorf("not connected"), 500)
+		return
+	}
+	ctx := context.Background()
+
+	rawInstances, err := queryBaseExportInstances(ctx, id)
+	if err != nil {
+		jsonErr(w, err, 500)
+		return
+	}
+	if len(rawInstances) == 0 {
+		jsonErr(w, fmt.Errorf("building %d not found or empty", id), 404)
+		return
+	}
+
+	cx, cy, cz := calculateBaseCentroid(rawInstances)
+	instances := buildBlueprintInstances(rawInstances, cx, cy, cz)
+
+	rawPlaceables, err := queryBaseExportPlaceables(ctx, rawInstances[0].ownerEntityID)
+	if err != nil {
+		jsonErr(w, err, 500)
+		return
+	}
+	placeables, pentashields := buildBlueprintPlaceables(rawPlaceables, cx, cy, cz)
+	writeExportBaseResponse(w, id, instances, placeables, pentashields)
 }

--- a/cmd/dune-admin/handlers_bases_export_test.go
+++ b/cmd/dune-admin/handlers_bases_export_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+func nearlyEqual(a, b, epsilon float64) bool {
+	return math.Abs(a-b) <= epsilon
+}
+
+func TestParseBasePathID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantID    int64
+		wantError string
+	}{
+		{name: "valid", input: "123", wantID: 123},
+		{name: "invalid", input: "abc", wantError: "invalid id"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseBasePathID(tt.input)
+			if tt.wantError != "" {
+				if err == nil || err.Error() != tt.wantError {
+					t.Fatalf("expected error %q, got %v", tt.wantError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantID {
+				t.Fatalf("expected ID %d, got %d", tt.wantID, got)
+			}
+		})
+	}
+}
+
+func TestCalculateBaseCentroid(t *testing.T) {
+	t.Parallel()
+
+	raws := []rawBaseInstance{
+		{transform: []float32{10, 20, 30, 0, 0, 0, 1}},
+		{transform: []float32{14, 24, 34, 0, 0, 0, 1}},
+	}
+
+	cx, cy, cz := calculateBaseCentroid(raws)
+	if cx != 12 || cy != 22 || cz != 32 {
+		t.Fatalf("unexpected centroid: (%v, %v, %v)", cx, cy, cz)
+	}
+}
+
+func TestBuildBlueprintInstances(t *testing.T) {
+	t.Parallel()
+
+	raws := []rawBaseInstance{
+		{
+			buildingType: "A",
+			transform:    []float32{10, 20, 30, 0, 0, 0, 1},
+		},
+		{
+			buildingType: "B",
+			transform:    []float32{14, 24, 34, 0, 0, 0.70710677, 0.70710677},
+		},
+	}
+
+	cx, cy, cz := calculateBaseCentroid(raws)
+	got := buildBlueprintInstances(raws, cx, cy, cz)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 instances, got %d", len(got))
+	}
+
+	if got[0].BuildingType != "A" || got[1].BuildingType != "B" {
+		t.Fatalf("unexpected building types: %#v", got)
+	}
+
+	if got[0].X != -2 || got[0].Y != -2 || got[0].Z != -2 {
+		t.Fatalf("unexpected first offsets: %+v", got[0])
+	}
+	if !nearlyEqual(got[0].Rotation, 0, 0.001) {
+		t.Fatalf("unexpected first rotation: %v", got[0].Rotation)
+	}
+	if !nearlyEqual(got[1].Rotation, 90, 0.01) {
+		t.Fatalf("unexpected second rotation: %v", got[1].Rotation)
+	}
+}
+
+func TestConvertExportPlaceable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		raw            rawBasePlaceable
+		cx             float64
+		cy             float64
+		cz             float64
+		placeableID    int
+		wantInclude    bool
+		wantHasPenta   bool
+		wantPlaceableX float64
+	}{
+		{
+			name:        "skip totem",
+			raw:         rawBasePlaceable{buildingType: "Totem_Placeable"},
+			wantInclude: false,
+		},
+		{
+			name: "skip invalid transform",
+			raw: rawBasePlaceable{
+				buildingType: "SomeType_Placeable",
+				location:     "invalid",
+				rotation:     "(0,0,0,1)",
+			},
+			wantInclude: false,
+		},
+		{
+			name: "normal placeable",
+			raw: rawBasePlaceable{
+				buildingType: "SomeType_Placeable",
+				location:     "(10,20,30)",
+				rotation:     "(0,0,0,1)",
+			},
+			cx:             1,
+			cy:             2,
+			cz:             3,
+			wantInclude:    true,
+			wantHasPenta:   false,
+			wantPlaceableX: 9,
+		},
+		{
+			name: "pentashield with scale",
+			raw: rawBasePlaceable{
+				buildingType: "MyPentashieldSurface_Placeable",
+				location:     "(10,20,30)",
+				rotation:     "(0,0,0,1)",
+				properties: map[string]any{
+					"MyPentashieldSurface_C": map[string]any{
+						"m_Scale": []any{3.0, 4.0, 5.0},
+					},
+				},
+			},
+			cx:             1,
+			cy:             2,
+			cz:             3,
+			placeableID:    7,
+			wantInclude:    true,
+			wantHasPenta:   true,
+			wantPlaceableX: 9,
+		},
+		{
+			name: "pentashield without scale skipped",
+			raw: rawBasePlaceable{
+				buildingType: "MyPentashieldSurface_Placeable",
+				location:     "(10,20,30)",
+				rotation:     "(0,0,0,1)",
+				properties: map[string]any{
+					"MyPentashieldSurface_C": map[string]any{},
+				},
+			},
+			wantInclude: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			placeable, pentashield, include := convertExportPlaceable(tt.raw, tt.cx, tt.cy, tt.cz, tt.placeableID)
+			if include != tt.wantInclude {
+				t.Fatalf("expected include=%v, got %v", tt.wantInclude, include)
+			}
+			if !include {
+				return
+			}
+			if placeable.X != tt.wantPlaceableX {
+				t.Fatalf("unexpected placeable X: %v", placeable.X)
+			}
+			if (pentashield != nil) != tt.wantHasPenta {
+				t.Fatalf("expected pentashield=%v, got %v", tt.wantHasPenta, pentashield != nil)
+			}
+			if pentashield != nil {
+				if pentashield.PlaceableID != tt.placeableID {
+					t.Fatalf("expected pentashield placeable id %d, got %d", tt.placeableID, pentashield.PlaceableID)
+				}
+				if pentashield.Scale != [3]int{3, 4, 5} {
+					t.Fatalf("unexpected pentashield scale: %#v", pentashield.Scale)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildBlueprintPlaceables_AssignsPentashieldIndex(t *testing.T) {
+	t.Parallel()
+
+	raws := []rawBasePlaceable{
+		{buildingType: "Totem_Placeable"},
+		{
+			buildingType: "Normal_Placeable",
+			location:     "(1,1,1)",
+			rotation:     "(0,0,0,1)",
+		},
+		{
+			buildingType: "ShieldPentashieldSurface_Placeable",
+			location:     "(2,2,2)",
+			rotation:     "(0,0,0,1)",
+			properties: map[string]any{
+				"ShieldPentashieldSurface_C": map[string]any{
+					"m_Scale": []any{1.0, 2.0, 3.0},
+				},
+			},
+		},
+	}
+
+	placeables, pentashields := buildBlueprintPlaceables(raws, 0, 0, 0)
+	if len(placeables) != 2 {
+		t.Fatalf("expected 2 placeables, got %d", len(placeables))
+	}
+	if len(pentashields) != 1 {
+		t.Fatalf("expected 1 pentashield, got %d", len(pentashields))
+	}
+	if pentashields[0].PlaceableID != 1 {
+		t.Fatalf("expected pentashield PlaceableID=1, got %d", pentashields[0].PlaceableID)
+	}
+}

--- a/cmd/dune-admin/handlers_battlegroup.go
+++ b/cmd/dune-admin/handlers_battlegroup.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type backupFile struct {
@@ -92,14 +93,199 @@ func handleBGPods(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]any{"pods": lines, "namespace": ns})
 }
 
-func bgName() string { return strings.TrimPrefix(globalPodNS, "funcom-seabass-") }
-
-func activeBackupDir() string {
+func activeBackupDir() (string, error) {
 	if backupDir != "" {
-		return backupDir
+		return backupDir, nil
 	}
-	// Legacy K8s default.
-	return fmt.Sprintf("/funcom/artifacts/database-dumps/%s", bgName())
+	if loadedConfig.BackupDir != "" {
+		return loadedConfig.BackupDir, nil
+	}
+	ns := firstNonEmpty(controlNS, loadedConfig.ControlNamespace, globalPodNS)
+	bg := strings.TrimPrefix(ns, "funcom-seabass-")
+	if globalControl != nil && globalControl.Name() == "local" && ns != "" && globalExecutor != nil {
+		pod, err := discoverK8sBackupPod(ns)
+		if err == nil && pod != "" && bg != "" {
+			return fmt.Sprintf("k8s://%s/%s/home/dune/artifacts/database-dumps/%s", ns, pod, bg), nil
+		}
+	}
+	if bg != "" {
+		// Legacy kubectl/host default.
+		return fmt.Sprintf("/funcom/artifacts/database-dumps/%s", bg), nil
+	}
+	return "", fmt.Errorf("backup_dir not configured and no battlegroup namespace discovered")
+}
+
+func parseK8sBackupDir(dir string) (ns, pod, inPodDir string, ok bool) {
+	const prefix = "k8s://"
+	if !strings.HasPrefix(dir, prefix) {
+		return "", "", "", false
+	}
+	rest := strings.TrimPrefix(dir, prefix)
+	parts := strings.SplitN(rest, "/", 3)
+	if len(parts) < 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", "", false
+	}
+	ns, pod, inPodDir = parts[0], parts[1], "/"+strings.TrimLeft(parts[2], "/")
+	return ns, pod, inPodDir, true
+}
+
+func discoverK8sBackupPod(ns string) (string, error) {
+	if globalExecutor == nil {
+		return "", fmt.Errorf("not connected")
+	}
+	kctl := kubectlCLI(globalExecutor)
+	out, err := globalExecutor.Exec(fmt.Sprintf(
+		"%s get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | grep -- '-sg-' | head -1",
+		kctl, shellQuote(ns),
+	))
+	if err == nil && strings.TrimSpace(out) != "" {
+		return strings.TrimSpace(out), nil
+	}
+	out, err = globalExecutor.Exec(fmt.Sprintf(
+		"%s get pods -n %s --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | grep bgd | head -1",
+		kctl, shellQuote(ns),
+	))
+	if err == nil && strings.TrimSpace(out) != "" {
+		return strings.TrimSpace(out), nil
+	}
+	return "", fmt.Errorf("could not discover backup pod in namespace %s", ns)
+}
+
+func ensureBackupDir(dir string) error {
+	if globalExecutor == nil {
+		return fmt.Errorf("not connected")
+	}
+	if ns, pod, inPodDir, ok := parseK8sBackupDir(dir); ok {
+		kctl := kubectlCLI(globalExecutor)
+		out, err := globalExecutor.Exec(fmt.Sprintf(
+			"%s exec -n %s %s -- mkdir -p %s 2>&1",
+			kctl, shellQuote(ns), shellQuote(pod), shellQuote(inPodDir),
+		))
+		if err != nil {
+			return fmt.Errorf("ensure k8s backup dir: %w (%s)", err, strings.TrimSpace(out))
+		}
+		return nil
+	}
+	out, err := globalExecutor.Exec(fmt.Sprintf(
+		"mkdir -p %s 2>/dev/null || sudo mkdir -p %s 2>&1",
+		shellQuote(dir), shellQuote(dir),
+	))
+	if err != nil {
+		return fmt.Errorf("ensure backup dir: %w (%s)", err, strings.TrimSpace(out))
+	}
+	return nil
+}
+
+func listBackupDir(dir string) (string, string, error) {
+	if globalExecutor == nil {
+		return "", "", fmt.Errorf("not connected")
+	}
+	if ns, pod, inPodDir, ok := parseK8sBackupDir(dir); ok {
+		kctl := kubectlCLI(globalExecutor)
+		listCmd := fmt.Sprintf(`ls -lt %s/ 2>/dev/null | awk '/\.backup$/{print $NF"|"$5"|"$6" "$7" "$8}'`, inPodDir)
+		out, err := globalExecutor.Exec(fmt.Sprintf(
+			"%s exec -n %s %s -- sh -lc %s 2>&1",
+			kctl, shellQuote(ns), shellQuote(pod), shellQuote(listCmd),
+		))
+		if err != nil {
+			return "", "", fmt.Errorf("list backups: %w (%s)", err, strings.TrimSpace(out))
+		}
+		yamlCmd := fmt.Sprintf(`ls %s/*.backup.yaml 2>/dev/null | xargs -r -I{} basename {} .yaml`, inPodDir)
+		yamlOut, err := globalExecutor.Exec(fmt.Sprintf(
+			"%s exec -n %s %s -- sh -lc %s 2>&1",
+			kctl, shellQuote(ns), shellQuote(pod), shellQuote(yamlCmd),
+		))
+		if err != nil {
+			return "", "", fmt.Errorf("list backup metadata: %w (%s)", err, strings.TrimSpace(yamlOut))
+		}
+		return out, yamlOut, nil
+	}
+	out, err := globalExecutor.Exec(fmt.Sprintf(
+		`ls -lt %s/ 2>/dev/null | awk '/\.backup$/{print $NF"|"$5"|"$6" "$7" "$8}'`,
+		dir))
+	if err != nil {
+		out, err = globalExecutor.Exec(fmt.Sprintf(
+			`sudo ls -lt %s/ 2>/dev/null | awk '/\.backup$/{print $NF"|"$5"|"$6" "$7" "$8}'`,
+			dir))
+		if err != nil {
+			return "", "", fmt.Errorf("list backups: %w (%s)", err, strings.TrimSpace(out))
+		}
+	}
+	yamlOut, err := globalExecutor.Exec(fmt.Sprintf(
+		`ls %s/*.backup.yaml 2>/dev/null | xargs -r -I{} basename {} .yaml`,
+		dir))
+	if err != nil {
+		yamlOut, err = globalExecutor.Exec(fmt.Sprintf(
+			`sudo ls %s/*.backup.yaml 2>/dev/null | xargs -r -I{} basename {} .yaml`,
+			dir))
+		if err != nil {
+			return "", "", fmt.Errorf("list backup metadata: %w (%s)", err, strings.TrimSpace(yamlOut))
+		}
+	}
+	return out, yamlOut, nil
+}
+
+func backupFileExists(dir, name string) bool {
+	if globalExecutor == nil {
+		return false
+	}
+	if ns, pod, inPodDir, ok := parseK8sBackupDir(dir); ok {
+		kctl := kubectlCLI(globalExecutor)
+		remotePath := strings.TrimRight(inPodDir, "/") + "/" + name
+		out, _ := globalExecutor.Exec(fmt.Sprintf(
+			"%s exec -n %s %s -- sh -lc %s 2>/dev/null",
+			kctl, shellQuote(ns), shellQuote(pod),
+			shellQuote(fmt.Sprintf("test -f %s && echo yes || echo no", shellQuote(remotePath))),
+		))
+		return strings.TrimSpace(out) == "yes"
+	}
+	path := strings.TrimRight(dir, "/") + "/" + name
+	out, _ := globalExecutor.Exec(fmt.Sprintf("test -f %s && echo yes || echo no", shellQuote(path)))
+	if strings.TrimSpace(out) == "yes" {
+		return true
+	}
+	out, _ = globalExecutor.Exec(fmt.Sprintf("sudo test -f %s && echo yes || echo no", shellQuote(path)))
+	return strings.TrimSpace(out) == "yes"
+}
+
+func backupReadCmd(dir, name string) string {
+	if ns, pod, inPodDir, ok := parseK8sBackupDir(dir); ok {
+		kctl := kubectlCLI(globalExecutor)
+		remotePath := strings.TrimRight(inPodDir, "/") + "/" + name
+		return fmt.Sprintf("%s exec -n %s %s -- cat %s", kctl, shellQuote(ns), shellQuote(pod), shellQuote(remotePath))
+	}
+	path := strings.TrimRight(dir, "/") + "/" + name
+	return fmt.Sprintf("cat %s 2>/dev/null || sudo cat %s", shellQuote(path), shellQuote(path))
+}
+
+func writeBackupFile(dir, name string, src io.Reader) error {
+	if globalExecutor == nil {
+		return fmt.Errorf("not connected")
+	}
+	if err := ensureBackupDir(dir); err != nil {
+		return err
+	}
+	if ns, pod, inPodDir, ok := parseK8sBackupDir(dir); ok {
+		tmp := fmt.Sprintf("/tmp/dune-admin-backup-%d.tmp", time.Now().UnixNano())
+		if err := globalExecutor.WriteFile(tmp, src); err != nil {
+			return fmt.Errorf("stage upload: %w", err)
+		}
+		defer func() {
+			_, _ = globalExecutor.Exec(fmt.Sprintf("rm -f %s 2>/dev/null || sudo rm -f %s 2>/dev/null || true",
+				shellQuote(tmp), shellQuote(tmp)))
+		}()
+		kctl := kubectlCLI(globalExecutor)
+		remotePath := strings.TrimRight(inPodDir, "/") + "/" + name
+		out, err := globalExecutor.Exec(fmt.Sprintf(
+			"%s cp %s %s/%s:%s 2>&1",
+			kctl, shellQuote(tmp), shellQuote(ns), shellQuote(pod), shellQuote(remotePath),
+		))
+		if err != nil {
+			return fmt.Errorf("copy to k8s pod: %w (%s)", err, strings.TrimSpace(out))
+		}
+		return nil
+	}
+	return globalExecutor.WriteFile(strings.TrimRight(dir, "/")+"/"+name, src)
 }
 
 func handleBGBackupFiles(w http.ResponseWriter, r *http.Request) {
@@ -107,13 +293,20 @@ func handleBGBackupFiles(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, fmt.Errorf("not connected"), 503)
 		return
 	}
-	dir := activeBackupDir()
-	out, _ := globalExecutor.Exec(fmt.Sprintf(
-		`sudo ls -lt %s/ 2>/dev/null | awk '/\.backup$/{print $NF"|"$5"|"$6" "$7" "$8}'`,
-		dir))
-	yamlOut, _ := globalExecutor.Exec(fmt.Sprintf(
-		`sudo ls %s/*.backup.yaml 2>/dev/null | xargs -r -I{} basename {} .yaml`,
-		dir))
+	dir, err := activeBackupDir()
+	if err != nil {
+		jsonErr(w, err, 500)
+		return
+	}
+	if err := ensureBackupDir(dir); err != nil {
+		jsonErr(w, err, 500)
+		return
+	}
+	out, yamlOut, err := listBackupDir(dir)
+	if err != nil {
+		jsonErr(w, err, 500)
+		return
+	}
 	hasYAML := make(map[string]bool)
 	for _, n := range strings.Split(strings.TrimSpace(yamlOut), "\n") {
 		if n != "" {
@@ -150,7 +343,11 @@ func handleBGBackupDownload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	baseName := strings.TrimSuffix(filename, ".backup")
-	dir := activeBackupDir()
+	dir, err := activeBackupDir()
+	if err != nil {
+		jsonErr(w, err, 500)
+		return
+	}
 
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s.zip"`, baseName))
 	w.Header().Set("Content-Type", "application/zip")
@@ -158,16 +355,14 @@ func handleBGBackupDownload(w http.ResponseWriter, r *http.Request) {
 	zw := zip.NewWriter(w)
 	for _, ext := range []string{".backup", ".backup.yaml"} {
 		name := baseName + ext
-		remotePath := dir + "/" + name
-		exists, _ := globalExecutor.Exec(fmt.Sprintf("sudo test -f %s && echo yes || echo no", shellQuote(remotePath)))
-		if strings.TrimSpace(exists) != "yes" {
+		if !backupFileExists(dir, name) {
 			continue
 		}
 		fw, err := zw.Create(name)
 		if err != nil {
 			continue
 		}
-		if err := globalExecutor.PipeToWriter(fmt.Sprintf("sudo cat %s", shellQuote(remotePath)), fw); err != nil {
+		if err := globalExecutor.PipeToWriter(backupReadCmd(dir, name), fw); err != nil {
 			fmt.Printf("zip entry %s: %v\n", name, err)
 		}
 	}
@@ -218,7 +413,15 @@ func handleBGBackupUpload(w http.ResponseWriter, r *http.Request) {
 	defer func() { _ = file.Close() }()
 
 	filename := header.Filename
-	dir := activeBackupDir()
+	dir, err := activeBackupDir()
+	if err != nil {
+		jsonErr(w, err, 500)
+		return
+	}
+	if err := ensureBackupDir(dir); err != nil {
+		jsonErr(w, err, 500)
+		return
+	}
 
 	if strings.HasSuffix(filename, ".zip") {
 		data, err := io.ReadAll(file)
@@ -244,9 +447,10 @@ func handleBGBackupUpload(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				continue
 			}
-			if err := globalExecutor.WriteFile(dir+"/"+name, rc); err != nil {
+			if err := writeBackupFile(dir, name, rc); err != nil {
 				_ = rc.Close()
-				continue
+				jsonErr(w, fmt.Errorf("upload failed for %s: %w", name, err), 500)
+				return
 			}
 			if err := rc.Close(); err != nil {
 				continue
@@ -261,7 +465,7 @@ func handleBGBackupUpload(w http.ResponseWriter, r *http.Request) {
 		}
 		jsonOK(w, map[string]string{"name": backupName})
 	} else if strings.HasSuffix(filename, ".backup") && !strings.ContainsAny(filename, "/\\") {
-		if err := globalExecutor.WriteFile(dir+"/"+filename, file); err != nil {
+		if err := writeBackupFile(dir, filename, file); err != nil {
 			jsonErr(w, fmt.Errorf("upload failed: %w", err), 500)
 			return
 		}
@@ -283,9 +487,29 @@ func restoreViaControl(ctx context.Context, filename string) (string, error) {
 			shellQuote(filename)))
 	}
 	// docker / local: pg_restore from the backup directory.
-	dir := activeBackupDir()
-	path := dir + "/" + filename
+	dir, err := activeBackupDir()
+	if err != nil {
+		return "", err
+	}
+	path := strings.TrimRight(dir, "/") + "/" + filename
+	if ns, pod, inPodDir, ok := parseK8sBackupDir(dir); ok {
+		kctl := kubectlCLI(globalExecutor)
+		tmp := fmt.Sprintf("/tmp/dune-admin-restore-%d.backup", time.Now().UnixNano())
+		remotePath := strings.TrimRight(inPodDir, "/") + "/" + filename
+		copyOut, copyErr := globalExecutor.Exec(fmt.Sprintf(
+			"%s cp %s/%s:%s %s 2>&1",
+			kctl, shellQuote(ns), shellQuote(pod), shellQuote(remotePath), shellQuote(tmp),
+		))
+		if copyErr != nil {
+			return copyOut, fmt.Errorf("copy backup to local restore path: %w", copyErr)
+		}
+		defer func() {
+			_, _ = globalExecutor.Exec(fmt.Sprintf("rm -f %s 2>/dev/null || sudo rm -f %s 2>/dev/null || true",
+				shellQuote(tmp), shellQuote(tmp)))
+		}()
+		path = tmp
+	}
 	return globalExecutor.Exec(fmt.Sprintf(
-		`pg_restore --clean --if-exists -h %s -p %d -U %s -d %s %s 2>&1`,
-		dbHost, dbPort, dbUser, dbName, shellQuote(path)))
+		`PGPASSWORD=%s pg_restore --no-password --clean --if-exists -h %s -p %d -U %s -d %s %s 2>&1`,
+		shellQuote(dbPass), dbHost, dbPort, dbUser, dbName, shellQuote(path)))
 }

--- a/cmd/dune-admin/handlers_battlegroup.go
+++ b/cmd/dune-admin/handlers_battlegroup.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -395,6 +396,65 @@ func handleBGRestore(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"output": out})
 }
 
+func allowedBackupArchiveEntry(entryName string) (string, bool) {
+	name := filepath.Base(entryName)
+	if strings.ContainsAny(name, "/\\") {
+		return "", false
+	}
+	if strings.HasSuffix(name, ".backup") || strings.HasSuffix(name, ".backup.yaml") {
+		return name, true
+	}
+	return "", false
+}
+
+func writeBackupArchiveEntries(dir string, zr *zip.Reader) (string, error) {
+	var backupName string
+	for _, zf := range zr.File {
+		name, ok := allowedBackupArchiveEntry(zf.Name)
+		if !ok {
+			continue
+		}
+		rc, err := zf.Open()
+		if err != nil {
+			continue
+		}
+		if err := writeBackupFile(dir, name, rc); err != nil {
+			_ = rc.Close()
+			return "", fmt.Errorf("upload failed for %s: %w", name, err)
+		}
+		if err := rc.Close(); err != nil {
+			continue
+		}
+		if strings.HasSuffix(name, ".backup") {
+			backupName = name
+		}
+	}
+	return backupName, nil
+}
+
+func uploadBackupArchive(dir string, file multipart.File) (string, int, error) {
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return "", 400, fmt.Errorf("read zip: %w", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", 400, fmt.Errorf("invalid zip: %w", err)
+	}
+	backupName, err := writeBackupArchiveEntries(dir, zr)
+	if err != nil {
+		return "", 500, err
+	}
+	if backupName == "" {
+		return "", 400, fmt.Errorf("zip contains no .backup file")
+	}
+	return backupName, 200, nil
+}
+
+func isDirectBackupUpload(filename string) bool {
+	return strings.HasSuffix(filename, ".backup") && !strings.ContainsAny(filename, "/\\")
+}
+
 func handleBGBackupUpload(w http.ResponseWriter, r *http.Request) {
 	if globalExecutor == nil {
 		jsonErr(w, fmt.Errorf("not connected"), 503)
@@ -424,55 +484,25 @@ func handleBGBackupUpload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if strings.HasSuffix(filename, ".zip") {
-		data, err := io.ReadAll(file)
+		backupName, status, err := uploadBackupArchive(dir, file)
 		if err != nil {
-			jsonErr(w, fmt.Errorf("read zip: %w", err), 400)
-			return
-		}
-		zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
-		if err != nil {
-			jsonErr(w, fmt.Errorf("invalid zip: %w", err), 400)
-			return
-		}
-		var backupName string
-		for _, zf := range zr.File {
-			name := filepath.Base(zf.Name)
-			if strings.ContainsAny(name, "/\\") {
-				continue
-			}
-			if !strings.HasSuffix(name, ".backup") && !strings.HasSuffix(name, ".backup.yaml") {
-				continue
-			}
-			rc, err := zf.Open()
-			if err != nil {
-				continue
-			}
-			if err := writeBackupFile(dir, name, rc); err != nil {
-				_ = rc.Close()
-				jsonErr(w, fmt.Errorf("upload failed for %s: %w", name, err), 500)
-				return
-			}
-			if err := rc.Close(); err != nil {
-				continue
-			}
-			if strings.HasSuffix(name, ".backup") && !strings.HasSuffix(name, ".yaml") {
-				backupName = name
-			}
-		}
-		if backupName == "" {
-			jsonErr(w, fmt.Errorf("zip contains no .backup file"), 400)
+			jsonErr(w, err, status)
 			return
 		}
 		jsonOK(w, map[string]string{"name": backupName})
-	} else if strings.HasSuffix(filename, ".backup") && !strings.ContainsAny(filename, "/\\") {
+		return
+	}
+
+	if isDirectBackupUpload(filename) {
 		if err := writeBackupFile(dir, filename, file); err != nil {
 			jsonErr(w, fmt.Errorf("upload failed: %w", err), 500)
 			return
 		}
 		jsonOK(w, map[string]string{"name": filename})
-	} else {
-		jsonErr(w, fmt.Errorf("file must be .backup or .zip"), 400)
+		return
 	}
+
+	jsonErr(w, fmt.Errorf("file must be .backup or .zip"), 400)
 }
 
 // restoreViaControl runs a restore command appropriate for the active control plane.

--- a/cmd/dune-admin/handlers_battlegroup_upload_test.go
+++ b/cmd/dune-admin/handlers_battlegroup_upload_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"testing"
+)
+
+type testMultipartFile struct {
+	*bytes.Reader
+}
+
+func (f testMultipartFile) Close() error { return nil }
+
+func TestAllowedBackupArchiveEntry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		entryName string
+		wantName  string
+		wantOK    bool
+	}{
+		{name: "backup", entryName: "save.backup", wantName: "save.backup", wantOK: true},
+		{name: "backup-yaml", entryName: "save.backup.yaml", wantName: "save.backup.yaml", wantOK: true},
+		{name: "nested-path", entryName: "dir/sub/save.backup", wantName: "save.backup", wantOK: true},
+		{name: "non-backup", entryName: "notes.txt", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotName, gotOK := allowedBackupArchiveEntry(tt.entryName)
+			if gotOK != tt.wantOK {
+				t.Fatalf("expected ok=%v, got %v", tt.wantOK, gotOK)
+			}
+			if gotName != tt.wantName {
+				t.Fatalf("expected name %q, got %q", tt.wantName, gotName)
+			}
+		})
+	}
+}
+
+func TestIsDirectBackupUpload(t *testing.T) {
+	t.Parallel()
+
+	if !isDirectBackupUpload("save.backup") {
+		t.Fatal("expected plain .backup filename to be accepted")
+	}
+	if isDirectBackupUpload("save.zip") {
+		t.Fatal("expected .zip to be rejected for direct backup upload")
+	}
+	if isDirectBackupUpload("../save.backup") {
+		t.Fatal("expected path traversal to be rejected")
+	}
+}
+
+func TestUploadBackupArchive_InvalidZip(t *testing.T) {
+	t.Parallel()
+
+	file := testMultipartFile{Reader: bytes.NewReader([]byte("not a zip"))}
+	_, status, err := uploadBackupArchive("/unused", file)
+	if err == nil {
+		t.Fatal("expected invalid zip error")
+	}
+	if status != 400 {
+		t.Fatalf("expected status 400, got %d", status)
+	}
+}
+
+func TestUploadBackupArchive_NoBackupFile(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("notes.txt")
+	if err != nil {
+		t.Fatalf("create zip entry: %v", err)
+	}
+	if _, err := w.Write([]byte("hello")); err != nil {
+		t.Fatalf("write zip entry: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+
+	file := testMultipartFile{Reader: bytes.NewReader(buf.Bytes())}
+	_, status, err := uploadBackupArchive("/unused", file)
+	if err == nil || err.Error() != "zip contains no .backup file" {
+		t.Fatalf("expected no-backup error, got %v", err)
+	}
+	if status != 400 {
+		t.Fatalf("expected status 400, got %d", status)
+	}
+}

--- a/cmd/dune-admin/handlers_blueprints.go
+++ b/cmd/dune-admin/handlers_blueprints.go
@@ -143,6 +143,150 @@ func isStructuralBuilding(buildingType string) bool {
 	return structuralBuildingTypes[buildingType]
 }
 
+func fetchBlueprintName(ctx context.Context, blueprintID int64) string {
+	var name string
+	_ = globalDB.QueryRow(ctx, `
+		SELECT COALESCE(i.stats->'FBuildingBlueprintItemStats'->1->>'BuildingBlueprintName', '')
+		FROM dune.building_blueprints bb
+		JOIN dune.items i ON i.id = bb.item_id
+		WHERE bb.id = $1`, blueprintID).Scan(&name)
+	return name
+}
+
+func buildBlueprintInstance(iid int, buildingType string, transform []float32, stability bool) (blueprintInstance, bool) {
+	if len(transform) < 4 {
+		return blueprintInstance{}, false
+	}
+	return blueprintInstance{
+		InstanceID:        &iid,
+		BuildingType:      buildingType,
+		X:                 float64(transform[0]),
+		Y:                 float64(transform[1]),
+		Z:                 float64(transform[2]),
+		Rotation:          float64(transform[3]),
+		ProvidesStability: &stability,
+	}, true
+}
+
+func fetchBlueprintInstances(ctx context.Context, blueprintID int64) ([]blueprintInstance, error) {
+	rows, err := globalDB.Query(ctx, `
+		SELECT instance_id, building_type, transform, provides_stability
+		FROM dune.building_blueprint_instances
+		WHERE building_blueprint_id = $1
+		ORDER BY instance_id`, blueprintID)
+	if err != nil {
+		return nil, fmt.Errorf("query instances: %w", err)
+	}
+	defer rows.Close()
+
+	var instances []blueprintInstance
+	for rows.Next() {
+		var iid int
+		var buildingType string
+		var transform []float32
+		var stability bool
+		if err := rows.Scan(&iid, &buildingType, &transform, &stability); err != nil {
+			continue
+		}
+		instance, ok := buildBlueprintInstance(iid, buildingType, transform, stability)
+		if !ok {
+			continue
+		}
+		instances = append(instances, instance)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read instances: %w", err)
+	}
+	return instances, nil
+}
+
+func buildBlueprintPlaceable(pid int, buildingType string, transform []float32) (blueprintPlaceable, bool) {
+	if len(transform) < 6 {
+		return blueprintPlaceable{}, false
+	}
+	return blueprintPlaceable{
+		PlaceableID:  &pid,
+		BuildingType: buildingType,
+		X:            float64(transform[0]),
+		Y:            float64(transform[1]),
+		Z:            float64(transform[2]),
+		RX:           float64(transform[3]),
+		RY:           float64(transform[4]),
+		RZ:           float64(transform[5]),
+	}, true
+}
+
+func fetchBlueprintPlaceables(ctx context.Context, blueprintID int64) ([]blueprintPlaceable, error) {
+	rows, err := globalDB.Query(ctx, `
+		SELECT placeable_id, building_type, transform
+		FROM dune.building_blueprint_placeables
+		WHERE building_blueprint_id = $1
+		ORDER BY placeable_id`, blueprintID)
+	if err != nil {
+		return nil, fmt.Errorf("query placeables: %w", err)
+	}
+	defer rows.Close()
+
+	var placeables []blueprintPlaceable
+	for rows.Next() {
+		var pid int
+		var buildingType string
+		var transform []float32
+		if err := rows.Scan(&pid, &buildingType, &transform); err != nil {
+			continue
+		}
+		placeable, ok := buildBlueprintPlaceable(pid, buildingType, transform)
+		if !ok {
+			continue
+		}
+		placeables = append(placeables, placeable)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read placeables: %w", err)
+	}
+	return placeables, nil
+}
+
+func buildBlueprintPentashield(pid int, scale []int16) (blueprintPentashield, bool) {
+	if len(scale) < 3 {
+		return blueprintPentashield{}, false
+	}
+	return blueprintPentashield{
+		PlaceableID: pid,
+		Scale:       [3]int{int(scale[0]), int(scale[1]), int(scale[2])},
+	}, true
+}
+
+func fetchBlueprintPentashields(ctx context.Context, blueprintID int64) ([]blueprintPentashield, error) {
+	rows, err := globalDB.Query(ctx, `
+		SELECT placeable_id, scale
+		FROM dune.building_blueprint_pentashields
+		WHERE building_blueprint_id = $1
+		ORDER BY placeable_id`, blueprintID)
+	if err != nil {
+		return nil, fmt.Errorf("query pentashields: %w", err)
+	}
+	defer rows.Close()
+
+	var pentashields []blueprintPentashield
+	for rows.Next() {
+		var pid int
+		var scale []int16
+		if err := rows.Scan(&pid, &scale); err != nil {
+			continue
+		}
+		pentashield, ok := buildBlueprintPentashield(pid, scale)
+		if !ok {
+			continue
+		}
+		pentashields = append(pentashields, pentashield)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read pentashields: %w", err)
+	}
+	return pentashields, nil
+}
+
 // fetchBlueprintData fetches blueprint instances, placeables, and pentashields
 // from the DB and returns a blueprintFile ready for JSON serialization.
 func fetchBlueprintData(ctx context.Context, blueprintID int64) (blueprintFile, error) {
@@ -150,116 +294,18 @@ func fetchBlueprintData(ctx context.Context, blueprintID int64) (blueprintFile, 
 		return blueprintFile{}, fmt.Errorf("not connected")
 	}
 
-	// Fetch the blueprint name from the item stats.
-	var name string
-	_ = globalDB.QueryRow(ctx, `
-		SELECT COALESCE(i.stats->'FBuildingBlueprintItemStats'->1->>'BuildingBlueprintName', '')
-		FROM dune.building_blueprints bb
-		JOIN dune.items i ON i.id = bb.item_id
-		WHERE bb.id = $1`, blueprintID).Scan(&name)
-
-	// Fetch instances.
-	iRows, err := globalDB.Query(ctx, `
-		SELECT instance_id, building_type, transform, provides_stability
-		FROM dune.building_blueprint_instances
-		WHERE building_blueprint_id = $1
-		ORDER BY instance_id`, blueprintID)
+	name := fetchBlueprintName(ctx, blueprintID)
+	instances, err := fetchBlueprintInstances(ctx, blueprintID)
 	if err != nil {
-		return blueprintFile{}, fmt.Errorf("query instances: %w", err)
+		return blueprintFile{}, err
 	}
-	defer iRows.Close()
-
-	var instances []blueprintInstance
-	for iRows.Next() {
-		var iid int
-		var btype string
-		var t []float32
-		var stability bool
-		if err := iRows.Scan(&iid, &btype, &t, &stability); err != nil {
-			continue
-		}
-		if len(t) < 4 {
-			continue
-		}
-		instances = append(instances, blueprintInstance{
-			InstanceID:        &iid,
-			BuildingType:      btype,
-			X:                 float64(t[0]),
-			Y:                 float64(t[1]),
-			Z:                 float64(t[2]),
-			Rotation:          float64(t[3]),
-			ProvidesStability: &stability,
-		})
-	}
-	if err := iRows.Err(); err != nil {
-		return blueprintFile{}, fmt.Errorf("read instances: %w", err)
-	}
-
-	// Fetch placeables.
-	pRows, err := globalDB.Query(ctx, `
-		SELECT placeable_id, building_type, transform
-		FROM dune.building_blueprint_placeables
-		WHERE building_blueprint_id = $1
-		ORDER BY placeable_id`, blueprintID)
+	placeables, err := fetchBlueprintPlaceables(ctx, blueprintID)
 	if err != nil {
-		return blueprintFile{}, fmt.Errorf("query placeables: %w", err)
+		return blueprintFile{}, err
 	}
-	defer pRows.Close()
-
-	var placeables []blueprintPlaceable
-	for pRows.Next() {
-		var pid int
-		var btype string
-		var t []float32
-		if err := pRows.Scan(&pid, &btype, &t); err != nil {
-			continue
-		}
-		if len(t) < 6 {
-			continue
-		}
-		placeables = append(placeables, blueprintPlaceable{
-			PlaceableID:  &pid,
-			BuildingType: btype,
-			X:            float64(t[0]),
-			Y:            float64(t[1]),
-			Z:            float64(t[2]),
-			RX:           float64(t[3]),
-			RY:           float64(t[4]),
-			RZ:           float64(t[5]),
-		})
-	}
-	if err := pRows.Err(); err != nil {
-		return blueprintFile{}, fmt.Errorf("read placeables: %w", err)
-	}
-
-	// Fetch pentashield scale data.
-	psRows, err := globalDB.Query(ctx, `
-		SELECT placeable_id, scale
-		FROM dune.building_blueprint_pentashields
-		WHERE building_blueprint_id = $1
-		ORDER BY placeable_id`, blueprintID)
+	pentashields, err := fetchBlueprintPentashields(ctx, blueprintID)
 	if err != nil {
-		return blueprintFile{}, fmt.Errorf("query pentashields: %w", err)
-	}
-	defer psRows.Close()
-
-	var pentashields []blueprintPentashield
-	for psRows.Next() {
-		var pid int
-		var scale []int16
-		if err := psRows.Scan(&pid, &scale); err != nil {
-			continue
-		}
-		if len(scale) < 3 {
-			continue
-		}
-		pentashields = append(pentashields, blueprintPentashield{
-			PlaceableID: pid,
-			Scale:       [3]int{int(scale[0]), int(scale[1]), int(scale[2])},
-		})
-	}
-	if err := psRows.Err(); err != nil {
-		return blueprintFile{}, fmt.Errorf("read pentashields: %w", err)
+		return blueprintFile{}, err
 	}
 
 	return blueprintFile{
@@ -268,6 +314,167 @@ func fetchBlueprintData(ctx context.Context, blueprintID int64) (blueprintFile, 
 		Placeables:   placeables,
 		Pentashields: pentashields,
 	}, nil
+}
+
+const blueprintImportBatchSize = 50
+
+const blueprintPlaceholderStats = `{"FCustomizationStats":[[], {}],"FBuildingBlueprintItemStats":[[], {"PlayerBlueprintId":"!!bbp#0"}],"FItemStackAndDurabilityStats":[[], {"DecayedMaxDurability":0.0}]}`
+
+func findBackpackInventoryID(ctx context.Context, tx pgx.Tx, playerPawnID int64) (int64, error) {
+	var invID int64
+	err := tx.QueryRow(ctx, `
+		SELECT id FROM dune.inventories
+		WHERE actor_id = $1 AND inventory_type = 0
+		LIMIT 1`, playerPawnID).Scan(&invID)
+	if err != nil {
+		return 0, fmt.Errorf("find inventory: %w", err)
+	}
+	return invID, nil
+}
+
+func nextInventoryPosition(ctx context.Context, tx pgx.Tx, inventoryID int64) int64 {
+	var nextPos int64
+	_ = tx.QueryRow(ctx, `
+		SELECT COALESCE(MAX(position_index), -1) + 1
+		FROM dune.items WHERE inventory_id = $1`, inventoryID).Scan(&nextPos)
+	return nextPos
+}
+
+func createBlueprintItem(ctx context.Context, tx pgx.Tx, inventoryID, position int64) (int64, error) {
+	var itemID int64
+	err := tx.QueryRow(ctx, `
+		INSERT INTO dune.items
+			(inventory_id, stack_size, position_index, template_id, quality_level, stats)
+		VALUES ($1, 1, $2, 'BuildingBlueprint_CopyDevice', 0, $3::jsonb)
+		RETURNING id`,
+		inventoryID, position, blueprintPlaceholderStats).Scan(&itemID)
+	if err != nil {
+		return 0, fmt.Errorf("create item: %w", err)
+	}
+	return itemID, nil
+}
+
+func createBlueprintRecord(ctx context.Context, tx pgx.Tx, itemID int64) (int64, error) {
+	var blueprintID int64
+	err := tx.QueryRow(ctx, `
+		INSERT INTO dune.building_blueprints (item_id, player_id, building_blueprint_map)
+		VALUES ($1, null, '')
+		RETURNING id`, itemID).Scan(&blueprintID)
+	if err != nil {
+		return 0, fmt.Errorf("create blueprint: %w", err)
+	}
+	return blueprintID, nil
+}
+
+func blueprintItemStatsJSON(blueprintID int64, name string) string {
+	nameJSON := ""
+	if name != "" {
+		nameJSON = fmt.Sprintf(`,"BuildingBlueprintName":%q`, name)
+	}
+	return fmt.Sprintf(
+		`{"FCustomizationStats":[[], {}],"FBuildingBlueprintItemStats":[[], {"PlayerBlueprintId":"!!bbp#%d"%s}],"FItemStackAndDurabilityStats":[[], {"DecayedMaxDurability":0.0}]}`,
+		blueprintID, nameJSON)
+}
+
+func updateBlueprintItemStats(ctx context.Context, tx pgx.Tx, itemID, blueprintID int64, name string) error {
+	if _, err := tx.Exec(ctx, `UPDATE dune.items SET stats = $1::jsonb WHERE id = $2`,
+		blueprintItemStatsJSON(blueprintID, name), itemID); err != nil {
+		return fmt.Errorf("update item stats: %w", err)
+	}
+	return nil
+}
+
+func resolveBlueprintImportInstance(start, offset int, inst blueprintInstance) (instanceID int, transform string, stability bool) {
+	transform = fmt.Sprintf("{%g,%g,%g,%g}",
+		float32(inst.X), float32(inst.Y), float32(inst.Z), float32(inst.Rotation))
+	instanceID = start + offset + 1
+	if inst.InstanceID != nil {
+		instanceID = *inst.InstanceID
+	}
+	stability = isStructuralBuilding(inst.BuildingType)
+	if inst.ProvidesStability != nil {
+		stability = *inst.ProvidesStability
+	}
+	return instanceID, transform, stability
+}
+
+func insertBlueprintInstances(ctx context.Context, tx pgx.Tx, blueprintID int64, instances []blueprintInstance) error {
+	for start := 0; start < len(instances); start += blueprintImportBatchSize {
+		end := start + blueprintImportBatchSize
+		if end > len(instances) {
+			end = len(instances)
+		}
+		batch := &pgx.Batch{}
+		for i, inst := range instances[start:end] {
+			instanceID, transform, stability := resolveBlueprintImportInstance(start, i, inst)
+			batch.Queue(`
+				INSERT INTO dune.building_blueprint_instances
+					(building_blueprint_id, instance_id, building_type, transform, hologram, provides_stability, health)
+				VALUES ($1, $2, $3, $4::real[], true, $5, 0)`,
+				blueprintID, instanceID, inst.BuildingType, transform, stability)
+		}
+		br := tx.SendBatch(ctx, batch)
+		for i := start; i < end; i++ {
+			if _, err := br.Exec(); err != nil {
+				_ = br.Close()
+				return fmt.Errorf("insert instance %d: %w", i, err)
+			}
+		}
+		_ = br.Close()
+	}
+	return nil
+}
+
+func resolveBlueprintImportPlaceable(start, offset int, pl blueprintPlaceable) (placeableID int, transform string) {
+	transform = fmt.Sprintf("{%g,%g,%g,%g,%g,%g}",
+		float32(pl.X), float32(pl.Y), float32(pl.Z),
+		float32(pl.RX), float32(pl.RY), float32(pl.RZ))
+	placeableID = start + offset + 1
+	if pl.PlaceableID != nil {
+		placeableID = *pl.PlaceableID
+	}
+	return placeableID, transform
+}
+
+func insertBlueprintPlaceables(ctx context.Context, tx pgx.Tx, blueprintID int64, placeables []blueprintPlaceable) error {
+	for start := 0; start < len(placeables); start += blueprintImportBatchSize {
+		end := start + blueprintImportBatchSize
+		if end > len(placeables) {
+			end = len(placeables)
+		}
+		batch := &pgx.Batch{}
+		for i, pl := range placeables[start:end] {
+			placeableID, transform := resolveBlueprintImportPlaceable(start, i, pl)
+			batch.Queue(`
+				INSERT INTO dune.building_blueprint_placeables
+					(building_blueprint_id, placeable_id, building_type, transform, hologram)
+				VALUES ($1, $2, $3, $4::real[], true)`,
+				blueprintID, placeableID, pl.BuildingType, transform)
+		}
+		br := tx.SendBatch(ctx, batch)
+		for i := start; i < end; i++ {
+			if _, err := br.Exec(); err != nil {
+				_ = br.Close()
+				return fmt.Errorf("insert placeable %d: %w", i, err)
+			}
+		}
+		_ = br.Close()
+	}
+	return nil
+}
+
+func insertBlueprintPentashields(ctx context.Context, tx pgx.Tx, blueprintID int64, pentashields []blueprintPentashield) error {
+	for _, ps := range pentashields {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO dune.building_blueprint_pentashields
+				(building_blueprint_id, placeable_id, scale)
+			VALUES ($1, $2, ARRAY[$3,$4,$5]::smallint[])`,
+			blueprintID, ps.PlaceableID,
+			int16(ps.Scale[0]), int16(ps.Scale[1]), int16(ps.Scale[2])); err != nil {
+			return fmt.Errorf("insert pentashield %d: %w", ps.PlaceableID, err)
+		}
+	}
+	return nil
 }
 
 // importBlueprintData imports a blueprintFile into the DB for the given player pawn ID.
@@ -287,57 +494,24 @@ func importBlueprintData(ctx context.Context, playerPawnID int64, bf blueprintFi
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	// Get backpack inventory.
-	var invID int64
-	err = tx.QueryRow(ctx, `
-		SELECT id FROM dune.inventories
-		WHERE actor_id = $1 AND inventory_type = 0
-		LIMIT 1`, playerPawnID).Scan(&invID)
+	invID, err := findBackpackInventoryID(ctx, tx, playerPawnID)
 	if err != nil {
-		return msgMutate{err: fmt.Errorf("find inventory: %w", err)}
+		return msgMutate{err: err}
 	}
 
-	// Next free position index.
-	var nextPos int64
-	_ = tx.QueryRow(ctx, `
-		SELECT COALESCE(MAX(position_index), -1) + 1
-		FROM dune.items WHERE inventory_id = $1`, invID).Scan(&nextPos)
-
-	// Placeholder stats — will be updated with real blueprint ID after insert.
-	placeholderStats := `{"FCustomizationStats":[[], {}],"FBuildingBlueprintItemStats":[[], {"PlayerBlueprintId":"!!bbp#0"}],"FItemStackAndDurabilityStats":[[], {"DecayedMaxDurability":0.0}]}`
-
-	var itemID int64
-	err = tx.QueryRow(ctx, `
-		INSERT INTO dune.items
-			(inventory_id, stack_size, position_index, template_id, quality_level, stats)
-		VALUES ($1, 1, $2, 'BuildingBlueprint_CopyDevice', 0, $3::jsonb)
-		RETURNING id`,
-		invID, nextPos, placeholderStats).Scan(&itemID)
+	itemID, err := createBlueprintItem(ctx, tx, invID, nextInventoryPosition(ctx, tx, invID))
 	if err != nil {
-		return msgMutate{err: fmt.Errorf("create item: %w", err)}
+		return msgMutate{err: err}
 	}
 
-	// Insert blueprint master record.
-	var blueprintID int64
-	err = tx.QueryRow(ctx, `
-		INSERT INTO dune.building_blueprints (item_id, player_id, building_blueprint_map)
-		VALUES ($1, null, '')
-		RETURNING id`, itemID).Scan(&blueprintID)
+	blueprintID, err := createBlueprintRecord(ctx, tx, itemID)
 	if err != nil {
-		return msgMutate{err: fmt.Errorf("create blueprint: %w", err)}
+		return msgMutate{err: err}
 	}
 
 	// Update item stats with real blueprint ID and name (no PlayerBaseBackupId — crashes the game).
-	nameJSON := ""
-	if bf.Name != "" {
-		nameJSON = fmt.Sprintf(`,"BuildingBlueprintName":%q`, bf.Name)
-	}
-	fullStats := fmt.Sprintf(
-		`{"FCustomizationStats":[[], {}],"FBuildingBlueprintItemStats":[[], {"PlayerBlueprintId":"!!bbp#%d"%s}],"FItemStackAndDurabilityStats":[[], {"DecayedMaxDurability":0.0}]}`,
-		blueprintID, nameJSON)
-	if _, err = tx.Exec(ctx, `UPDATE dune.items SET stats = $1::jsonb WHERE id = $2`,
-		fullStats, itemID); err != nil {
-		return msgMutate{err: fmt.Errorf("update item stats: %w", err)}
+	if err := updateBlueprintItemStats(ctx, tx, itemID, blueprintID, bf.Name); err != nil {
+		return msgMutate{err: err}
 	}
 
 	// Insert instances in batches of 50.
@@ -346,81 +520,18 @@ func importBlueprintData(ctx context.Context, playerPawnID int64, bf blueprintFi
 	// back to 1-based sequential ids and a structural-type stability lookup —
 	// matching the indexing scheme used by every existing blueprint in the DB
 	// that the source pentashield placeable_id references assume.
-	const batchSize = 50
-	for start := 0; start < len(bf.Instances); start += batchSize {
-		end := start + batchSize
-		if end > len(bf.Instances) {
-			end = len(bf.Instances)
-		}
-		batch := &pgx.Batch{}
-		for i, inst := range bf.Instances[start:end] {
-			transform := fmt.Sprintf("{%g,%g,%g,%g}",
-				float32(inst.X), float32(inst.Y), float32(inst.Z), float32(inst.Rotation))
-			instanceID := start + i + 1
-			if inst.InstanceID != nil {
-				instanceID = *inst.InstanceID
-			}
-			stability := isStructuralBuilding(inst.BuildingType)
-			if inst.ProvidesStability != nil {
-				stability = *inst.ProvidesStability
-			}
-			batch.Queue(`
-				INSERT INTO dune.building_blueprint_instances
-					(building_blueprint_id, instance_id, building_type, transform, hologram, provides_stability, health)
-				VALUES ($1, $2, $3, $4::real[], true, $5, 0)`,
-				blueprintID, instanceID, inst.BuildingType, transform, stability)
-		}
-		br := tx.SendBatch(ctx, batch)
-		for i := start; i < end; i++ {
-			if _, err := br.Exec(); err != nil {
-				_ = br.Close()
-				return msgMutate{err: fmt.Errorf("insert instance %d: %w", i, err)}
-			}
-		}
-		_ = br.Close()
+	if err := insertBlueprintInstances(ctx, tx, blueprintID, bf.Instances); err != nil {
+		return msgMutate{err: err}
 	}
 
 	// Insert placeables in batches of 50.
-	for start := 0; start < len(bf.Placeables); start += batchSize {
-		end := start + batchSize
-		if end > len(bf.Placeables) {
-			end = len(bf.Placeables)
-		}
-		batch := &pgx.Batch{}
-		for i, pl := range bf.Placeables[start:end] {
-			transform := fmt.Sprintf("{%g,%g,%g,%g,%g,%g}",
-				float32(pl.X), float32(pl.Y), float32(pl.Z),
-				float32(pl.RX), float32(pl.RY), float32(pl.RZ))
-			placeableID := start + i + 1
-			if pl.PlaceableID != nil {
-				placeableID = *pl.PlaceableID
-			}
-			batch.Queue(`
-				INSERT INTO dune.building_blueprint_placeables
-					(building_blueprint_id, placeable_id, building_type, transform, hologram)
-				VALUES ($1, $2, $3, $4::real[], true)`,
-				blueprintID, placeableID, pl.BuildingType, transform)
-		}
-		br := tx.SendBatch(ctx, batch)
-		for i := start; i < end; i++ {
-			if _, err := br.Exec(); err != nil {
-				_ = br.Close()
-				return msgMutate{err: fmt.Errorf("insert placeable %d: %w", i, err)}
-			}
-		}
-		_ = br.Close()
+	if err := insertBlueprintPlaceables(ctx, tx, blueprintID, bf.Placeables); err != nil {
+		return msgMutate{err: err}
 	}
 
 	// Insert pentashield scale data.
-	for _, ps := range bf.Pentashields {
-		if _, err = tx.Exec(ctx, `
-			INSERT INTO dune.building_blueprint_pentashields
-				(building_blueprint_id, placeable_id, scale)
-			VALUES ($1, $2, ARRAY[$3,$4,$5]::smallint[])`,
-			blueprintID, ps.PlaceableID,
-			int16(ps.Scale[0]), int16(ps.Scale[1]), int16(ps.Scale[2])); err != nil {
-			return msgMutate{err: fmt.Errorf("insert pentashield %d: %w", ps.PlaceableID, err)}
-		}
+	if err := insertBlueprintPentashields(ctx, tx, blueprintID, bf.Pentashields); err != nil {
+		return msgMutate{err: err}
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/cmd/dune-admin/handlers_blueprints_fetch_test.go
+++ b/cmd/dune-admin/handlers_blueprints_fetch_test.go
@@ -1,0 +1,60 @@
+package main
+
+import "testing"
+
+func TestBuildBlueprintInstance(t *testing.T) {
+	t.Parallel()
+
+	instance, ok := buildBlueprintInstance(7, "TypeA", []float32{1, 2, 3, 4}, true)
+	if !ok {
+		t.Fatalf("expected valid transform to produce an instance")
+	}
+	if instance.InstanceID == nil || *instance.InstanceID != 7 {
+		t.Fatalf("unexpected instance id: %+v", instance.InstanceID)
+	}
+	if instance.BuildingType != "TypeA" || instance.X != 1 || instance.Y != 2 || instance.Z != 3 || instance.Rotation != 4 {
+		t.Fatalf("unexpected instance payload: %+v", instance)
+	}
+	if instance.ProvidesStability == nil || !*instance.ProvidesStability {
+		t.Fatalf("expected stability=true pointer in instance")
+	}
+
+	if _, ok := buildBlueprintInstance(1, "TypeB", []float32{1, 2, 3}, false); ok {
+		t.Fatalf("expected short transform to be rejected")
+	}
+}
+
+func TestBuildBlueprintPlaceable(t *testing.T) {
+	t.Parallel()
+
+	placeable, ok := buildBlueprintPlaceable(9, "TypeP", []float32{1, 2, 3, 4, 5, 6})
+	if !ok {
+		t.Fatalf("expected valid transform to produce a placeable")
+	}
+	if placeable.PlaceableID == nil || *placeable.PlaceableID != 9 {
+		t.Fatalf("unexpected placeable id: %+v", placeable.PlaceableID)
+	}
+	if placeable.BuildingType != "TypeP" || placeable.X != 1 || placeable.Y != 2 || placeable.Z != 3 || placeable.RX != 4 || placeable.RY != 5 || placeable.RZ != 6 {
+		t.Fatalf("unexpected placeable payload: %+v", placeable)
+	}
+
+	if _, ok := buildBlueprintPlaceable(1, "TypeBad", []float32{1, 2, 3, 4, 5}); ok {
+		t.Fatalf("expected short placeable transform to be rejected")
+	}
+}
+
+func TestBuildBlueprintPentashield(t *testing.T) {
+	t.Parallel()
+
+	pentashield, ok := buildBlueprintPentashield(11, []int16{10, 20, 30})
+	if !ok {
+		t.Fatalf("expected valid scale to produce pentashield")
+	}
+	if pentashield.PlaceableID != 11 || pentashield.Scale != [3]int{10, 20, 30} {
+		t.Fatalf("unexpected pentashield payload: %+v", pentashield)
+	}
+
+	if _, ok := buildBlueprintPentashield(1, []int16{1, 2}); ok {
+		t.Fatalf("expected short pentashield scale to be rejected")
+	}
+}

--- a/cmd/dune-admin/handlers_blueprints_import_test.go
+++ b/cmd/dune-admin/handlers_blueprints_import_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func boolPtr(v bool) *bool {
+	return &v
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func TestBlueprintItemStatsJSON(t *testing.T) {
+	withName := blueprintItemStatsJSON(123, "My Blueprint")
+	if !strings.Contains(withName, `"PlayerBlueprintId":"!!bbp#123"`) {
+		t.Fatalf("missing blueprint id in stats JSON: %s", withName)
+	}
+	if !strings.Contains(withName, `"BuildingBlueprintName":"My Blueprint"`) {
+		t.Fatalf("missing blueprint name in stats JSON: %s", withName)
+	}
+
+	withoutName := blueprintItemStatsJSON(77, "")
+	if strings.Contains(withoutName, "BuildingBlueprintName") {
+		t.Fatalf("expected no blueprint name when empty, got: %s", withoutName)
+	}
+}
+
+func TestResolveBlueprintImportInstance(t *testing.T) {
+	inst := blueprintInstance{
+		BuildingType: "Atreides_Outpost_Foundation",
+		X:            1,
+		Y:            2,
+		Z:            3,
+		Rotation:     90,
+	}
+	id, transform, stability := resolveBlueprintImportInstance(50, 2, inst)
+	if id != 53 {
+		t.Fatalf("expected fallback instance id 53, got %d", id)
+	}
+	if transform != "{1,2,3,90}" {
+		t.Fatalf("unexpected transform: %q", transform)
+	}
+	if !stability {
+		t.Fatal("expected structural building fallback to set stability=true")
+	}
+
+	customID := 900
+	inst.InstanceID = intPtr(customID)
+	inst.ProvidesStability = boolPtr(false)
+	id, _, stability = resolveBlueprintImportInstance(0, 0, inst)
+	if id != customID {
+		t.Fatalf("expected explicit instance id %d, got %d", customID, id)
+	}
+	if stability {
+		t.Fatal("expected explicit ProvidesStability override to win")
+	}
+}
+
+func TestResolveBlueprintImportPlaceable(t *testing.T) {
+	pl := blueprintPlaceable{
+		BuildingType: "SomePlaceable",
+		X:            4,
+		Y:            5,
+		Z:            6,
+		RX:           1,
+		RY:           2,
+		RZ:           3,
+	}
+	id, transform := resolveBlueprintImportPlaceable(10, 1, pl)
+	if id != 12 {
+		t.Fatalf("expected fallback placeable id 12, got %d", id)
+	}
+	if transform != "{4,5,6,1,2,3}" {
+		t.Fatalf("unexpected transform: %q", transform)
+	}
+
+	customID := 321
+	pl.PlaceableID = intPtr(customID)
+	id, _ = resolveBlueprintImportPlaceable(0, 0, pl)
+	if id != customID {
+		t.Fatalf("expected explicit placeable id %d, got %d", customID, id)
+	}
+}

--- a/cmd/dune-admin/handlers_config.go
+++ b/cmd/dune-admin/handlers_config.go
@@ -28,44 +28,42 @@ func handleGetConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleSaveConfig writes an updated config, then reconnects.
-func handleSaveConfig(w http.ResponseWriter, r *http.Request) {
-	var cfg appConfig
-	if err := decode(r, &cfg); err != nil {
-		jsonErr(w, fmt.Errorf("decode: %w", err), 400)
+func preserveMaskedDBPass(
+	cfg *appConfig,
+	readFile func(string) ([]byte, error),
+	path string,
+	fallback string,
+) {
+	if cfg.DBPass != "••••••••" {
 		return
 	}
-
-	// If the client sent back the masked placeholder, keep the existing password.
+	existing, err := readFile(path)
+	if err == nil {
+		var old appConfig
+		if yaml.Unmarshal(existing, &old) == nil && old.DBPass != "" {
+			cfg.DBPass = old.DBPass
+		}
+	}
 	if cfg.DBPass == "••••••••" {
-		existing, err := os.ReadFile(configPath())
-		if err == nil {
-			var old appConfig
-			if yaml.Unmarshal(existing, &old) == nil && old.DBPass != "" {
-				cfg.DBPass = old.DBPass
-			}
-		}
-		if cfg.DBPass == "••••••••" {
-			cfg.DBPass = dbPass // fall back to in-memory value
-		}
+		cfg.DBPass = fallback
 	}
+}
 
+func writeConfigFile(cfg appConfig) error {
 	if err := os.MkdirAll(configDir(), 0700); err != nil {
-		jsonErr(w, fmt.Errorf("create config dir: %w", err), 500)
-		return
+		return fmt.Errorf("create config dir: %w", err)
 	}
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
-		jsonErr(w, fmt.Errorf("marshal config: %w", err), 500)
-		return
+		return fmt.Errorf("marshal config: %w", err)
 	}
 	if err := os.WriteFile(configPath(), data, 0600); err != nil {
-		jsonErr(w, fmt.Errorf("write config: %w", err), 500)
-		return
+		return fmt.Errorf("write config: %w", err)
 	}
+	return nil
+}
 
-	// Apply the new values to globals so connectAll picks them up.
-	applyConfig(cfg)
-
+func resetRuntimeConnections() {
 	if globalDB != nil {
 		globalDB.Close()
 		globalDB = nil
@@ -76,6 +74,26 @@ func handleSaveConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	globalSSH = nil
 	globalControl = nil
+}
+
+func handleSaveConfig(w http.ResponseWriter, r *http.Request) {
+	var cfg appConfig
+	if err := decode(r, &cfg); err != nil {
+		jsonErr(w, fmt.Errorf("decode: %w", err), 400)
+		return
+	}
+
+	// If the client sent back the masked placeholder, keep the existing password.
+	preserveMaskedDBPass(&cfg, os.ReadFile, configPath(), dbPass)
+
+	if err := writeConfigFile(cfg); err != nil {
+		jsonErr(w, err, 500)
+		return
+	}
+
+	// Apply the new values to globals so connectAll picks them up.
+	applyConfig(cfg)
+	resetRuntimeConnections()
 
 	if err := connectAll(); err != nil {
 		jsonErr(w, fmt.Errorf("reconnect failed: %w", err), 500)

--- a/cmd/dune-admin/handlers_config_test.go
+++ b/cmd/dune-admin/handlers_config_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPreserveMaskedDBPass(t *testing.T) {
+	t.Parallel()
+
+	t.Run("keeps explicit password", func(t *testing.T) {
+		cfg := appConfig{DBPass: "new-pass"}
+		preserveMaskedDBPass(&cfg, func(string) ([]byte, error) {
+			t.Fatalf("readFile should not be called for explicit password")
+			return nil, nil
+		}, "/tmp/unused", "fallback")
+		if cfg.DBPass != "new-pass" {
+			t.Fatalf("expected explicit password to stay unchanged, got %q", cfg.DBPass)
+		}
+	})
+
+	t.Run("uses existing config password", func(t *testing.T) {
+		cfg := appConfig{DBPass: "••••••••"}
+		preserveMaskedDBPass(&cfg, func(string) ([]byte, error) {
+			return []byte("db_pass: stored-pass\n"), nil
+		}, "/tmp/config.yaml", "fallback")
+		if cfg.DBPass != "stored-pass" {
+			t.Fatalf("expected stored password from config file, got %q", cfg.DBPass)
+		}
+	})
+
+	t.Run("falls back to in-memory password", func(t *testing.T) {
+		cfg := appConfig{DBPass: "••••••••"}
+		preserveMaskedDBPass(&cfg, func(string) ([]byte, error) {
+			return nil, errors.New("no file")
+		}, "/tmp/missing.yaml", "fallback")
+		if cfg.DBPass != "fallback" {
+			t.Fatalf("expected fallback password, got %q", cfg.DBPass)
+		}
+	})
+}

--- a/cmd/dune-admin/handlers_market.go
+++ b/cmd/dune-admin/handlers_market.go
@@ -7,6 +7,86 @@ import (
 	"strings"
 )
 
+type marketItemsFilter struct {
+	search   string
+	category string
+	tier     *int
+	rarity   string
+	owner    string
+}
+
+func buildMarketItemsFilter(r *http.Request) marketItemsFilter {
+	q := r.URL.Query()
+	filter := marketItemsFilter{
+		search:   strings.ToLower(q.Get("search")),
+		category: q.Get("category"),
+		rarity:   strings.ToLower(q.Get("rarity")),
+		owner:    q.Get("owner"),
+	}
+	if tierStr := q.Get("tier"); tierStr != "" {
+		if tier, err := strconv.Atoi(tierStr); err == nil {
+			filter.tier = &tier
+		}
+	}
+	return filter
+}
+
+func marketItemMatchesFilter(it marketItem, filter marketItemsFilter) bool {
+	if filter.search != "" {
+		if !strings.Contains(strings.ToLower(it.DisplayName), filter.search) &&
+			!strings.Contains(strings.ToLower(it.TemplateID), filter.search) {
+			return false
+		}
+	}
+	if filter.category != "" && !strings.HasPrefix(it.Category, filter.category) {
+		return false
+	}
+	if filter.tier != nil && it.Tier != *filter.tier {
+		return false
+	}
+	if filter.rarity != "" && !strings.EqualFold(it.Rarity, filter.rarity) {
+		return false
+	}
+	if filter.owner == "bot" && it.BotStock == 0 {
+		return false
+	}
+	if filter.owner == "player" && (it.TotalStock-it.BotStock) == 0 {
+		return false
+	}
+	return true
+}
+
+func filterMarketItems(items []marketItem, filter marketItemsFilter) []marketItem {
+	filtered := make([]marketItem, 0, len(items))
+	for _, it := range items {
+		if marketItemMatchesFilter(it, filter) {
+			filtered = append(filtered, it)
+		}
+	}
+	return filtered
+}
+
+func marketItemsPagination(r *http.Request, total int) (start, end, page, limit int) {
+	q := r.URL.Query()
+	limit = 100
+	page = 0
+	if parsedLimit, err := strconv.Atoi(q.Get("limit")); err == nil && parsedLimit > 0 && parsedLimit <= 500 {
+		limit = parsedLimit
+	}
+	if parsedPage, err := strconv.Atoi(q.Get("page")); err == nil && parsedPage > 0 {
+		page = parsedPage
+	}
+	start = page * limit
+	end = start + limit
+	if start >= total {
+		start = total
+	}
+	if end > total {
+		end = total
+	}
+	return start, end, page, limit
+}
+
 // handleMarketItems returns all active exchange listings aggregated by template ID.
 // Query params: search, category, tier, rarity, owner (bot|player|all), page, limit.
 func handleMarketItems(w http.ResponseWriter, r *http.Request) {
@@ -25,59 +105,9 @@ func handleMarketItems(w http.ResponseWriter, r *http.Request) {
 		items = []marketItem{}
 	}
 
-	q := r.URL.Query()
-	search := strings.ToLower(q.Get("search"))
-	category := q.Get("category")
-	tierStr := q.Get("tier")
-	rarity := strings.ToLower(q.Get("rarity"))
-	owner := q.Get("owner") // "bot", "player", or "" for all
-
-	// Apply filters in Go — simpler than parameterised SQL for this aggregation query.
-	filtered := items[:0]
-	for _, it := range items {
-		if search != "" {
-			if !strings.Contains(strings.ToLower(it.DisplayName), search) &&
-				!strings.Contains(strings.ToLower(it.TemplateID), search) {
-				continue
-			}
-		}
-		if category != "" && !strings.HasPrefix(it.Category, category) {
-			continue
-		}
-		if tierStr != "" {
-			if t, err := strconv.Atoi(tierStr); err == nil && it.Tier != t {
-				continue
-			}
-		}
-		if rarity != "" && !strings.EqualFold(it.Rarity, rarity) {
-			continue
-		}
-		if owner == "bot" && it.BotStock == 0 {
-			continue
-		}
-		if owner == "player" && (it.TotalStock-it.BotStock) == 0 {
-			continue
-		}
-		filtered = append(filtered, it)
-	}
-
-	// Pagination.
-	limit := 100
-	page := 0
-	if l, err := strconv.Atoi(q.Get("limit")); err == nil && l > 0 && l <= 500 {
-		limit = l
-	}
-	if p, err := strconv.Atoi(q.Get("page")); err == nil && p > 0 {
-		page = p
-	}
-	start := page * limit
-	end := start + limit
-	if start >= len(filtered) {
-		start = len(filtered)
-	}
-	if end > len(filtered) {
-		end = len(filtered)
-	}
+	filter := buildMarketItemsFilter(r)
+	filtered := filterMarketItems(items, filter)
+	start, end, page, limit := marketItemsPagination(r, len(filtered))
 
 	jsonOK(w, map[string]any{
 		"items": filtered[start:end],

--- a/cmd/dune-admin/handlers_market_bot.go
+++ b/cmd/dune-admin/handlers_market_bot.go
@@ -1,95 +1,87 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
 )
 
-// botProxy forwards a request to the market bot API and returns the raw body.
-// Returns (body, statusCode, error).
-func botProxy(method, path string, body io.Reader) ([]byte, int, error) {
-	if marketBotAddr == "" {
-		return nil, 503, fmt.Errorf("market_bot_addr not configured")
-	}
-	req, err := http.NewRequestWithContext(context.Background(), method, marketBotAddr+path, body)
-	if err != nil {
-		return nil, 500, err
-	}
-	if marketBotToken != "" {
-		req.Header.Set("Authorization", "Bearer "+marketBotToken)
-	}
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req) // #nosec G704 -- marketBotAddr is admin-configured, not user-supplied
-	if err != nil {
-		return nil, 503, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	data, err := io.ReadAll(resp.Body)
-	return data, resp.StatusCode, err
-}
+// ── status ────────────────────────────────────────────────────────────────────
 
-// handleMarketBotStatus proxies GET /status from the bot API and injects a
-// "running" field (true when the bot responds, false when unreachable).
 func handleMarketBotStatus(w http.ResponseWriter, r *http.Request) {
-	data, _, err := botProxy(http.MethodGet, "/status", nil)
-	if err != nil {
-		// Bot is unreachable — return a minimal status rather than an error so
-		// the frontend can show a "stopped" state instead of an error banner.
-		jsonOK(w, map[string]any{"running": false, "error": err.Error()})
+	if embeddedBot == nil {
+		jsonOK(w, map[string]any{
+			"running": false,
+			"enabled": false,
+			"mode":    "embedded",
+			"error":   "embedded market bot is disabled; set market_bot_enabled: true and restart dune-admin",
+		})
 		return
 	}
-	var m map[string]any
-	if json.Unmarshal(data, &m) == nil {
-		m["running"] = true
-		jsonOK(w, m)
-		return
+	snap := embeddedBot.StatusSnapshot()
+	m, _ := json.Marshal(snap)
+	var out map[string]any
+	_ = json.Unmarshal(m, &out)
+	if out == nil {
+		out = map[string]any{}
 	}
-	// Passthrough if JSON parsing fails.
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(data) //nolint:errcheck
+	running := embeddedBot.Enabled()
+	out["running"] = running
+	out["enabled"] = running
+	out["mode"] = "embedded"
+	jsonOK(w, out)
 }
 
-// handleMarketBotConfig proxies GET/PUT /config from/to the bot API.
-// On a successful PUT the bot returns a short ack, not the updated config,
-// so we follow up with a GET and return the canonical config to the client.
+// ── config ────────────────────────────────────────────────────────────────────
+
 func handleMarketBotConfig(w http.ResponseWriter, r *http.Request) {
-	var body io.Reader
-	if r.Method == http.MethodPut {
-		body = r.Body
-	}
-	data, code, err := botProxy(r.Method, "/config", body)
-	if err != nil {
-		jsonErr(w, err, code)
+	if embeddedBot == nil {
+		jsonErr(w, fmt.Errorf("embedded market bot is disabled"), http.StatusServiceUnavailable)
 		return
 	}
-	if r.Method == http.MethodPut && code == http.StatusOK {
-		if cfgData, _, cfgErr := botProxy(http.MethodGet, "/config", nil); cfgErr == nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(cfgData) //nolint:errcheck
+	switch r.Method {
+	case http.MethodGet:
+		data, err := embeddedBot.ConfigJSON()
+		if err != nil {
+			jsonErr(w, err, 500)
 			return
 		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data) //nolint:errcheck
+		return
+	case http.MethodPut:
+		var patch map[string]json.RawMessage
+		if err := decode(r, &patch); err != nil {
+			jsonErr(w, err, 400)
+			return
+		}
+		if err := embeddedBot.ApplyConfig(patch); err != nil {
+			jsonErr(w, err, 400)
+			return
+		}
+		data, err := embeddedBot.ConfigJSON()
+		if err != nil {
+			jsonErr(w, err, 500)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data) //nolint:errcheck
+		return
+	default:
+		jsonErr(w, fmt.Errorf("method not allowed"), http.StatusMethodNotAllowed)
+		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(code)
-	w.Write(data) //nolint:errcheck
 }
+
+// ── lifecycle exec ────────────────────────────────────────────────────────────
 
 var botCmdAllowlist = map[string]bool{
 	"start": true, "stop": true, "restart": true,
 }
 
-// handleMarketBotExec runs a lifecycle command (start/stop/restart) on the bot
-// using the configured control plane.
 func handleMarketBotExec(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Cmd string `json:"cmd"`
@@ -102,86 +94,44 @@ func handleMarketBotExec(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, fmt.Errorf("unknown command %q", req.Cmd), 400)
 		return
 	}
-	if globalExecutor == nil {
-		jsonErr(w, fmt.Errorf("not connected"), 503)
-		return
-	}
-	if marketBotContainer == "" {
-		jsonErr(w, fmt.Errorf("market_bot_container not configured"), 503)
-		return
-	}
 
-	out, err := execBotCommand(r.Context(), req.Cmd)
-	if err != nil {
-		jsonErr(w, fmt.Errorf("exec: %w — output: %s", err, out), 500)
+	if embeddedBot == nil {
+		jsonErr(w, fmt.Errorf("embedded market bot is disabled"), http.StatusServiceUnavailable)
 		return
 	}
-	jsonOK(w, map[string]string{"output": out})
+	output := "ok"
+	switch req.Cmd {
+	case "start":
+		embeddedBot.Resume()
+		output = "resumed"
+	case "stop":
+		embeddedBot.Pause()
+		output = "paused"
+	case "restart":
+		if err := embeddedBot.Restart(r.Context()); err != nil {
+			jsonErr(w, err, 500)
+			return
+		}
+		output = "restarted"
+	}
+	jsonOK(w, map[string]string{"output": output})
 }
 
-// execBotCommand runs start/stop/restart on the bot container/deployment.
-func execBotCommand(ctx context.Context, cmd string) (string, error) {
-	if globalControl == nil {
-		return "", fmt.Errorf("not connected")
-	}
-	switch globalControl.Name() {
-	case "kubectl":
-		ns := marketBotNamespace
-		if ns == "" {
-			ns = "default"
-		}
-		switch cmd {
-		case "start":
-			return globalExecutor.Exec(fmt.Sprintf("sudo kubectl scale deployment/%s -n %s --replicas=1 2>&1", marketBotContainer, ns))
-		case "stop":
-			return globalExecutor.Exec(fmt.Sprintf("sudo kubectl scale deployment/%s -n %s --replicas=0 2>&1", marketBotContainer, ns))
-		case "restart":
-			return globalExecutor.Exec(fmt.Sprintf("sudo kubectl rollout restart deployment/%s -n %s 2>&1", marketBotContainer, ns))
-		}
-	case "docker":
-		return globalExecutor.Exec(fmt.Sprintf("docker %s %s 2>&1", cmd, marketBotContainer))
-	}
-	return "", fmt.Errorf("lifecycle commands not supported for %s control plane", globalControl.Name())
-}
+// ── log streaming ─────────────────────────────────────────────────────────────
 
-// handleMarketBotLogsReady returns whether log streaming is available and why not if not.
-// The WebSocket client calls this first so it can surface HTTP error bodies
-// (which browsers don't expose on WS connection failure).
 func handleMarketBotLogsReady(w http.ResponseWriter, r *http.Request) {
-	if globalControl == nil || globalExecutor == nil {
-		jsonOK(w, map[string]any{"ready": false, "reason": "not connected to server"})
+	if embeddedBot == nil {
+		jsonOK(w, map[string]any{"ready": false, "mode": "embedded", "reason": "embedded market bot is disabled"})
 		return
 	}
-	if marketBotContainer == "" {
-		jsonOK(w, map[string]any{"ready": false, "reason": "market_bot_container not configured"})
-		return
-	}
-	ns, name, err := botLogSource(r.Context())
-	if err != nil {
-		jsonOK(w, map[string]any{"ready": false, "reason": err.Error()})
-		return
-	}
-	jsonOK(w, map[string]any{"ready": true, "namespace": ns, "name": name})
+	jsonOK(w, map[string]any{"ready": true, "mode": "embedded"})
 }
 
-// handleMarketBotLogs streams bot container logs over WebSocket.
-// It discovers the bot pod (kubectl) or uses the container name directly (docker).
 func handleMarketBotLogs(w http.ResponseWriter, r *http.Request) {
-	if globalControl == nil || globalExecutor == nil {
-		http.Error(w, "not connected", http.StatusServiceUnavailable)
+	if embeddedBot == nil {
+		http.Error(w, "embedded market bot is disabled", http.StatusServiceUnavailable)
 		return
 	}
-	if marketBotContainer == "" {
-		http.Error(w, "market_bot_container not configured", http.StatusServiceUnavailable)
-		return
-	}
-
-	ns, name, err := botLogSource(r.Context())
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
-		return
-	}
-
 	conn, err := wsUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return
@@ -189,57 +139,19 @@ func handleMarketBotLogs(w http.ResponseWriter, r *http.Request) {
 	defer func() { _ = conn.Close() }()
 	_ = conn.SetWriteDeadline(time.Time{})
 
-	ch, cancel, err := globalControl.StreamLog(r.Context(), globalExecutor, ns, name)
-	if err != nil {
-		conn.WriteMessage(websocket.TextMessage, []byte("error: "+err.Error())) //nolint:errcheck
-		return
-	}
-	defer cancel()
-
-	for line := range ch {
-		if err := conn.WriteMessage(websocket.TextMessage, []byte(line)); err != nil {
+	ch := embeddedBot.Sink.Subscribe()
+	defer embeddedBot.Sink.Unsubscribe(ch)
+	for {
+		select {
+		case line, ok := <-ch:
+			if !ok {
+				return
+			}
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(line)); err != nil {
+				return
+			}
+		case <-r.Context().Done():
 			return
 		}
-	}
-}
-
-// botLogSource returns the namespace and pod/container name for log streaming.
-func botLogSource(ctx context.Context) (ns, name string, err error) {
-	switch globalControl.Name() {
-	case "kubectl":
-		botNS := marketBotNamespace
-		if botNS == "" {
-			botNS = "default"
-		}
-		// Try label selector matching deployment name first (most accurate).
-		labelSel := ""
-		if marketBotContainer != "" {
-			labelSel = fmt.Sprintf(" -l app=%s", marketBotContainer)
-		}
-		out, execErr := globalExecutor.Exec(fmt.Sprintf(
-			"sudo kubectl get pods -n %s%s --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}' 2>/dev/null",
-			botNS, labelSel))
-		pod := strings.TrimSpace(strings.Trim(out, "'"))
-		if execErr != nil || pod == "" {
-			// Retry without Running filter — pod might be initialising.
-			out, _ = globalExecutor.Exec(fmt.Sprintf(
-				"sudo kubectl get pods -n %s%s -o jsonpath='{.items[0].metadata.name}' 2>/dev/null",
-				botNS, labelSel))
-			pod = strings.TrimSpace(strings.Trim(out, "'"))
-		}
-		if execErr != nil || pod == "" {
-			// Last resort: any pod in namespace, no label filter.
-			out, _ = globalExecutor.Exec(fmt.Sprintf(
-				"sudo kubectl get pods -n %s -o jsonpath='{.items[0].metadata.name}' 2>/dev/null",
-				botNS))
-			pod = strings.TrimSpace(strings.Trim(out, "'"))
-		}
-		if pod == "" {
-			return "", "", fmt.Errorf("no running pod found in namespace %s (deployment: %s)", botNS, marketBotContainer)
-		}
-		return botNS, pod, nil
-	default:
-		// docker/local: container name is used directly.
-		return "", marketBotContainer, nil
 	}
 }

--- a/cmd/dune-admin/handlers_market_items_test.go
+++ b/cmd/dune-admin/handlers_market_items_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBuildMarketItemsFilter(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest("GET", "/api/v1/market/items?search=Spice&category=resources&tier=3&rarity=rare&owner=bot", nil)
+	filter := buildMarketItemsFilter(r)
+
+	if filter.search != "spice" || filter.category != "resources" || filter.rarity != "rare" || filter.owner != "bot" {
+		t.Fatalf("unexpected filter fields: %+v", filter)
+	}
+	if filter.tier == nil || *filter.tier != 3 {
+		t.Fatalf("expected tier=3, got %+v", filter.tier)
+	}
+
+	rInvalid := httptest.NewRequest("GET", "/api/v1/market/items?tier=not-a-number", nil)
+	filter = buildMarketItemsFilter(rInvalid)
+	if filter.tier != nil {
+		t.Fatalf("expected invalid tier to be ignored, got %+v", filter.tier)
+	}
+}
+
+func TestMarketItemMatchesFilter(t *testing.T) {
+	t.Parallel()
+
+	item := marketItem{
+		TemplateID:  "Dune.Spice.Raw",
+		DisplayName: "Raw Spice",
+		Category:    "resources/spice",
+		Tier:        3,
+		Rarity:      "Rare",
+		TotalStock:  12,
+		BotStock:    2,
+	}
+
+	if !marketItemMatchesFilter(item, marketItemsFilter{search: "spice"}) {
+		t.Fatal("expected search filter to match")
+	}
+	if marketItemMatchesFilter(item, marketItemsFilter{search: "water"}) {
+		t.Fatal("expected non-matching search to fail")
+	}
+	if marketItemMatchesFilter(item, marketItemsFilter{category: "weapons"}) {
+		t.Fatal("expected non-matching category to fail")
+	}
+	if marketItemMatchesFilter(item, marketItemsFilter{owner: "player", tier: intRef(4)}) {
+		t.Fatal("expected tier mismatch to fail")
+	}
+	if !marketItemMatchesFilter(item, marketItemsFilter{owner: "player"}) {
+		t.Fatal("expected player-owner filter to match when player stock exists")
+	}
+}
+
+func TestFilterMarketItems(t *testing.T) {
+	t.Parallel()
+
+	items := []marketItem{
+		{TemplateID: "A", DisplayName: "Alpha", Category: "cat/a", TotalStock: 5, BotStock: 0},
+		{TemplateID: "B", DisplayName: "Bravo", Category: "cat/b", TotalStock: 5, BotStock: 5},
+	}
+	filtered := filterMarketItems(items, marketItemsFilter{owner: "player"})
+	if len(filtered) != 1 || filtered[0].TemplateID != "A" {
+		t.Fatalf("unexpected filtered items: %#v", filtered)
+	}
+}
+
+func TestMarketItemsPagination(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest("GET", "/api/v1/market/items?page=2&limit=3", nil)
+	start, end, page, limit := marketItemsPagination(r, 8)
+	if start != 6 || end != 8 || page != 2 || limit != 3 {
+		t.Fatalf("unexpected pagination: start=%d end=%d page=%d limit=%d", start, end, page, limit)
+	}
+
+	rDefault := httptest.NewRequest("GET", "/api/v1/market/items?page=-1&limit=9999", nil)
+	start, end, page, limit = marketItemsPagination(rDefault, 4)
+	if start != 0 || end != 4 || page != 0 || limit != 100 {
+		t.Fatalf("unexpected default pagination: start=%d end=%d page=%d limit=%d", start, end, page, limit)
+	}
+}
+
+func intRef(v int) *int {
+	return &v
+}

--- a/cmd/dune-admin/handlers_players.go
+++ b/cmd/dune-admin/handlers_players.go
@@ -227,52 +227,68 @@ func handleGiveItem(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]any{"ok": msg.ok, "path": "db"})
 }
 
-func handleGiveItems(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		PlayerID int64 `json:"player_id"`
-		Items    []struct {
-			Template string `json:"template"`
-			Qty      int64  `json:"qty"`
-			Quality  int64  `json:"quality"`
-		} `json:"items"`
-	}
-	if err := decode(r, &req); err != nil {
-		jsonErr(w, err, 400)
-		return
-	}
-	type skippedItem struct {
-		Template string `json:"template"`
-		Reason   string `json:"reason"`
-	}
-	given := []string{}
-	skipped := []skippedItem{}
+type giveItemInput struct {
+	Template string `json:"template"`
+	Qty      int64  `json:"qty"`
+	Quality  int64  `json:"quality"`
+}
 
-	ctx := context.Background()
-	// Determine path once for all items in the batch.
-	online := req.PlayerID != 0 && checkPlayerOffline(ctx, req.PlayerID) != nil
-	var flsID string
-	if online {
-		var err error
-		flsID, err = flsIDFromActorID(ctx, req.PlayerID)
-		if err != nil {
-			online = false // fall back to DB path if FLS ID resolution fails
-		}
-	}
+type giveItemsRequest struct {
+	PlayerID int64           `json:"player_id"`
+	Items    []giveItemInput `json:"items"`
+}
 
+type skippedItem struct {
+	Template string `json:"template"`
+	Reason   string `json:"reason"`
+}
+
+type giveItemsDeps struct {
+	checkCapacity func(context.Context, int64, string, int64) error
+	rmqAdd        func(string, string, int, float64) error
+	dbGive        func(int64, string, int64, int64) (msgMutate, bool)
+}
+
+func resolveGiveItemsOnlinePath(
+	ctx context.Context,
+	playerID int64,
+	isOffline func(context.Context, int64) error,
+	resolveFLS func(context.Context, int64) (string, error),
+) (bool, string) {
+	online := playerID != 0 && isOffline(ctx, playerID) != nil
+	if !online {
+		return false, ""
+	}
+	flsID, err := resolveFLS(ctx, playerID)
+	if err != nil {
+		return false, ""
+	}
+	return true, flsID
+}
+
+func processGiveItems(
+	ctx context.Context,
+	req giveItemsRequest,
+	online bool,
+	flsID string,
+	deps giveItemsDeps,
+) ([]string, []skippedItem) {
+	given := make([]string, 0, len(req.Items))
+	skipped := make([]skippedItem, 0)
 	for _, item := range req.Items {
 		if online && item.Quality == 0 {
-			if err := checkInventoryCapacity(ctx, req.PlayerID, item.Template, item.Qty); err != nil {
+			if err := deps.checkCapacity(ctx, req.PlayerID, item.Template, item.Qty); err != nil {
 				skipped = append(skipped, skippedItem{Template: item.Template, Reason: err.Error()})
 				continue
 			}
-			if err := rmqAddItemToInventory(flsID, item.Template, int(item.Qty), 1.0); err != nil {
+			if err := deps.rmqAdd(flsID, item.Template, int(item.Qty), 1.0); err != nil {
 				skipped = append(skipped, skippedItem{Template: item.Template, Reason: err.Error()})
 				continue
 			}
 			given = append(given, item.Template)
 			continue
 		}
-		msg, ok := cmdGiveItem(req.PlayerID, item.Template, item.Qty, item.Quality)().(msgMutate)
+		msg, ok := deps.dbGive(req.PlayerID, item.Template, item.Qty, item.Quality)
 		if !ok || msg.err != nil {
 			reason := "internal error"
 			if ok && msg.err != nil {
@@ -283,6 +299,26 @@ func handleGiveItems(w http.ResponseWriter, r *http.Request) {
 		}
 		given = append(given, item.Template)
 	}
+	return given, skipped
+}
+
+func handleGiveItems(w http.ResponseWriter, r *http.Request) {
+	var req giveItemsRequest
+	if err := decode(r, &req); err != nil {
+		jsonErr(w, err, 400)
+		return
+	}
+	ctx := context.Background()
+	online, flsID := resolveGiveItemsOnlinePath(ctx, req.PlayerID, checkPlayerOffline, flsIDFromActorID)
+	given, skipped := processGiveItems(ctx, req, online, flsID, giveItemsDeps{
+		checkCapacity: checkInventoryCapacity,
+		rmqAdd:        rmqAddItemToInventory,
+		dbGive: func(playerID int64, template string, qty, quality int64) (msgMutate, bool) {
+			msg, ok := cmdGiveItem(playerID, template, qty, quality)().(msgMutate)
+			return msg, ok
+		},
+	})
+
 	jsonOK(w, map[string]any{"given": given, "skipped": skipped})
 }
 

--- a/cmd/dune-admin/handlers_players_give_items_test.go
+++ b/cmd/dune-admin/handlers_players_give_items_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestResolveGiveItemsOnlinePath(t *testing.T) {
+	t.Parallel()
+
+	offline := func(context.Context, int64) error { return nil }
+	online := func(context.Context, int64) error { return errors.New("online") }
+	resolve := func(context.Context, int64) (string, error) { return "fls-123", nil }
+	failResolve := func(context.Context, int64) (string, error) { return "", errors.New("boom") }
+
+	if on, fls := resolveGiveItemsOnlinePath(context.Background(), 0, online, resolve); on || fls != "" {
+		t.Fatalf("expected playerID=0 to force DB path, got on=%v fls=%q", on, fls)
+	}
+	if on, fls := resolveGiveItemsOnlinePath(context.Background(), 42, offline, resolve); on || fls != "" {
+		t.Fatalf("expected offline player to use DB path, got on=%v fls=%q", on, fls)
+	}
+	if on, fls := resolveGiveItemsOnlinePath(context.Background(), 42, online, resolve); !on || fls != "fls-123" {
+		t.Fatalf("expected online RMQ path with fls id, got on=%v fls=%q", on, fls)
+	}
+	if on, fls := resolveGiveItemsOnlinePath(context.Background(), 42, online, failResolve); on || fls != "" {
+		t.Fatalf("expected FLS resolve failure to fall back to DB, got on=%v fls=%q", on, fls)
+	}
+}
+
+func TestProcessGiveItems(t *testing.T) {
+	t.Parallel()
+
+	req := giveItemsRequest{
+		PlayerID: 11,
+		Items: []giveItemInput{
+			{Template: "A", Qty: 2, Quality: 0},
+			{Template: "B", Qty: 1, Quality: 5},
+			{Template: "C", Qty: 1, Quality: 0},
+		},
+	}
+
+	var rmqSent []string
+	given, skipped := processGiveItems(context.Background(), req, true, "fls-123", giveItemsDeps{
+		checkCapacity: func(_ context.Context, _ int64, template string, _ int64) error {
+			if template == "C" {
+				return errors.New("inventory full")
+			}
+			return nil
+		},
+		rmqAdd: func(_ string, template string, _ int, _ float64) error {
+			rmqSent = append(rmqSent, template)
+			return nil
+		},
+		dbGive: func(_ int64, template string, _, _ int64) (msgMutate, bool) {
+			if template != "B" {
+				t.Fatalf("unexpected DB call for template %q", template)
+			}
+			return msgMutate{ok: "done"}, true
+		},
+	})
+
+	if len(given) != 2 || given[0] != "A" || given[1] != "B" {
+		t.Fatalf("unexpected given: %v", given)
+	}
+	if len(skipped) != 1 || skipped[0].Template != "C" || skipped[0].Reason != "inventory full" {
+		t.Fatalf("unexpected skipped: %+v", skipped)
+	}
+	if len(rmqSent) != 1 || rmqSent[0] != "A" {
+		t.Fatalf("unexpected RMQ calls: %v", rmqSent)
+	}
+}
+
+func TestProcessGiveItems_DBFailureReasons(t *testing.T) {
+	t.Parallel()
+
+	req := giveItemsRequest{
+		PlayerID: 11,
+		Items: []giveItemInput{
+			{Template: "X", Qty: 1, Quality: 9},
+			{Template: "Y", Qty: 1, Quality: 9},
+		},
+	}
+
+	given, skipped := processGiveItems(context.Background(), req, false, "", giveItemsDeps{
+		checkCapacity: func(context.Context, int64, string, int64) error { return nil },
+		rmqAdd:        func(string, string, int, float64) error { return nil },
+		dbGive: func(_ int64, template string, _, _ int64) (msgMutate, bool) {
+			if template == "X" {
+				return msgMutate{}, false
+			}
+			return msgMutate{err: errors.New("db failed")}, true
+		},
+	})
+
+	if len(given) != 0 {
+		t.Fatalf("expected no successful grants, got %v", given)
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("expected two skipped items, got %+v", skipped)
+	}
+	if skipped[0].Template != "X" || skipped[0].Reason != "internal error" {
+		t.Fatalf("unexpected first skipped entry: %+v", skipped[0])
+	}
+	if skipped[1].Template != "Y" || skipped[1].Reason != "db failed" {
+		t.Fatalf("unexpected second skipped entry: %+v", skipped[1])
+	}
+}

--- a/cmd/dune-admin/handlers_server_settings.go
+++ b/cmd/dune-admin/handlers_server_settings.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"os"
+	pathpkg "path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -379,9 +380,10 @@ func readDefaultINIContent(iniDir, filename string) string {
 // discoverDefaultINI does the actual multi-strategy search for a Default INI
 // file. Search order:
 //  1. Configured default_ini_dir (local read or via executor)
-//  2. Common host paths — /home, /root, /dune first, then k3s containerd layers
-//  3. Relative path traversal from iniDir (Hyper-V / bare-metal layouts)
-//  4. kubectl/docker exec into the game container (requires pod running)
+//  2. If iniDir is k8s://..., derive nearby Config paths in the same pod
+//  3. Common host paths — /home, /root, /dune first, then k3s containerd layers
+//  4. Relative path traversal from iniDir (Hyper-V / bare-metal layouts)
+//  5. kubectl/docker exec into the game container (requires pod running)
 func discoverDefaultINI(iniDir, filename string) string {
 	// 1. Explicit config path.
 	if loadedConfig.DefaultIniDir != "" {
@@ -391,6 +393,25 @@ func discoverDefaultINI(iniDir, filename string) string {
 		}
 		if c := readINIContent(p); c != "" {
 			return c
+		}
+	}
+
+	// 1b. When INI dir points to a k8s pod path, derive nearby Config paths in
+	// the same pod first. This is the most reliable source in deployed mode.
+	if ns, pod, inPodDir, ok := parseK8sINIPath(iniDir); ok {
+		candidates := []string{
+			pathpkg.Clean(pathpkg.Join(inPodDir, "..", "..", "..", "Config", filename)),
+			pathpkg.Clean(pathpkg.Join(inPodDir, "..", "..", "Config", filename)),
+			pathpkg.Clean(pathpkg.Join(inPodDir, "..", "..", "..", "..", "Config", filename)),
+			"/DuneSandbox/Config/" + filename,
+			"/home/dune/server/DuneSandbox/Config/" + filename,
+			"/home/dune/DuneSandbox/Config/" + filename,
+			"/game/DuneSandbox/Config/" + filename,
+		}
+		for _, inPodPath := range candidates {
+			if c := readINIContent(fmt.Sprintf("k8s://%s/%s%s", ns, pod, inPodPath)); c != "" {
+				return c
+			}
 		}
 	}
 
@@ -442,15 +463,59 @@ func discoverDefaultINI(iniDir, filename string) string {
 	return ""
 }
 
+func parseK8sINIPath(path string) (ns, pod, inPodPath string, ok bool) {
+	const prefix = "k8s://"
+	if !strings.HasPrefix(path, prefix) {
+		return "", "", "", false
+	}
+	rest := strings.TrimPrefix(path, prefix)
+	parts := strings.SplitN(rest, "/", 3)
+	if len(parts) < 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", "", false
+	}
+	ns, pod, inPodPath = parts[0], parts[1], "/"+strings.TrimLeft(parts[2], "/")
+	return ns, pod, inPodPath, true
+}
+
 func readINIContent(path string) string {
 	if globalExecutor == nil {
 		return ""
+	}
+	if ns, pod, inPodPath, ok := parseK8sINIPath(path); ok {
+		kctl := kubectlCLI(globalExecutor)
+		out, err := globalExecutor.Exec(fmt.Sprintf(
+			"%s exec -n %s %s -- cat %s 2>/dev/null",
+			kctl, ns, pod, shellQuote(inPodPath)))
+		if err != nil {
+			return ""
+		}
+		return out
 	}
 	out, err := globalExecutor.Exec(fmt.Sprintf("sudo cat %s 2>/dev/null", shellQuote(path)))
 	if err != nil {
 		return ""
 	}
 	return out
+}
+
+func writeINIContent(path, body string) error {
+	if globalExecutor == nil {
+		return fmt.Errorf("not connected")
+	}
+	if ns, pod, inPodPath, ok := parseK8sINIPath(path); ok {
+		kctl := kubectlCLI(globalExecutor)
+		payload := base64.StdEncoding.EncodeToString([]byte(body))
+		cmd := fmt.Sprintf(
+			"echo %s | base64 -d | %s exec -i -n %s %s -- sh -lc 'cat > %s' 2>/dev/null",
+			shellQuote(payload), kctl, ns, pod, shellQuote(inPodPath),
+		)
+		out, err := globalExecutor.Exec(cmd)
+		if err != nil {
+			return fmt.Errorf("write %s: %w — %s", inPodPath, err, strings.TrimSpace(out))
+		}
+		return nil
+	}
+	return globalExecutor.WriteFile(path, strings.NewReader(body))
 }
 
 func handleGetServerSettings(w http.ResponseWriter, r *http.Request) {
@@ -1031,7 +1096,7 @@ func handleUpdateServerSettings(w http.ResponseWriter, r *http.Request) {
 			jsonErr(w, fmt.Errorf("UserGame.ini: %w", err), 409)
 			return
 		}
-		if err := globalExecutor.WriteFile(path, strings.NewReader(body)); err != nil {
+		if err := writeINIContent(path, body); err != nil {
 			jsonErr(w, fmt.Errorf("write UserGame.ini: %w", err), 500)
 			return
 		}
@@ -1043,7 +1108,7 @@ func handleUpdateServerSettings(w http.ResponseWriter, r *http.Request) {
 			jsonErr(w, fmt.Errorf("UserEngine.ini: %w", err), 409)
 			return
 		}
-		if err := globalExecutor.WriteFile(path, strings.NewReader(body)); err != nil {
+		if err := writeINIContent(path, body); err != nil {
 			jsonErr(w, fmt.Errorf("write UserEngine.ini: %w", err), 500)
 			return
 		}
@@ -1094,9 +1159,7 @@ func handleUpdateRawSection(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var buf bytes.Buffer
-	buf.WriteString(updated)
-	if err := globalExecutor.WriteFile(filePath, &buf); err != nil {
+	if err := writeINIContent(filePath, updated); err != nil {
 		jsonErr(w, fmt.Errorf("write %s: %w", filePath, err), 500)
 		return
 	}

--- a/cmd/dune-admin/handlers_server_settings.go
+++ b/cmd/dune-admin/handlers_server_settings.go
@@ -203,45 +203,82 @@ func parseINILines(content, source string, schemaKeys map[string]bool) []RawSect
 
 	for _, raw := range strings.Split(content, "\n") {
 		line := strings.TrimSpace(raw)
-		if line == "" || strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#") {
+		if shouldSkipINILine(line) {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			curSec = line[1 : len(line)-1]
-			if _, ok := secMap[curSec]; !ok {
-				secMap[curSec] = len(result)
-				result = append(result, RawSection{Section: curSec, Source: source})
-			}
+		if section, ok := parseINISectionHeader(line); ok {
+			curSec = section
+			ensureRawSectionIndex(curSec, source, secMap, &result)
 			continue
 		}
 		if curSec == "" {
 			continue
 		}
-		prefix, rest := "", line
-		if len(line) > 0 && (line[0] == '+' || line[0] == '-') {
-			prefix = string(line[0])
-			rest = line[1:]
-		}
-		eq := strings.Index(rest, "=")
-		if eq <= 0 {
+		rawLine, ok := parseRawINILine(line)
+		if !ok {
 			continue
 		}
-		key := strings.TrimSpace(rest[:eq])
-		value := strings.TrimSpace(rest[eq+1:])
-
-		// Include if it's an array line OR the key is not in the schema.
-		if prefix != "" || !schemaKeys[curSec+"|"+key] {
-			idx := secMap[curSec]
-			result[idx].Lines = append(result[idx].Lines, RawLine{Prefix: prefix, Key: key, Value: value})
+		if shouldIncludeRawLine(curSec, rawLine, schemaKeys) {
+			idx := ensureRawSectionIndex(curSec, source, secMap, &result)
+			result[idx].Lines = append(result[idx].Lines, rawLine)
 		}
 	}
 
-	// Drop sections with no lines.
+	return compactRawSections(result)
+}
+
+func shouldSkipINILine(line string) bool {
+	return line == "" || strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#")
+}
+
+func parseINISectionHeader(line string) (string, bool) {
+	if !strings.HasPrefix(line, "[") || !strings.HasSuffix(line, "]") {
+		return "", false
+	}
+	return line[1 : len(line)-1], true
+}
+
+func parseRawINILine(line string) (RawLine, bool) {
+	prefix, rest := "", line
+	if line[0] == '+' || line[0] == '-' {
+		prefix = string(line[0])
+		rest = line[1:]
+	}
+	eq := strings.Index(rest, "=")
+	if eq <= 0 {
+		return RawLine{}, false
+	}
+	return RawLine{
+		Prefix: prefix,
+		Key:    strings.TrimSpace(rest[:eq]),
+		Value:  strings.TrimSpace(rest[eq+1:]),
+	}, true
+}
+
+func shouldIncludeRawLine(section string, line RawLine, schemaKeys map[string]bool) bool {
+	if line.Prefix != "" {
+		return true
+	}
+	return !schemaKeys[section+"|"+line.Key]
+}
+
+func ensureRawSectionIndex(section, source string, secMap map[string]int, result *[]RawSection) int {
+	if idx, ok := secMap[section]; ok {
+		return idx
+	}
+	idx := len(*result)
+	secMap[section] = idx
+	*result = append(*result, RawSection{Section: section, Source: source})
+	return idx
+}
+
+func compactRawSections(result []RawSection) []RawSection {
 	out := result[:0]
-	for _, s := range result {
-		if len(s.Lines) > 0 {
-			out = append(out, s)
+	for _, section := range result {
+		if len(section.Lines) == 0 {
+			continue
 		}
+		out = append(out, section)
 	}
 	return out
 }
@@ -384,72 +421,122 @@ func readDefaultINIContent(iniDir, filename string) string {
 //  3. Common host paths — /home, /root, /dune first, then k3s containerd layers
 //  4. Relative path traversal from iniDir (Hyper-V / bare-metal layouts)
 //  5. kubectl/docker exec into the game container (requires pod running)
+func configuredDefaultINIPath(filename string) string {
+	if loadedConfig.DefaultIniDir == "" {
+		return ""
+	}
+	return filepath.Join(loadedConfig.DefaultIniDir, filename)
+}
+
+func k8sDerivedDefaultINICandidates(inPodDir, filename string) []string {
+	return []string{
+		pathpkg.Clean(pathpkg.Join(inPodDir, "..", "..", "..", "Config", filename)),
+		pathpkg.Clean(pathpkg.Join(inPodDir, "..", "..", "Config", filename)),
+		pathpkg.Clean(pathpkg.Join(inPodDir, "..", "..", "..", "..", "Config", filename)),
+		"/DuneSandbox/Config/" + filename,
+		"/home/dune/server/DuneSandbox/Config/" + filename,
+		"/home/dune/DuneSandbox/Config/" + filename,
+		"/game/DuneSandbox/Config/" + filename,
+	}
+}
+
+func hostDefaultINICandidates(filename string) []string {
+	return []string{
+		"/home/dune/" + filename,
+		"/home/" + filename,
+		"/root/" + filename,
+		"/dune/" + filename,
+		"/home/dune/server/DuneSandbox/Config/" + filename,
+	}
+}
+
+func relativeDefaultINICandidates(iniDir, filename string) []string {
+	return []string{
+		filepath.Join(iniDir, "..", "..", "..", "Config", filename),
+		filepath.Join(iniDir, "..", "..", "Config", filename),
+		filepath.Join(iniDir, "..", "..", "..", "..", "Config", filename),
+	}
+}
+
+func discoverViaConfiguredPath(filename string) string {
+	path := configuredDefaultINIPath(filename)
+	if path == "" {
+		return ""
+	}
+	if data, err := os.ReadFile(path); err == nil && len(data) > 0 {
+		return string(data)
+	}
+	return readINIContent(path)
+}
+
+func discoverViaK8sDerivedPath(iniDir, filename string) string {
+	ns, pod, inPodDir, ok := parseK8sINIPath(iniDir)
+	if !ok {
+		return ""
+	}
+	for _, inPodPath := range k8sDerivedDefaultINICandidates(inPodDir, filename) {
+		if content := readINIContent(fmt.Sprintf("k8s://%s/%s%s", ns, pod, inPodPath)); content != "" {
+			return content
+		}
+	}
+	return ""
+}
+
+func discoverViaHostPaths(filename string) string {
+	for _, path := range hostDefaultINICandidates(filename) {
+		if content := readINIContent(path); content != "" {
+			return content
+		}
+	}
+	return ""
+}
+
+func discoverViaHostFind(filename string) string {
+	out, _ := globalExecutor.Exec(fmt.Sprintf(
+		"sudo find /home /root /dune /run/k3s/containerd /var/lib/rancher/k3s/agent/containerd"+
+			" -maxdepth 10 -name %s -not -path '*/Saved/*' -not -path '*/saved/*' 2>/dev/null | head -1",
+		shellQuote(filename)))
+	if path := strings.TrimSpace(out); path != "" {
+		return readINIContent(path)
+	}
+	return ""
+}
+
+func discoverViaRelativePath(iniDir, filename string) string {
+	for _, path := range relativeDefaultINICandidates(iniDir, filename) {
+		if content := readINIContent(path); content != "" {
+			return content
+		}
+	}
+	return ""
+}
+
 func discoverDefaultINI(iniDir, filename string) string {
-	// 1. Explicit config path.
-	if loadedConfig.DefaultIniDir != "" {
-		p := filepath.Join(loadedConfig.DefaultIniDir, filename)
-		if data, err := os.ReadFile(p); err == nil && len(data) > 0 {
-			return string(data)
-		}
-		if c := readINIContent(p); c != "" {
-			return c
-		}
+	if content := discoverViaConfiguredPath(filename); content != "" {
+		return content
 	}
 
 	// 1b. When INI dir points to a k8s pod path, derive nearby Config paths in
 	// the same pod first. This is the most reliable source in deployed mode.
-	if ns, pod, inPodDir, ok := parseK8sINIPath(iniDir); ok {
-		candidates := []string{
-			pathpkg.Clean(pathpkg.Join(inPodDir, "..", "..", "..", "Config", filename)),
-			pathpkg.Clean(pathpkg.Join(inPodDir, "..", "..", "Config", filename)),
-			pathpkg.Clean(pathpkg.Join(inPodDir, "..", "..", "..", "..", "Config", filename)),
-			"/DuneSandbox/Config/" + filename,
-			"/home/dune/server/DuneSandbox/Config/" + filename,
-			"/home/dune/DuneSandbox/Config/" + filename,
-			"/game/DuneSandbox/Config/" + filename,
-		}
-		for _, inPodPath := range candidates {
-			if c := readINIContent(fmt.Sprintf("k8s://%s/%s%s", ns, pod, inPodPath)); c != "" {
-				return c
-			}
-		}
+	if content := discoverViaK8sDerivedPath(iniDir, filename); content != "" {
+		return content
 	}
 
 	if globalExecutor != nil {
 		// 2a. Well-known host directories — tried in order before any find.
-		for _, p := range []string{
-			"/home/dune/" + filename,
-			"/home/" + filename,
-			"/root/" + filename,
-			"/dune/" + filename,
-			"/home/dune/server/DuneSandbox/Config/" + filename,
-		} {
-			if c := readINIContent(p); c != "" {
-				return c
-			}
+		if content := discoverViaHostPaths(filename); content != "" {
+			return content
 		}
 
 		// 2b. Host filesystem scan: /home /root /dune first, then k3s containerd
 		// paths. These require sudo but the executor already runs with sudo access.
-		out, _ := globalExecutor.Exec(fmt.Sprintf(
-			"sudo find /home /root /dune /run/k3s/containerd /var/lib/rancher/k3s/agent/containerd"+
-				" -maxdepth 10 -name %s -not -path '*/Saved/*' -not -path '*/saved/*' 2>/dev/null | head -1",
-			shellQuote(filename)))
-		if p := strings.TrimSpace(out); p != "" {
-			if c := readINIContent(p); c != "" {
-				return c
-			}
+		if content := discoverViaHostFind(filename); content != "" {
+			return content
 		}
 
 		// 3. Relative candidates from iniDir (non-k8s layouts).
-		for _, p := range []string{
-			filepath.Join(iniDir, "..", "..", "..", "Config", filename),
-			filepath.Join(iniDir, "..", "..", "Config", filename),
-			filepath.Join(iniDir, "..", "..", "..", "..", "Config", filename),
-		} {
-			if c := readINIContent(p); c != "" {
-				return c
-			}
+		if content := discoverViaRelativePath(iniDir, filename); content != "" {
+			return content
 		}
 	}
 
@@ -498,6 +585,145 @@ func readINIContent(path string) string {
 	return out
 }
 
+type layerSource struct {
+	name string
+	ini  map[string]map[string]string
+}
+
+type discoveredKey struct {
+	section string
+	key     string
+}
+
+func serverSettingsSchemaKeys() map[string]bool {
+	schemaKeys := make(map[string]bool, len(serverSettingsSchema))
+	for _, def := range serverSettingsSchema {
+		schemaKeys[def.Section+"|"+def.Key] = true
+	}
+	return schemaKeys
+}
+
+func buildLayerSources(
+	defaultEngineIni,
+	defaultGameIni,
+	engineIni,
+	gameIni map[string]map[string]string,
+) []layerSource {
+	return []layerSource{
+		{name: "defaultEngine", ini: defaultEngineIni},
+		{name: "defaultGame", ini: defaultGameIni},
+		{name: "userEngine", ini: engineIni},
+		{name: "userGame", ini: gameIni},
+	}
+}
+
+func applySettingLayers(s *ServerSetting, layerSources []layerSource) {
+	for _, src := range layerSources {
+		if v, ok := src.ini[s.Section][s.Key]; ok {
+			if s.Type == "" {
+				s.Type = string(inferType(v))
+			}
+			s.Layers = append(s.Layers, SettingLayer{Source: src.name, Value: v})
+			s.Current = v
+			s.Source = src.name
+		}
+	}
+	s.IsOverride = strings.HasPrefix(s.Source, "user")
+	if s.Layers == nil {
+		s.Layers = []SettingLayer{}
+	}
+}
+
+func buildSchemaSettings(layerSources []layerSource) []ServerSetting {
+	settings := make([]ServerSetting, 0, len(serverSettingsSchema))
+	for _, def := range serverSettingsSchema {
+		s := ServerSetting{
+			Section:     def.Section,
+			Key:         def.Key,
+			Type:        string(def.Type),
+			Default:     def.Default,
+			Label:       def.Label,
+			Description: def.Description,
+			Category:    def.Category,
+			Current:     def.Default,
+		}
+		applySettingLayers(&s, layerSources)
+		settings = append(settings, s)
+	}
+	return settings
+}
+
+func discoverUnknownSettings(layerSources []layerSource, schemaKeys map[string]bool) []discoveredKey {
+	seenKeys := make(map[string]bool, len(schemaKeys))
+	for k := range schemaKeys {
+		seenKeys[k] = true
+	}
+
+	discovered := make([]discoveredKey, 0, 32)
+	for _, src := range layerSources {
+		for section, keys := range src.ini {
+			for key := range keys {
+				// Skip array-prefix lines (+/-); they belong in raw sections.
+				if strings.HasPrefix(key, "+") || strings.HasPrefix(key, "-") {
+					continue
+				}
+				composite := section + "|" + key
+				if seenKeys[composite] {
+					continue
+				}
+				seenKeys[composite] = true
+				discovered = append(discovered, discoveredKey{section: section, key: key})
+			}
+		}
+	}
+	sort.Slice(discovered, func(i, j int) bool {
+		if discovered[i].section != discovered[j].section {
+			return discovered[i].section < discovered[j].section
+		}
+		return discovered[i].key < discovered[j].key
+	})
+	return discovered
+}
+
+func buildDiscoveredSettings(
+	discovered []discoveredKey,
+	layerSources []layerSource,
+	schemaKeys map[string]bool,
+) []ServerSetting {
+	settings := make([]ServerSetting, 0, len(discovered))
+	for _, dk := range discovered {
+		s := ServerSetting{
+			Section:  dk.section,
+			Key:      dk.key,
+			Label:    dk.key,
+			Category: shortSectionName(dk.section),
+			Layers:   []SettingLayer{},
+		}
+		applySettingLayers(&s, layerSources)
+		if s.Type == "" {
+			s.Type = string(settingString)
+		}
+		settings = append(settings, s)
+		schemaKeys[dk.section+"|"+dk.key] = true
+	}
+	return settings
+}
+
+func buildServerSettingsRawSections(
+	defaultGameContent,
+	defaultEngineContent,
+	gameContent,
+	engineContent string,
+	schemaKeys map[string]bool,
+) []RawSection {
+	raw := make([]RawSection, 0, 16)
+	raw = append(raw, parseINILines(defaultGameContent, "defaultGame", schemaKeys)...)
+	raw = append(raw, parseINILines(defaultEngineContent, "defaultEngine", schemaKeys)...)
+	raw = append(raw, parseINILines(gameContent, "userGame", schemaKeys)...)
+	raw = append(raw, parseINILines(engineContent, "userEngine", schemaKeys)...)
+	return raw
+}
+
 func writeINIContent(path, body string) error {
 	if globalExecutor == nil {
 		return fmt.Errorf("not connected")
@@ -539,113 +765,12 @@ func handleGetServerSettings(w http.ResponseWriter, r *http.Request) {
 	defaultGameIni := parseINI(defaultGameContent)
 	defaultEngineIni := parseINI(defaultEngineContent)
 
-	// Build schema key set for raw-line filtering.
-	schemaKeys := map[string]bool{}
-	for _, def := range serverSettingsSchema {
-		schemaKeys[def.Section+"|"+def.Key] = true
-	}
-
-	// Schema settings — build layers from all INI sources and always include all entries.
-	type layerSource struct {
-		name string
-		ini  map[string]map[string]string
-	}
-	layerSources := []layerSource{
-		{"defaultEngine", defaultEngineIni},
-		{"defaultGame", defaultGameIni},
-		{"userEngine", engineIni},
-		{"userGame", gameIni},
-	}
-
-	var settings []ServerSetting
-	for _, def := range serverSettingsSchema {
-		s := ServerSetting{
-			Section:     def.Section,
-			Key:         def.Key,
-			Type:        string(def.Type),
-			Default:     def.Default,
-			Label:       def.Label,
-			Description: def.Description,
-			Category:    def.Category,
-			Current:     def.Default,
-		}
-		for _, src := range layerSources {
-			if v, ok := src.ini[def.Section][def.Key]; ok {
-				s.Layers = append(s.Layers, SettingLayer{Source: src.name, Value: v})
-				s.Current = v
-				s.Source = src.name
-			}
-		}
-		s.IsOverride = strings.HasPrefix(s.Source, "user")
-		if s.Layers == nil {
-			s.Layers = []SettingLayer{}
-		}
-		settings = append(settings, s)
-	}
-
-	// Discover all keys present in any INI file that aren't in the hardcoded schema.
-	// These get typed settings with inferred types so they participate in the layer UI.
-	type discoveredKey struct{ section, key string }
-	seenKeys := make(map[string]bool, len(schemaKeys))
-	for k := range schemaKeys {
-		seenKeys[k] = true
-	}
-	var discovered []discoveredKey
-	for _, src := range layerSources {
-		for section, keys := range src.ini {
-			for key := range keys {
-				// Skip array-prefix lines (+/-); they belong in raw sections.
-				if strings.HasPrefix(key, "+") || strings.HasPrefix(key, "-") {
-					continue
-				}
-				k := section + "|" + key
-				if !seenKeys[k] {
-					seenKeys[k] = true
-					discovered = append(discovered, discoveredKey{section, key})
-				}
-			}
-		}
-	}
-	sort.Slice(discovered, func(i, j int) bool {
-		if discovered[i].section != discovered[j].section {
-			return discovered[i].section < discovered[j].section
-		}
-		return discovered[i].key < discovered[j].key
-	})
-	for _, dk := range discovered {
-		s := ServerSetting{
-			Section:  dk.section,
-			Key:      dk.key,
-			Label:    dk.key,
-			Category: shortSectionName(dk.section),
-			Layers:   []SettingLayer{},
-		}
-		for _, src := range layerSources {
-			if v, ok := src.ini[dk.section][dk.key]; ok {
-				if s.Type == "" {
-					s.Type = string(inferType(v))
-				}
-				s.Layers = append(s.Layers, SettingLayer{Source: src.name, Value: v})
-				s.Current = v
-				s.Source = src.name
-			}
-		}
-		if s.Type == "" {
-			s.Type = string(settingString)
-		}
-		s.IsOverride = strings.HasPrefix(s.Source, "user")
-		settings = append(settings, s)
-		schemaKeys[dk.section+"|"+dk.key] = true
-	}
-
-	// Raw lines — array entries and anything not promoted to a typed setting.
-	// All four files use the same schemaKeys (which now includes discovered keys)
-	// so nothing appears in both the typed panel and the raw panel.
-	var raw []RawSection
-	raw = append(raw, parseINILines(defaultGameContent, "defaultGame", schemaKeys)...)
-	raw = append(raw, parseINILines(defaultEngineContent, "defaultEngine", schemaKeys)...)
-	raw = append(raw, parseINILines(gameContent, "userGame", schemaKeys)...)
-	raw = append(raw, parseINILines(engineContent, "userEngine", schemaKeys)...)
+	layerSources := buildLayerSources(defaultEngineIni, defaultGameIni, engineIni, gameIni)
+	schemaKeys := serverSettingsSchemaKeys()
+	settings := buildSchemaSettings(layerSources)
+	discovered := discoverUnknownSettings(layerSources, schemaKeys)
+	settings = append(settings, buildDiscoveredSettings(discovered, layerSources, schemaKeys)...)
+	raw := buildServerSettingsRawSections(defaultGameContent, defaultEngineContent, gameContent, engineContent, schemaKeys)
 
 	jsonOK(w, map[string]any{
 		"settings": settings,
@@ -853,45 +978,60 @@ func stripEmptySections(content string) string {
 		return content
 	}
 	lines := strings.Split(content, "\n")
-	// Find each section's (headerIdx, nextHeaderIdx). For each, check whether
-	// the body is empty; if so, mark the header line for removal.
-	skip := make(map[int]bool)
-	var headerIdxs []int
-	for i, l := range lines {
-		trim := strings.TrimSpace(l)
-		if strings.HasPrefix(trim, "[") && strings.HasSuffix(trim, "]") {
-			headerIdxs = append(headerIdxs, i)
-		}
-	}
-	for k, idx := range headerIdxs {
-		end := len(lines)
-		if k+1 < len(headerIdxs) {
-			end = headerIdxs[k+1]
-		}
-		empty := true
-		for j := idx + 1; j < end; j++ {
-			if strings.TrimSpace(lines[j]) != "" {
-				empty = false
-				break
-			}
-		}
-		if empty {
-			skip[idx] = true
-			// Also consume the trailing blank lines so we don't leave a void.
-			for j := idx + 1; j < end; j++ {
-				skip[j] = true
-			}
+	skip := map[int]bool{}
+	headerIdxs := findINISectionHeaders(lines)
+	for i, headerIdx := range headerIdxs {
+		sectionEnd := nextINISectionStart(i, headerIdxs, len(lines))
+		if isINISectionBodyEmpty(lines, headerIdx+1, sectionEnd) {
+			markINISectionRange(skip, headerIdx, sectionEnd)
 		}
 	}
 	if len(skip) == 0 {
 		return content
 	}
+	return joinINILinesWithoutSkipped(lines, skip)
+}
+
+func findINISectionHeaders(lines []string) []int {
+	headerIdxs := make([]int, 0, len(lines))
+	for i, line := range lines {
+		trim := strings.TrimSpace(line)
+		if strings.HasPrefix(trim, "[") && strings.HasSuffix(trim, "]") {
+			headerIdxs = append(headerIdxs, i)
+		}
+	}
+	return headerIdxs
+}
+
+func nextINISectionStart(current int, headerIdxs []int, lineCount int) int {
+	if current+1 < len(headerIdxs) {
+		return headerIdxs[current+1]
+	}
+	return lineCount
+}
+
+func isINISectionBodyEmpty(lines []string, start, end int) bool {
+	for i := start; i < end; i++ {
+		if strings.TrimSpace(lines[i]) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func markINISectionRange(skip map[int]bool, start, end int) {
+	for i := start; i < end; i++ {
+		skip[i] = true
+	}
+}
+
+func joinINILinesWithoutSkipped(lines []string, skip map[int]bool) string {
 	out := make([]string, 0, len(lines))
-	for i, l := range lines {
+	for i, line := range lines {
 		if skip[i] {
 			continue
 		}
-		out = append(out, l)
+		out = append(out, line)
 	}
 	return strings.Join(out, "\n")
 }
@@ -901,6 +1041,39 @@ func stripEmptySections(content string) string {
 // or "-Foo" appears in owned, any line with that exact prefixed key is removed;
 // if plain "Foo" is owned, all variants (plain, +Foo, -Foo) are removed.
 // Comments and unrelated lines are left alone.
+func parseOwnedINIKey(trim string) (lineKey, baseKey string, ok bool) {
+	if len(trim) == 0 || trim[0] == ';' || trim[0] == '#' {
+		return "", "", false
+	}
+	rest := trim
+	prefix := ""
+	if trim[0] == '+' || trim[0] == '-' {
+		prefix = string(trim[0])
+		rest = trim[1:]
+	}
+	eq := strings.Index(rest, "=")
+	if eq <= 0 {
+		return "", "", false
+	}
+	baseKey = strings.TrimSpace(rest[:eq])
+	return prefix + baseKey, baseKey, true
+}
+
+func shouldStripOwnedLine(section, trim string, owned map[string]map[string]bool) bool {
+	if section == "" {
+		return false
+	}
+	lineKey, baseKey, ok := parseOwnedINIKey(trim)
+	if !ok {
+		return false
+	}
+	secOwned := owned[section]
+	if secOwned == nil {
+		return false
+	}
+	return secOwned[lineKey] || secOwned[baseKey]
+}
+
 func stripKeysFromContent(content string, owned map[string]map[string]bool) string {
 	if len(owned) == 0 || content == "" {
 		return content
@@ -916,24 +1089,8 @@ func stripKeysFromContent(content string, owned map[string]map[string]bool) stri
 			out = append(out, line)
 			continue
 		}
-		// Drop lines where the (possibly-prefixed) key is dune-admin-owned.
-		// Comments, blank lines, and section headers are preserved as-is.
-		if curSec != "" && len(trim) > 0 && trim[0] != ';' && trim[0] != '#' {
-			rest := trim
-			pfx := ""
-			if trim[0] == '+' || trim[0] == '-' {
-				pfx = string(trim[0])
-				rest = trim[1:]
-			}
-			if eq := strings.Index(rest, "="); eq > 0 {
-				baseKey := strings.TrimSpace(rest[:eq])
-				lineKey := pfx + baseKey
-				secOwned := owned[curSec]
-				// Drop if: exact prefixed key owned, OR plain base key owned (covers all variants).
-				if secOwned != nil && (secOwned[lineKey] || secOwned[baseKey]) {
-					continue
-				}
-			}
+		if shouldStripOwnedLine(curSec, trim, owned) {
+			continue
 		}
 		out = append(out, line)
 	}
@@ -1026,6 +1183,75 @@ func applyDuneAdminRawSection(content, section, rawLines string) (string, error)
 	return strings.TrimRight(preMarker, "\n") + "\n\n" + block, nil
 }
 
+type normalizedServerSettingUpdates struct {
+	updates map[string]map[string]string
+	applied int
+	cleared int
+}
+
+func buildServerSettingsSchemaMap() map[string]settingDef {
+	schemaMap := make(map[string]settingDef, len(serverSettingsSchema))
+	for _, d := range serverSettingsSchema {
+		schemaMap[d.Section+"|"+d.Key] = d
+	}
+	return schemaMap
+}
+
+func normalizeServerSettingsUpdates(
+	requested []serverSettingUpdate,
+	schemaMap map[string]settingDef,
+) (normalizedServerSettingUpdates, error) {
+	normalized := normalizedServerSettingUpdates{
+		updates: make(map[string]map[string]string, len(requested)),
+	}
+	for _, update := range requested {
+		if normalized.updates[update.Section] == nil {
+			normalized.updates[update.Section] = map[string]string{}
+		}
+		if update.Value == "" {
+			normalized.updates[update.Section][update.Key] = ""
+			normalized.cleared++
+			continue
+		}
+
+		def, known := schemaMap[update.Section+"|"+update.Key]
+		if known {
+			norm, err := normalizeValue(def.Type, update.Value)
+			if err != nil {
+				return normalizedServerSettingUpdates{}, fmt.Errorf("invalid value for %s: %w", update.Key, err)
+			}
+			normalized.updates[update.Section][update.Key] = norm
+		} else {
+			normalized.updates[update.Section][update.Key] = update.Value
+		}
+		normalized.applied++
+	}
+	return normalized, nil
+}
+
+func splitServerSettingsUpdatesByFile(
+	defaultEngineIni map[string]map[string]string,
+	updates map[string]map[string]string,
+) (gameUpdates, engineUpdates map[string]map[string]string) {
+	gameUpdates = map[string]map[string]string{}
+	engineUpdates = map[string]map[string]string{}
+	for sec, kvs := range updates {
+		if _, inEngine := defaultEngineIni[sec]; inEngine {
+			engineUpdates[sec] = kvs
+		} else {
+			gameUpdates[sec] = kvs
+		}
+	}
+	return gameUpdates, engineUpdates
+}
+
+func buildUpdatedINIContent(path string, updates map[string]map[string]string) (string, error) {
+	if len(updates) == 0 {
+		return "", nil
+	}
+	return applyDuneAdminUpdates(readINIContent(path), updates)
+}
+
 func handleUpdateServerSettings(w http.ResponseWriter, r *http.Request) {
 	if globalExecutor == nil {
 		jsonErr(w, fmt.Errorf("not connected"), 503)
@@ -1045,79 +1271,48 @@ func handleUpdateServerSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build schema lookup for type validation.
-	schemaMap := map[string]settingDef{}
-	for _, d := range serverSettingsSchema {
-		schemaMap[d.Section+"|"+d.Key] = d
-	}
-
-	// Normalise values and build the update map.
-	updates := map[string]map[string]string{}
-	applied, cleared := 0, 0
-	for _, u := range req.Updates {
-		if updates[u.Section] == nil {
-			updates[u.Section] = map[string]string{}
-		}
-		if u.Value == "" {
-			updates[u.Section][u.Key] = ""
-			cleared++
-		} else {
-			def, known := schemaMap[u.Section+"|"+u.Key]
-			if known {
-				norm, err := normalizeValue(def.Type, u.Value)
-				if err != nil {
-					jsonErr(w, fmt.Errorf("invalid value for %s: %w", u.Key, err), 400)
-					return
-				}
-				updates[u.Section][u.Key] = norm
-			} else {
-				updates[u.Section][u.Key] = u.Value
-			}
-			applied++
-		}
+	normalized, err := normalizeServerSettingsUpdates(req.Updates, buildServerSettingsSchemaMap())
+	if err != nil {
+		jsonErr(w, err, 400)
+		return
 	}
 
 	// Route each section to UserGame.ini or UserEngine.ini based on which default
 	// file declares it. Sections found in DefaultEngine.ini go to UserEngine.ini;
 	// everything else goes to UserGame.ini.
 	defaultEngineIni := parseINI(readDefaultINIContent(dir, "DefaultEngine.ini"))
-	gameUpdates, engineUpdates := map[string]map[string]string{}, map[string]map[string]string{}
-	for sec, kvs := range updates {
-		if _, inEngine := defaultEngineIni[sec]; inEngine {
-			engineUpdates[sec] = kvs
-		} else {
-			gameUpdates[sec] = kvs
-		}
+	gameUpdates, engineUpdates := splitServerSettingsUpdatesByFile(defaultEngineIni, normalized.updates)
+
+	gamePath := dir + "/UserGame.ini"
+	gameBody, err := buildUpdatedINIContent(gamePath, gameUpdates)
+	if err != nil {
+		jsonErr(w, fmt.Errorf("UserGame.ini: %w", err), 409)
+		return
 	}
 	if len(gameUpdates) > 0 {
-		path := dir + "/UserGame.ini"
-		body, err := applyDuneAdminUpdates(readINIContent(path), gameUpdates)
-		if err != nil {
-			jsonErr(w, fmt.Errorf("UserGame.ini: %w", err), 409)
-			return
-		}
-		if err := writeINIContent(path, body); err != nil {
+		if err := writeINIContent(gamePath, gameBody); err != nil {
 			jsonErr(w, fmt.Errorf("write UserGame.ini: %w", err), 500)
 			return
 		}
 	}
+
+	enginePath := dir + "/UserEngine.ini"
+	engineBody, err := buildUpdatedINIContent(enginePath, engineUpdates)
+	if err != nil {
+		jsonErr(w, fmt.Errorf("UserEngine.ini: %w", err), 409)
+		return
+	}
 	if len(engineUpdates) > 0 {
-		path := dir + "/UserEngine.ini"
-		body, err := applyDuneAdminUpdates(readINIContent(path), engineUpdates)
-		if err != nil {
-			jsonErr(w, fmt.Errorf("UserEngine.ini: %w", err), 409)
-			return
-		}
-		if err := writeINIContent(path, body); err != nil {
+		if err := writeINIContent(enginePath, engineBody); err != nil {
 			jsonErr(w, fmt.Errorf("write UserEngine.ini: %w", err), 500)
 			return
 		}
 	}
 
 	jsonOK(w, map[string]any{
-		"ok":      fmt.Sprintf("Saved (%d set, %d cleared). Restart the game server to apply.", applied, cleared),
-		"applied": applied,
-		"cleared": cleared,
+		"ok":      fmt.Sprintf("Saved (%d set, %d cleared). Restart the game server to apply.", normalized.applied, normalized.cleared),
+		"applied": normalized.applied,
+		"cleared": normalized.cleared,
 	})
 }
 

--- a/cmd/dune-admin/handlers_server_settings_discover_test.go
+++ b/cmd/dune-admin/handlers_server_settings_discover_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestConfiguredDefaultINIPath(t *testing.T) {
+	originalConfig := loadedConfig
+	t.Cleanup(func() { loadedConfig = originalConfig })
+
+	loadedConfig.DefaultIniDir = "/opt/dune/config"
+	if got := configuredDefaultINIPath("DefaultGame.ini"); got != "/opt/dune/config/DefaultGame.ini" {
+		t.Fatalf("unexpected configured path: %q", got)
+	}
+
+	loadedConfig.DefaultIniDir = ""
+	if got := configuredDefaultINIPath("DefaultGame.ini"); got != "" {
+		t.Fatalf("expected empty configured path when default ini dir unset, got %q", got)
+	}
+}
+
+func TestK8sDerivedDefaultINICandidates(t *testing.T) {
+	t.Parallel()
+
+	got := k8sDerivedDefaultINICandidates("/home/dune/server/state", "DefaultEngine.ini")
+	if len(got) < 7 {
+		t.Fatalf("expected at least 7 candidates, got %d", len(got))
+	}
+	if got[0] != "/home/Config/DefaultEngine.ini" {
+		t.Fatalf("unexpected first candidate: %q", got[0])
+	}
+	if got[len(got)-1] != "/game/DuneSandbox/Config/DefaultEngine.ini" {
+		t.Fatalf("unexpected last candidate: %q", got[len(got)-1])
+	}
+}
+
+func TestHostDefaultINICandidates(t *testing.T) {
+	t.Parallel()
+
+	got := hostDefaultINICandidates("DefaultGame.ini")
+	want := []string{
+		"/home/dune/DefaultGame.ini",
+		"/home/DefaultGame.ini",
+		"/root/DefaultGame.ini",
+		"/dune/DefaultGame.ini",
+		"/home/dune/server/DuneSandbox/Config/DefaultGame.ini",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d host candidates, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidate %d mismatch: want %q got %q", i, want[i], got[i])
+		}
+	}
+}
+
+func TestRelativeDefaultINICandidates(t *testing.T) {
+	t.Parallel()
+
+	base := filepath.Clean("/srv/dune/server/state")
+	got := relativeDefaultINICandidates(base, "DefaultEngine.ini")
+	want := []string{
+		filepath.Join(base, "..", "..", "..", "Config", "DefaultEngine.ini"),
+		filepath.Join(base, "..", "..", "Config", "DefaultEngine.ini"),
+		filepath.Join(base, "..", "..", "..", "..", "Config", "DefaultEngine.ini"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d relative candidates, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidate %d mismatch: want %q got %q", i, want[i], got[i])
+		}
+	}
+}

--- a/cmd/dune-admin/handlers_server_settings_get_test.go
+++ b/cmd/dune-admin/handlers_server_settings_get_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestServerSettingsSchemaKeys(t *testing.T) {
+	keys := serverSettingsSchemaKeys()
+	if len(keys) != len(serverSettingsSchema) {
+		t.Fatalf("expected %d keys, got %d", len(serverSettingsSchema), len(keys))
+	}
+	first := serverSettingsSchema[0]
+	if !keys[first.Section+"|"+first.Key] {
+		t.Fatalf("missing schema key %s|%s", first.Section, first.Key)
+	}
+}
+
+func TestApplySettingLayers(t *testing.T) {
+	s := ServerSetting{
+		Section: "Sec",
+		Key:     "Key",
+		Type:    string(settingInt),
+		Current: "0",
+	}
+	sources := []layerSource{
+		{name: "defaultGame", ini: map[string]map[string]string{"Sec": {"Key": "1"}}},
+		{name: "userGame", ini: map[string]map[string]string{"Sec": {"Key": "2"}}},
+	}
+
+	applySettingLayers(&s, sources)
+
+	if s.Current != "2" || s.Source != "userGame" {
+		t.Fatalf("unexpected current/source: %q / %q", s.Current, s.Source)
+	}
+	if !s.IsOverride {
+		t.Fatal("expected IsOverride=true")
+	}
+	if len(s.Layers) != 2 {
+		t.Fatalf("expected 2 layers, got %d", len(s.Layers))
+	}
+}
+
+func TestDiscoverUnknownSettings(t *testing.T) {
+	schemaKeys := map[string]bool{"Sec|Known": true}
+	sources := []layerSource{
+		{
+			name: "defaultGame",
+			ini: map[string]map[string]string{
+				"Sec": {"Known": "1", "+Array": "x", "CustomB": "true"},
+				"A":   {"CustomA": "42"},
+			},
+		},
+		{
+			name: "userGame",
+			ini: map[string]map[string]string{
+				"Sec": {"CustomB": "false"},
+			},
+		},
+	}
+
+	discovered := discoverUnknownSettings(sources, schemaKeys)
+	if len(discovered) != 2 {
+		t.Fatalf("expected 2 discovered keys, got %d", len(discovered))
+	}
+	if discovered[0].section != "A" || discovered[0].key != "CustomA" {
+		t.Fatalf("unexpected first discovered key: %+v", discovered[0])
+	}
+	if discovered[1].section != "Sec" || discovered[1].key != "CustomB" {
+		t.Fatalf("unexpected second discovered key: %+v", discovered[1])
+	}
+}
+
+func TestBuildDiscoveredSettings(t *testing.T) {
+	discovered := []discoveredKey{{section: "Sec", key: "Custom"}}
+	schemaKeys := map[string]bool{}
+	sources := []layerSource{
+		{name: "defaultGame", ini: map[string]map[string]string{"Sec": {"Custom": "1"}}},
+		{name: "userGame", ini: map[string]map[string]string{"Sec": {"Custom": "True"}}},
+	}
+
+	settings := buildDiscoveredSettings(discovered, sources, schemaKeys)
+	if len(settings) != 1 {
+		t.Fatalf("expected 1 discovered setting, got %d", len(settings))
+	}
+	if settings[0].Type != string(settingInt) {
+		t.Fatalf("expected inferred type int from first layer, got %q", settings[0].Type)
+	}
+	if settings[0].Current != "True" || settings[0].Source != "userGame" {
+		t.Fatalf("unexpected current/source: %q / %q", settings[0].Current, settings[0].Source)
+	}
+	if !settings[0].IsOverride {
+		t.Fatal("expected IsOverride=true for user layer")
+	}
+	if !schemaKeys["Sec|Custom"] {
+		t.Fatal("expected discovered key to be added to schema key set")
+	}
+}
+
+func TestBuildServerSettingsRawSections(t *testing.T) {
+	schemaKeys := map[string]bool{"Sec|Known": true}
+	defaultGame := "[Sec]\nKnown=1\nOther=2\n+Array=3\n"
+	defaultEngine := "[Sec]\n-Array=4\n"
+	raw := buildServerSettingsRawSections(defaultGame, defaultEngine, "", "", schemaKeys)
+
+	if len(raw) != 2 {
+		t.Fatalf("expected 2 raw sections, got %d", len(raw))
+	}
+	if raw[0].Source != "defaultGame" || len(raw[0].Lines) != 2 {
+		t.Fatalf("unexpected defaultGame raw section: %+v", raw[0])
+	}
+	if raw[1].Source != "defaultEngine" || len(raw[1].Lines) != 1 {
+		t.Fatalf("unexpected defaultEngine raw section: %+v", raw[1])
+	}
+	if raw[0].Lines[0].Key != "Other" || raw[0].Lines[0].Prefix != "" {
+		t.Fatalf("unexpected first defaultGame raw line: %+v", raw[0].Lines[0])
+	}
+	if raw[0].Lines[1].Key != "Array" || raw[0].Lines[1].Prefix != "+" {
+		t.Fatalf("unexpected second defaultGame raw line: %+v", raw[0].Lines[1])
+	}
+	if raw[1].Lines[0].Key != "Array" || raw[1].Lines[0].Prefix != "-" {
+		t.Fatalf("unexpected defaultEngine raw line: %+v", raw[1].Lines[0])
+	}
+}

--- a/cmd/dune-admin/handlers_server_settings_parse_ini_test.go
+++ b/cmd/dune-admin/handlers_server_settings_parse_ini_test.go
@@ -1,0 +1,68 @@
+package main
+
+import "testing"
+
+func TestParseINILines_FiltersSchemaAndPreservesArrayPrefixes(t *testing.T) {
+	t.Parallel()
+
+	content := `
+; comment
+[SectionOne]
+Known=1
+Unknown = 2
++Known=3
+-Known=4
+NoEqualsHere
+
+[SectionTwo]
+Another=abc
+`
+	schemaKeys := map[string]bool{"SectionOne|Known": true}
+
+	got := parseINILines(content, "userGame", schemaKeys)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(got))
+	}
+	if got[0].Section != "SectionOne" || got[0].Source != "userGame" {
+		t.Fatalf("unexpected first section metadata: %+v", got[0])
+	}
+	if len(got[0].Lines) != 3 {
+		t.Fatalf("expected 3 lines in SectionOne, got %d", len(got[0].Lines))
+	}
+	if got[0].Lines[0] != (RawLine{Key: "Unknown", Value: "2"}) {
+		t.Fatalf("unexpected first raw line: %+v", got[0].Lines[0])
+	}
+	if got[0].Lines[1] != (RawLine{Prefix: "+", Key: "Known", Value: "3"}) {
+		t.Fatalf("unexpected +array raw line: %+v", got[0].Lines[1])
+	}
+	if got[0].Lines[2] != (RawLine{Prefix: "-", Key: "Known", Value: "4"}) {
+		t.Fatalf("unexpected -array raw line: %+v", got[0].Lines[2])
+	}
+
+	if got[1].Section != "SectionTwo" || len(got[1].Lines) != 1 {
+		t.Fatalf("unexpected second section: %+v", got[1])
+	}
+	if got[1].Lines[0] != (RawLine{Key: "Another", Value: "abc"}) {
+		t.Fatalf("unexpected second section line: %+v", got[1].Lines[0])
+	}
+}
+
+func TestParseINILines_DropsSectionsWithoutRawLines(t *testing.T) {
+	t.Parallel()
+
+	content := `
+[OnlySchema]
+Known=1
+[HasRaw]
+Unknown=2
+`
+	schemaKeys := map[string]bool{"OnlySchema|Known": true}
+
+	got := parseINILines(content, "defaultGame", schemaKeys)
+	if len(got) != 1 {
+		t.Fatalf("expected only one section after compaction, got %d", len(got))
+	}
+	if got[0].Section != "HasRaw" {
+		t.Fatalf("expected HasRaw section to remain, got %q", got[0].Section)
+	}
+}

--- a/cmd/dune-admin/handlers_server_settings_strip_empty_sections_test.go
+++ b/cmd/dune-admin/handlers_server_settings_strip_empty_sections_test.go
@@ -1,0 +1,43 @@
+package main
+
+import "testing"
+
+func TestStripEmptySections(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "empty content",
+			content: "",
+			want:    "",
+		},
+		{
+			name:    "removes section with only blank body",
+			content: "[Keep]\nKey=1\n\n[Remove]\n\n\n[AlsoKeep]\n;comment\n",
+			want:    "[Keep]\nKey=1\n\n[AlsoKeep]\n;comment\n",
+		},
+		{
+			name:    "preserves sections with comments or values",
+			content: "[Commented]\n; docs\n\n[Valued]\n+Array=1\n\n[Blank]\n\n",
+			want:    "[Commented]\n; docs\n\n[Valued]\n+Array=1\n",
+		},
+		{
+			name:    "keeps non-section preface lines",
+			content: "; header\n\n[Remove]\n\n[Keep]\nValue=1\n",
+			want:    "; header\n\n[Keep]\nValue=1\n",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripEmptySections(tt.content); got != tt.want {
+				t.Fatalf("unexpected output\nwant:\n%q\ngot:\n%q", tt.want, got)
+			}
+		})
+	}
+}

--- a/cmd/dune-admin/handlers_server_settings_strip_keys_test.go
+++ b/cmd/dune-admin/handlers_server_settings_strip_keys_test.go
@@ -1,0 +1,75 @@
+package main
+
+import "testing"
+
+func TestStripKeysFromContent(t *testing.T) {
+	t.Parallel()
+
+	content := `[Sec]
+Foo=1
++Foo=2
+-Foo=3
+Bar=9
+[Other]
+Foo=4
+`
+
+	owned := map[string]map[string]bool{
+		"Sec": {"Foo": true},
+	}
+	got := stripKeysFromContent(content, owned)
+	want := `[Sec]
+Bar=9
+[Other]
+Foo=4
+`
+	if got != want {
+		t.Fatalf("unexpected stripped content\nwant:\n%q\ngot:\n%q", want, got)
+	}
+}
+
+func TestStripKeysFromContent_PrefixedOwnership(t *testing.T) {
+	t.Parallel()
+
+	content := `[Sec]
+Foo=1
++Foo=2
+-Foo=3
+`
+
+	owned := map[string]map[string]bool{
+		"Sec": {"+Foo": true},
+	}
+	got := stripKeysFromContent(content, owned)
+	want := `[Sec]
+Foo=1
+-Foo=3
+`
+	if got != want {
+		t.Fatalf("unexpected prefixed strip result\nwant:\n%q\ngot:\n%q", want, got)
+	}
+}
+
+func TestStripKeysFromContent_PreservesCommentsAndInvalidLines(t *testing.T) {
+	t.Parallel()
+
+	content := `[Sec]
+; comment
+# hash comment
+NoEquals
+Owned=1
+`
+
+	owned := map[string]map[string]bool{
+		"Sec": {"Owned": true},
+	}
+	got := stripKeysFromContent(content, owned)
+	want := `[Sec]
+; comment
+# hash comment
+NoEquals
+`
+	if got != want {
+		t.Fatalf("unexpected comment preservation result\nwant:\n%q\ngot:\n%q", want, got)
+	}
+}

--- a/cmd/dune-admin/handlers_server_settings_update_test.go
+++ b/cmd/dune-admin/handlers_server_settings_update_test.go
@@ -1,0 +1,84 @@
+package main
+
+import "testing"
+
+func TestBuildServerSettingsSchemaMap(t *testing.T) {
+	t.Parallel()
+
+	schemaMap := buildServerSettingsSchemaMap()
+	if len(schemaMap) != len(serverSettingsSchema) {
+		t.Fatalf("expected %d schema entries, got %d", len(serverSettingsSchema), len(schemaMap))
+	}
+	if _, ok := schemaMap[secBuilding+"|bEnableBuildingStability"]; !ok {
+		t.Fatalf("expected known schema key for building stability")
+	}
+}
+
+func TestNormalizeServerSettingsUpdates(t *testing.T) {
+	t.Parallel()
+
+	schemaMap := buildServerSettingsSchemaMap()
+	normalized, err := normalizeServerSettingsUpdates([]serverSettingUpdate{
+		{Section: secBuilding, Key: "bEnableBuildingStability", Value: "true"},
+		{Section: secBuilding, Key: "CustomKey", Value: "raw-value"},
+		{Section: secBuilding, Key: "AnotherKey", Value: ""},
+	}, schemaMap)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if normalized.applied != 2 || normalized.cleared != 1 {
+		t.Fatalf("unexpected counters: applied=%d cleared=%d", normalized.applied, normalized.cleared)
+	}
+	if got := normalized.updates[secBuilding]["bEnableBuildingStability"]; got != "True" {
+		t.Fatalf("expected normalized bool value True, got %q", got)
+	}
+	if got := normalized.updates[secBuilding]["CustomKey"]; got != "raw-value" {
+		t.Fatalf("expected custom key passthrough, got %q", got)
+	}
+	if got := normalized.updates[secBuilding]["AnotherKey"]; got != "" {
+		t.Fatalf("expected clear marker empty string, got %q", got)
+	}
+}
+
+func TestNormalizeServerSettingsUpdates_InvalidKnownValue(t *testing.T) {
+	t.Parallel()
+
+	schemaMap := buildServerSettingsSchemaMap()
+	_, err := normalizeServerSettingsUpdates([]serverSettingUpdate{
+		{Section: secBuilding, Key: "bEnableBuildingStability", Value: "not-bool"},
+	}, schemaMap)
+	if err == nil {
+		t.Fatalf("expected normalization error for invalid bool")
+	}
+}
+
+func TestSplitServerSettingsUpdatesByFile(t *testing.T) {
+	t.Parallel()
+
+	defaultEngine := map[string]map[string]string{
+		"/Script/Engine.EngineSection": {"K": "V"},
+	}
+	updates := map[string]map[string]string{
+		"/Script/Engine.EngineSection": {"A": "1"},
+		secBuilding:                    {"B": "2"},
+	}
+	game, engine := splitServerSettingsUpdatesByFile(defaultEngine, updates)
+	if _, ok := engine["/Script/Engine.EngineSection"]; !ok {
+		t.Fatalf("expected engine section to route to engine updates")
+	}
+	if _, ok := game[secBuilding]; !ok {
+		t.Fatalf("expected non-engine section to route to game updates")
+	}
+}
+
+func TestBuildUpdatedINIContent_NoUpdates(t *testing.T) {
+	t.Parallel()
+
+	body, err := buildUpdatedINIContent("ignored.ini", map[string]map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if body != "" {
+		t.Fatalf("expected empty body when no updates, got %q", body)
+	}
+}

--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -10,8 +11,11 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"dune-admin/internal/marketbot"
 )
 
 // AppVersion is the conduit release version shown to users.
@@ -27,33 +31,30 @@ var BuildTime = "unknown"
 // ── config ────────────────────────────────────────────────────────────────────
 
 var (
-	setupMode          bool
-	sqlQuery           string
-	sshHost            string
-	sshUser            string
-	sshKeyPath         string
-	itemDataPath       string
-	scripCurrencyID    int
-	dbHost             string
-	dbPort             int
-	dbUser             string
-	dbPass             string
-	dbName             string
-	dbSchema           string
-	listenAddr         string
-	controlPlane       string
-	controlNS          string
-	brokerGameAddr     string
-	brokerAdminAddr    string
-	brokerTLS          bool
-	brokerUser         string
-	brokerPass         string
-	backupDir          string
-	serverIniDir       string
-	marketBotAddr      string
-	marketBotToken     string
-	marketBotContainer string
-	marketBotNamespace string
+	setupMode       bool
+	sqlQuery        string
+	renderK8SOut    string
+	sshHost         string
+	sshUser         string
+	sshKeyPath      string
+	itemDataPath    string
+	scripCurrencyID int
+	dbHost          string
+	dbPort          int
+	dbUser          string
+	dbPass          string
+	dbName          string
+	dbSchema        string
+	listenAddr      string
+	controlPlane    string
+	controlNS       string
+	brokerGameAddr  string
+	brokerAdminAddr string
+	brokerTLS       bool
+	brokerUser      string
+	brokerPass      string
+	backupDir       string
+	serverIniDir    string
 )
 
 // appConfig mirrors the fields written to ~/.dune-admin/config.yaml.
@@ -122,15 +123,6 @@ type appConfig struct {
 	ScripCurrency int    `yaml:"scrip_currency"`
 	ListenAddr    string `yaml:"listen_addr"`
 
-	// Market bot — optional; enables bot control panel.
-	// MarketBotAddr is the bot's HTTP API address (e.g. "http://market-bot.svc:8081").
-	// MarketBotContainer is the deployment name (kubectl) or container name (docker).
-	// MarketBotNamespace is only used by the kubectl control plane.
-	MarketBotAddr      string `yaml:"market_bot_addr"`
-	MarketBotToken     string `yaml:"market_bot_token"`
-	MarketBotContainer string `yaml:"market_bot_container"`
-	MarketBotNamespace string `yaml:"market_bot_namespace"`
-
 	// AMP-specific — used when Control == "amp" (CubeCoders AMP w/ podman).
 	// AmpInstance is the ampinstmgr instance name (e.g. "MehDune01").
 	// AmpContainer is the podman container name (default "AMP_<instance>").
@@ -156,9 +148,15 @@ type appConfig struct {
 	AmpDataRoot string `yaml:"amp_data_root"`
 	DirectorURL string `yaml:"director_url"`
 
-	// FrontendDir overrides the auto-detected SPA directory. When unset the
-	// server looks in ./dist then ./web/dist and serves the first match.
-	FrontendDir string `yaml:"frontend_dir"`
+	// ── Embedded market bot ────────────────────────────────────────────────
+	// MarketBotEnabled starts the market bot as an in-process goroutine.
+	MarketBotEnabled  bool          `yaml:"market_bot_enabled"`
+	MarketBotCacheDB  string        `yaml:"market_bot_cache_db"`
+	MarketBotItemData string        `yaml:"market_bot_item_data"`
+	MarketBotBuyInt   time.Duration `yaml:"market_bot_buy_interval"`
+	MarketBotListInt  time.Duration `yaml:"market_bot_list_interval"`
+	MarketBotThresh   float64       `yaml:"market_bot_buy_threshold"`
+	MarketBotMaxBuys  int           `yaml:"market_bot_max_buys"`
 }
 
 func configDir() string {
@@ -217,10 +215,6 @@ func loadConfig() {
 			setEnvIfMissing("BROKER_JWT_SECRET", cfg.BrokerJWTSecret)
 			setEnvIfMissing("BACKUP_DIR", cfg.BackupDir)
 			setEnvIfMissing("SERVER_INI_DIR", cfg.ServerIniDir)
-			setEnvIfMissing("MARKET_BOT_ADDR", cfg.MarketBotAddr)
-			setEnvIfMissing("MARKET_BOT_TOKEN", cfg.MarketBotToken)
-			setEnvIfMissing("MARKET_BOT_CONTAINER", cfg.MarketBotContainer)
-			setEnvIfMissing("MARKET_BOT_NAMESPACE", cfg.MarketBotNamespace)
 			return
 		}
 	}
@@ -290,12 +284,9 @@ func init() {
 	flag.StringVar(&brokerPass, "broker-pass", envOr("BROKER_PASS", ""), "AMQP broker password (required for broker features)")
 	flag.StringVar(&backupDir, "backup-dir", envOr("BACKUP_DIR", ""), "Backup directory path")
 	flag.StringVar(&serverIniDir, "ini-dir", envOr("SERVER_INI_DIR", ""), "Directory containing UserGame.ini / UserOverrides.ini")
-	flag.StringVar(&marketBotAddr, "market-bot-addr", envOr("MARKET_BOT_ADDR", ""), "Market bot HTTP API address (e.g. http://host:8081)")
-	flag.StringVar(&marketBotToken, "market-bot-token", envOr("MARKET_BOT_TOKEN", ""), "Market bot bearer token")
-	flag.StringVar(&marketBotContainer, "market-bot-container", envOr("MARKET_BOT_CONTAINER", "market-bot"), "Market bot container/deployment name")
-	flag.StringVar(&marketBotNamespace, "market-bot-namespace", envOr("MARKET_BOT_NAMESPACE", ""), "Market bot k8s namespace")
 	flag.BoolVar(&setupMode, "setup", false, "Interactive setup wizard — writes ~/.dune-admin/config.yaml")
 	flag.StringVar(&sqlQuery, "sql", "", "Run a SQL query and print results to stdout, then exit")
+	flag.StringVar(&renderK8SOut, "render-k8s", "", "Render k8s manifest with values from loaded config (path or '-' for stdout)")
 }
 
 func resolveKeyPath() string {
@@ -444,6 +435,13 @@ func main() {
 		}
 		return
 	}
+	if renderK8SOut != "" {
+		if err := renderK8SManifest(renderK8SOut); err != nil {
+			fmt.Fprintln(os.Stderr, "render-k8s:", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	if err := loadItemData(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -490,5 +488,49 @@ func main() {
 		}
 	}
 
+	// Start embedded market bot when enabled in config.
+	if loadedConfig.MarketBotEnabled {
+		botCtx, botCancel := context.WithCancel(context.Background())
+		cacheDB := loadedConfig.MarketBotCacheDB
+		if cacheDB == "" {
+			cacheDB = filepath.Join(configDir(), "market-bot-cache.db")
+		}
+		itemDataForBot := loadedConfig.MarketBotItemData
+		if itemDataForBot == "" {
+			if itemDataPath != "" {
+				itemDataForBot = itemDataPath
+			} else {
+				itemDataForBot = resolveItemDataPath()
+			}
+		}
+		inst, err := marketbot.Run(botCtx, marketbot.BotConfig{
+			DBPool:       globalDB,
+			DBHost:       dbHost,
+			DBPort:       dbPort,
+			DBUser:       dbUser,
+			DBPass:       dbPass,
+			DBName:       dbName,
+			DBSchema:     dbSchema,
+			CacheDB:      cacheDB,
+			ItemDataPath: itemDataForBot,
+			BuyInterval:  loadedConfig.MarketBotBuyInt,
+			ListInterval: loadedConfig.MarketBotListInt,
+			BuyThreshold: loadedConfig.MarketBotThresh,
+			MaxBuys:      loadedConfig.MarketBotMaxBuys,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "market-bot: startup failed: %v\n", err)
+			botCancel()
+		} else {
+			embeddedBot = inst
+			// Ensure the bot is stopped on process exit.
+			defer botCancel()
+		}
+	}
+
 	startServer(listenAddr)
 }
+
+// embeddedBot holds the live market bot instance when market_bot_enabled=true.
+// Nil when bot is disabled.
+var embeddedBot *marketbot.Instance

--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -412,120 +412,160 @@ func needsSetup() bool {
 	return true
 }
 
-func main() {
-	flag.Parse()
+func runSQLMode(query string) error {
+	if msg, ok := cmdConnect().(msgConnect); ok && msg.err != nil {
+		return fmt.Errorf("connect: %w", msg.err)
+	}
+	if msg, ok := cmdRunSQL(query)().(msgSQL); ok {
+		if msg.err != nil {
+			return msg.err
+		}
+		fmt.Println(msg.result)
+	}
+	return nil
+}
 
+func runImmediateModes() (handled bool, err error) {
 	// Explicit -setup flag: reconfigure and exit (don't start server).
 	if setupMode {
 		runSetup()
-		return
+		return true, nil
 	}
-
 	if sqlQuery != "" {
-		if msg, ok := cmdConnect().(msgConnect); ok && msg.err != nil {
-			fmt.Fprintln(os.Stderr, "connect:", msg.err)
-			os.Exit(1)
-		}
-		if msg, ok := cmdRunSQL(sqlQuery)().(msgSQL); ok {
-			if msg.err != nil {
-				fmt.Fprintln(os.Stderr, msg.err)
-				os.Exit(1)
-			}
-			fmt.Println(msg.result)
-		}
-		return
+		return true, runSQLMode(sqlQuery)
 	}
 	if renderK8SOut != "" {
-		if err := renderK8SManifest(renderK8SOut); err != nil {
-			fmt.Fprintln(os.Stderr, "render-k8s:", err)
+		return true, renderK8SManifest(renderK8SOut)
+	}
+	return false, nil
+}
+
+func loadRuntimeData() error {
+	if err := loadItemData(); err != nil {
+		return err
+	}
+	if err := loadTagsData(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func setupIfNeeded() bool {
+	// Auto-run setup wizard when no config exists — setup leaves us connected.
+	if !needsSetup() {
+		return false
+	}
+	runSetup()
+	fmt.Println()
+	fmt.Printf("Starting server on %s...\n", listenAddr)
+	return true
+}
+
+func closeGlobalConnections() {
+	if globalDB != nil {
+		globalDB.Close()
+	}
+	if globalSSH != nil {
+		_ = globalSSH.Close()
+	}
+}
+
+func refreshItemTemplates() {
+	if msg, ok := cmdFetchItemTemplates().(msgItemTemplates); ok {
+		mergeItemTemplates(msg.templates)
+	}
+}
+
+func connectAndPrimeTemplates(alreadyConnected bool) {
+	if alreadyConnected {
+		// Already connected by setup; just populate item templates.
+		refreshItemTemplates()
+		return
+	}
+	// Connect synchronously (SSH + DB).
+	if msg, ok := cmdConnect().(msgConnect); ok && msg.err != nil {
+		fmt.Fprintln(os.Stderr, "connect:", msg.err)
+		fmt.Fprintln(os.Stderr, "Starting server anyway — use /api/v1/reconnect to retry")
+		return
+	}
+	refreshItemTemplates()
+}
+
+func resolveEmbeddedMarketBotPaths(cfg appConfig, fallbackItemDataPath string) (cacheDB string, itemDataForBot string) {
+	cacheDB = cfg.MarketBotCacheDB
+	if cacheDB == "" {
+		cacheDB = filepath.Join(configDir(), "market-bot-cache.db")
+	}
+	itemDataForBot = cfg.MarketBotItemData
+	if itemDataForBot == "" {
+		if fallbackItemDataPath != "" {
+			itemDataForBot = fallbackItemDataPath
+		} else {
+			itemDataForBot = resolveItemDataPath()
+		}
+	}
+	return cacheDB, itemDataForBot
+}
+
+func startEmbeddedMarketBotIfEnabled(cfg appConfig) context.CancelFunc {
+	if !cfg.MarketBotEnabled {
+		return nil
+	}
+	botCtx, botCancel := context.WithCancel(context.Background())
+	cacheDB, itemDataForBot := resolveEmbeddedMarketBotPaths(cfg, itemDataPath)
+	inst, err := marketbot.Run(botCtx, marketbot.BotConfig{
+		DBPool:       globalDB,
+		DBHost:       dbHost,
+		DBPort:       dbPort,
+		DBUser:       dbUser,
+		DBPass:       dbPass,
+		DBName:       dbName,
+		DBSchema:     dbSchema,
+		CacheDB:      cacheDB,
+		ItemDataPath: itemDataForBot,
+		BuyInterval:  cfg.MarketBotBuyInt,
+		ListInterval: cfg.MarketBotListInt,
+		BuyThreshold: cfg.MarketBotThresh,
+		MaxBuys:      cfg.MarketBotMaxBuys,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "market-bot: startup failed: %v\n", err)
+		botCancel()
+		return nil
+	}
+	embeddedBot = inst
+	return botCancel
+}
+
+func main() {
+	flag.Parse()
+
+	handled, err := runImmediateModes()
+	if handled {
+		if err != nil {
+			label := ""
+			if renderK8SOut != "" {
+				label = "render-k8s: "
+			}
+			fmt.Fprintln(os.Stderr, label+err.Error())
 			os.Exit(1)
 		}
 		return
 	}
 
-	if err := loadItemData(); err != nil {
+	if err := loadRuntimeData(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
-	if err := loadTagsData(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+	alreadyConnected := setupIfNeeded()
+	defer closeGlobalConnections()
 
-	// Auto-run setup wizard when no config exists — setup leaves us connected.
-	alreadyConnected := false
-	if needsSetup() {
-		runSetup()
-		alreadyConnected = true
-		fmt.Println()
-		fmt.Printf("Starting server on %s...\n", listenAddr)
-	}
+	connectAndPrimeTemplates(alreadyConnected)
 
-	defer func() {
-		if globalDB != nil {
-			globalDB.Close()
-		}
-		if globalSSH != nil {
-			_ = globalSSH.Close()
-		}
-	}()
-
-	if !alreadyConnected {
-		// Connect synchronously (SSH + DB).
-		if msg, ok := cmdConnect().(msgConnect); ok && msg.err != nil {
-			fmt.Fprintln(os.Stderr, "connect:", msg.err)
-			fmt.Fprintln(os.Stderr, "Starting server anyway — use /api/v1/reconnect to retry")
-		} else {
-			if msg, ok := cmdFetchItemTemplates().(msgItemTemplates); ok {
-				mergeItemTemplates(msg.templates)
-			}
-		}
-	} else {
-		// Already connected by setup; just populate item templates.
-		if msg, ok := cmdFetchItemTemplates().(msgItemTemplates); ok {
-			mergeItemTemplates(msg.templates)
-		}
-	}
-
-	// Start embedded market bot when enabled in config.
-	if loadedConfig.MarketBotEnabled {
-		botCtx, botCancel := context.WithCancel(context.Background())
-		cacheDB := loadedConfig.MarketBotCacheDB
-		if cacheDB == "" {
-			cacheDB = filepath.Join(configDir(), "market-bot-cache.db")
-		}
-		itemDataForBot := loadedConfig.MarketBotItemData
-		if itemDataForBot == "" {
-			if itemDataPath != "" {
-				itemDataForBot = itemDataPath
-			} else {
-				itemDataForBot = resolveItemDataPath()
-			}
-		}
-		inst, err := marketbot.Run(botCtx, marketbot.BotConfig{
-			DBPool:       globalDB,
-			DBHost:       dbHost,
-			DBPort:       dbPort,
-			DBUser:       dbUser,
-			DBPass:       dbPass,
-			DBName:       dbName,
-			DBSchema:     dbSchema,
-			CacheDB:      cacheDB,
-			ItemDataPath: itemDataForBot,
-			BuyInterval:  loadedConfig.MarketBotBuyInt,
-			ListInterval: loadedConfig.MarketBotListInt,
-			BuyThreshold: loadedConfig.MarketBotThresh,
-			MaxBuys:      loadedConfig.MarketBotMaxBuys,
-		})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "market-bot: startup failed: %v\n", err)
-			botCancel()
-		} else {
-			embeddedBot = inst
-			// Ensure the bot is stopped on process exit.
-			defer botCancel()
-		}
+	if botCancel := startEmbeddedMarketBotIfEnabled(loadedConfig); botCancel != nil {
+		// Ensure the bot is stopped on process exit.
+		defer botCancel()
 	}
 
 	startServer(listenAddr)

--- a/cmd/dune-admin/main_marketbot_paths_test.go
+++ b/cmd/dune-admin/main_marketbot_paths_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveEmbeddedMarketBotPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses explicit config values", func(t *testing.T) {
+		t.Parallel()
+		cfg := appConfig{
+			MarketBotCacheDB:  "/tmp/custom-cache.db",
+			MarketBotItemData: "/tmp/custom-item-data.json",
+		}
+		cacheDB, itemDataForBot := resolveEmbeddedMarketBotPaths(cfg, "/fallback.json")
+		if cacheDB != "/tmp/custom-cache.db" {
+			t.Fatalf("expected explicit cache db path, got %q", cacheDB)
+		}
+		if itemDataForBot != "/tmp/custom-item-data.json" {
+			t.Fatalf("expected explicit item-data path, got %q", itemDataForBot)
+		}
+	})
+
+	t.Run("falls back to provided item-data path", func(t *testing.T) {
+		t.Parallel()
+		cfg := appConfig{}
+		cacheDB, itemDataForBot := resolveEmbeddedMarketBotPaths(cfg, "/fallback.json")
+		wantCache := filepath.Join(configDir(), "market-bot-cache.db")
+		if cacheDB != wantCache {
+			t.Fatalf("expected default cache path %q, got %q", wantCache, cacheDB)
+		}
+		if itemDataForBot != "/fallback.json" {
+			t.Fatalf("expected fallback item-data path, got %q", itemDataForBot)
+		}
+	})
+}

--- a/cmd/dune-admin/progression_presets.go
+++ b/cmd/dune-admin/progression_presets.go
@@ -89,35 +89,61 @@ var progressionPresets = []progressionPreset{
 
 // cmdApplyProgressionPreset applies a preset by completing each node (and its
 // children + tags) via the existing cmdCompleteJourneyNode logic.
+func progressionPresetByID(presetID string) *progressionPreset {
+	for i := range progressionPresets {
+		if progressionPresets[i].ID == presetID {
+			return &progressionPresets[i]
+		}
+	}
+	return nil
+}
+
+func completionError(presetID, nodeID string, msg msgMutate, ok bool) error {
+	if ok && msg.err == nil {
+		return nil
+	}
+	if ok && msg.err != nil {
+		return fmt.Errorf("apply %s (node %s): %w", presetID, nodeID, msg.err)
+	}
+	return fmt.Errorf("apply %s (node %s): internal error", presetID, nodeID)
+}
+
+func applyProgressionPresetNodes(
+	accountID int64,
+	presetID string,
+	nodeIDs []string,
+	complete func(accountID int64, nodeID string) (msgMutate, bool),
+) (int, int, error) {
+	totalNodes := 0
+	totalTags := 0
+	for _, nodeID := range nodeIDs {
+		msg, ok := complete(accountID, nodeID)
+		if err := completionError(presetID, nodeID, msg, ok); err != nil {
+			return totalNodes, totalTags, err
+		}
+		n, t := parseCompletionCounts(msg.ok)
+		totalNodes += n
+		totalTags += t
+	}
+	return totalNodes, totalTags, nil
+}
+
 func cmdApplyProgressionPreset(accountID int64, presetID string) Cmd {
 	return func() Msg {
 		if globalDB == nil {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
-		var preset *progressionPreset
-		for i := range progressionPresets {
-			if progressionPresets[i].ID == presetID {
-				preset = &progressionPresets[i]
-				break
-			}
-		}
+		preset := progressionPresetByID(presetID)
 		if preset == nil {
 			return msgMutate{err: fmt.Errorf("unknown preset: %s", presetID)}
 		}
 
-		totalNodes := 0
-		totalTags := 0
-		for _, nodeID := range preset.Nodes {
-			msg, ok := cmdCompleteJourneyNode(accountID, nodeID)().(msgMutate)
-			if !ok || msg.err != nil {
-				if msg.err != nil {
-					return msgMutate{err: fmt.Errorf("apply %s (node %s): %w", presetID, nodeID, msg.err)}
-				}
-				return msgMutate{err: fmt.Errorf("apply %s (node %s): internal error", presetID, nodeID)}
-			}
-			n, t := parseCompletionCounts(msg.ok)
-			totalNodes += n
-			totalTags += t
+		totalNodes, totalTags, err := applyProgressionPresetNodes(accountID, presetID, preset.Nodes, func(id int64, nodeID string) (msgMutate, bool) {
+			msg, ok := cmdCompleteJourneyNode(id, nodeID)().(msgMutate)
+			return msg, ok
+		})
+		if err != nil {
+			return msgMutate{err: err}
 		}
 		return msgMutate{ok: fmt.Sprintf(
 			"Applied preset '%s': %d node(s), %d tag(s) — takes effect on next login",

--- a/cmd/dune-admin/progression_presets_test.go
+++ b/cmd/dune-admin/progression_presets_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestProgressionPresetByID(t *testing.T) {
+	t.Parallel()
+
+	preset := progressionPresetByID("skip_npe")
+	if preset == nil {
+		t.Fatalf("expected known preset to be found")
+	}
+	if preset.Name == "" || len(preset.Nodes) == 0 {
+		t.Fatalf("unexpected preset payload: %+v", preset)
+	}
+	if progressionPresetByID("missing") != nil {
+		t.Fatalf("expected unknown preset lookup to return nil")
+	}
+}
+
+func TestApplyProgressionPresetNodes(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	nodes, tags, err := applyProgressionPresetNodes(77, "p1", []string{"A", "B"}, func(accountID int64, nodeID string) (msgMutate, bool) {
+		if accountID != 77 {
+			t.Fatalf("unexpected accountID: %d", accountID)
+		}
+		calls = append(calls, nodeID)
+		switch nodeID {
+		case "A":
+			return msgMutate{ok: "Completed A + 4 node(s), +2 tag(s) — takes effect on next login"}, true
+		case "B":
+			return msgMutate{ok: "Completed B + 1 node(s) — takes effect on next login"}, true
+		default:
+			t.Fatalf("unexpected node %q", nodeID)
+			return msgMutate{}, false
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if nodes != 7 || tags != 2 {
+		t.Fatalf("unexpected totals: nodes=%d tags=%d", nodes, tags)
+	}
+	if len(calls) != 2 || calls[0] != "A" || calls[1] != "B" {
+		t.Fatalf("unexpected call order: %v", calls)
+	}
+}
+
+func TestApplyProgressionPresetNodes_Errors(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := applyProgressionPresetNodes(1, "p2", []string{"A"}, func(int64, string) (msgMutate, bool) {
+		return msgMutate{}, false
+	})
+	if err == nil || err.Error() != "apply p2 (node A): internal error" {
+		t.Fatalf("unexpected internal-error result: %v", err)
+	}
+
+	_, _, err = applyProgressionPresetNodes(1, "p3", []string{"B"}, func(int64, string) (msgMutate, bool) {
+		return msgMutate{err: errors.New("nope")}, true
+	})
+	if err == nil || err.Error() != "apply p3 (node B): nope" {
+		t.Fatalf("unexpected wrapped error: %v", err)
+	}
+}

--- a/cmd/dune-admin/render_k8s.go
+++ b/cmd/dune-admin/render_k8s.go
@@ -1,0 +1,347 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func durationOr(d, def time.Duration) time.Duration {
+	if d > 0 {
+		return d
+	}
+	return def
+}
+
+func yamlScalar(s string) string {
+	b, err := yaml.Marshal(s)
+	if err != nil {
+		return strconv.Quote(s)
+	}
+	return strings.TrimSpace(string(b))
+}
+
+func indentLines(s, prefix string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i, line := range lines {
+		lines[i] = prefix + line
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func renderK8SManifest(outPath string) error {
+	control := firstNonEmpty(controlPlane, loadedConfig.Control)
+	if control == "" {
+		control = resolveControl()
+	}
+	listen := firstNonEmpty(listenAddr, loadedConfig.ListenAddr)
+	if listen == "" {
+		listen = ":8080"
+	}
+
+	dbHostVal := firstNonEmpty(dbHost, loadedConfig.DBHost, "postgres.default.svc.cluster.local")
+	dbPortVal := dbPort
+	if dbPortVal == 0 {
+		if loadedConfig.DBPort != 0 {
+			dbPortVal = loadedConfig.DBPort
+		} else {
+			dbPortVal = 15432
+		}
+	}
+	dbUserVal := firstNonEmpty(dbUser, loadedConfig.DBUser, "dune")
+	dbNameVal := firstNonEmpty(dbName, loadedConfig.DBName, "dune")
+	dbSchemaVal := firstNonEmpty(dbSchema, loadedConfig.DBSchema, "dune")
+	dbPassVal := firstNonEmpty(dbPass, loadedConfig.DBPass, "replace-me")
+
+	buyInt := durationOr(loadedConfig.MarketBotBuyInt, 5*time.Minute)
+	listInt := durationOr(loadedConfig.MarketBotListInt, 30*time.Minute)
+	cacheDB := firstNonEmpty(loadedConfig.MarketBotCacheDB, "/data/market-bot-cache.db")
+	itemData := firstNonEmpty(loadedConfig.MarketBotItemData, "/app/item-data.json")
+	buyThreshold := loadedConfig.MarketBotThresh
+	if buyThreshold == 0 {
+		buyThreshold = 1.05
+	}
+	maxBuys := loadedConfig.MarketBotMaxBuys
+	if maxBuys == 0 {
+		maxBuys = 50
+	}
+
+	manifestCfg := map[string]any{
+		"control":                  control,
+		"listen_addr":              listen,
+		"db_host":                  dbHostVal,
+		"db_port":                  dbPortVal,
+		"db_user":                  dbUserVal,
+		"db_name":                  dbNameVal,
+		"db_schema":                dbSchemaVal,
+		"market_bot_enabled":       loadedConfig.MarketBotEnabled,
+		"market_bot_cache_db":      cacheDB,
+		"market_bot_item_data":     itemData,
+		"market_bot_buy_interval":  buyInt.String(),
+		"market_bot_list_interval": listInt.String(),
+		"market_bot_buy_threshold": buyThreshold,
+		"market_bot_max_buys":      maxBuys,
+	}
+	if loadedConfig.SSHHost != "" {
+		manifestCfg["ssh_host"] = loadedConfig.SSHHost
+	}
+	if loadedConfig.SSHUser != "" {
+		manifestCfg["ssh_user"] = loadedConfig.SSHUser
+	}
+	if loadedConfig.SSHKey != "" {
+		manifestCfg["ssh_key"] = loadedConfig.SSHKey
+	}
+	if loadedConfig.ControlNamespace != "" {
+		manifestCfg["control_namespace"] = loadedConfig.ControlNamespace
+	}
+	if loadedConfig.BrokerGameAddr != "" {
+		manifestCfg["broker_game_addr"] = loadedConfig.BrokerGameAddr
+	}
+	if loadedConfig.BrokerAdminAddr != "" {
+		manifestCfg["broker_admin_addr"] = loadedConfig.BrokerAdminAddr
+	}
+	if loadedConfig.BrokerTLS {
+		manifestCfg["broker_tls"] = true
+	}
+	if loadedConfig.ServerIniDir != "" {
+		manifestCfg["server_ini_dir"] = loadedConfig.ServerIniDir
+	}
+	if loadedConfig.DefaultIniDir != "" {
+		manifestCfg["default_ini_dir"] = loadedConfig.DefaultIniDir
+	}
+	if loadedConfig.BackupDir != "" {
+		manifestCfg["backup_dir"] = loadedConfig.BackupDir
+	}
+	if loadedConfig.Control == "amp" || control == "amp" {
+		if loadedConfig.AmpInstance != "" {
+			manifestCfg["amp_instance"] = loadedConfig.AmpInstance
+		}
+		if loadedConfig.AmpContainer != "" {
+			manifestCfg["amp_container"] = loadedConfig.AmpContainer
+		}
+		if loadedConfig.AmpUser != "" {
+			manifestCfg["amp_user"] = loadedConfig.AmpUser
+		}
+		if loadedConfig.AmpLogPath != "" {
+			manifestCfg["amp_log_path"] = loadedConfig.AmpLogPath
+		}
+		if loadedConfig.AmpUseContainer != nil {
+			manifestCfg["amp_use_container"] = *loadedConfig.AmpUseContainer
+		}
+		if loadedConfig.AmpDataRoot != "" {
+			manifestCfg["amp_data_root"] = loadedConfig.AmpDataRoot
+		}
+		if loadedConfig.DirectorURL != "" {
+			manifestCfg["director_url"] = loadedConfig.DirectorURL
+		}
+	}
+
+	cfgYAMLBytes, err := yaml.Marshal(manifestCfg)
+	if err != nil {
+		return fmt.Errorf("marshal embedded config: %w", err)
+	}
+
+	brokerUserVal := firstNonEmpty(brokerUser, loadedConfig.BrokerUser)
+	brokerPassVal := firstNonEmpty(brokerPass, loadedConfig.BrokerPass)
+	brokerJWTVal := firstNonEmpty(os.Getenv("BROKER_JWT_SECRET"), loadedConfig.BrokerJWTSecret)
+
+	var out strings.Builder
+	out.WriteString("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: dune-admin\n---\n")
+	out.WriteString("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: dune-admin-config\n  namespace: dune-admin\n")
+	out.WriteString("data:\n")
+	out.WriteString("  DB_HOST: " + yamlScalar(dbHostVal) + "\n")
+	out.WriteString("  DB_PORT: " + yamlScalar(strconv.Itoa(dbPortVal)) + "\n")
+	out.WriteString("  DB_USER: " + yamlScalar(dbUserVal) + "\n")
+	out.WriteString("  DB_NAME: " + yamlScalar(dbNameVal) + "\n")
+	out.WriteString("  DB_SCHEMA: " + yamlScalar(dbSchemaVal) + "\n")
+	out.WriteString("  LISTEN_ADDR: " + yamlScalar(listen) + "\n")
+	out.WriteString("  CONTROL: " + yamlScalar(control) + "\n")
+	out.WriteString("  MARKET_BOT_ENABLED: " + yamlScalar(strconv.FormatBool(loadedConfig.MarketBotEnabled)) + "\n")
+	out.WriteString("  MARKET_BOT_BUY_INTERVAL: " + yamlScalar(buyInt.String()) + "\n")
+	out.WriteString("  MARKET_BOT_LIST_INTERVAL: " + yamlScalar(listInt.String()) + "\n")
+	out.WriteString("  config.yaml: |\n")
+	out.WriteString(indentLines(string(cfgYAMLBytes), "    "))
+
+	out.WriteString("---\napiVersion: v1\nkind: Secret\nmetadata:\n  name: dune-admin-secrets\n  namespace: dune-admin\n")
+	out.WriteString("type: Opaque\nstringData:\n")
+	out.WriteString("  DB_PASS: " + yamlScalar(dbPassVal) + "\n")
+	out.WriteString("  BROKER_USER: " + yamlScalar(brokerUserVal) + "\n")
+	out.WriteString("  BROKER_PASS: " + yamlScalar(brokerPassVal) + "\n")
+	out.WriteString("  BROKER_JWT_SECRET: " + yamlScalar(brokerJWTVal) + "\n")
+
+	out.WriteString(`---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: market-bot-cache
+  namespace: dune-admin
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dune-admin
+  namespace: dune-admin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dune-admin
+  template:
+    metadata:
+      labels:
+        app: dune-admin
+    spec:
+      containers:
+        - name: dune-admin
+          image: ghcr.io/icehunter/dune-admin:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: DB_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: DB_HOST
+            - name: DB_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: DB_PORT
+            - name: DB_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: DB_USER
+            - name: DB_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: DB_NAME
+            - name: DB_SCHEMA
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: DB_SCHEMA
+            - name: LISTEN_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: LISTEN_ADDR
+            - name: CONTROL
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: CONTROL
+            - name: MARKET_BOT_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: MARKET_BOT_ENABLED
+            - name: MARKET_BOT_BUY_INTERVAL
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: MARKET_BOT_BUY_INTERVAL
+            - name: MARKET_BOT_LIST_INTERVAL
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: MARKET_BOT_LIST_INTERVAL
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: dune-admin-secrets
+                  key: DB_PASS
+            - name: BROKER_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dune-admin-secrets
+                  key: BROKER_USER
+            - name: BROKER_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: dune-admin-secrets
+                  key: BROKER_PASS
+            - name: BROKER_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: dune-admin-secrets
+                  key: BROKER_JWT_SECRET
+          volumeMounts:
+            - name: market-bot-cache
+              mountPath: /data
+            - name: config
+              mountPath: /root/.dune-admin/config.yaml
+              subPath: config.yaml
+          readinessProbe:
+            httpGet:
+              path: /api/v1/status
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/v1/status
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+      volumes:
+        - name: market-bot-cache
+          persistentVolumeClaim:
+            claimName: market-bot-cache
+        - name: config
+          configMap:
+            name: dune-admin-config
+            items:
+              - key: config.yaml
+                path: config.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dune-admin
+  namespace: dune-admin
+spec:
+  selector:
+    app: dune-admin
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  type: ClusterIP
+`)
+
+	if outPath == "-" {
+		fmt.Print(out.String())
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	if err := os.WriteFile(outPath, []byte(out.String()), 0o644); err != nil {
+		return fmt.Errorf("write manifest %s: %w", outPath, err)
+	}
+	return nil
+}

--- a/cmd/dune-admin/server.go
+++ b/cmd/dune-admin/server.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 )
@@ -238,19 +236,6 @@ func startServer(addr string) {
 		}
 	}
 
-	// ── SPA frontend (universal, opt-in) ────────────────────────────────────
-	candidates := []string{"./dist", "./web/dist"}
-	if loadedConfig.FrontendDir != "" {
-		candidates = append([]string{loadedConfig.FrontendDir}, candidates...)
-	}
-	for _, dir := range candidates {
-		if info, err := os.Stat(dir); err == nil && info.IsDir() {
-			log.Printf("Serving frontend from %s", dir)
-			mux.Handle("/", spaHandler(dir))
-			break
-		}
-	}
-
 	srv := &http.Server{
 		Addr:              addr,
 		Handler:           corsMiddleware(mux),
@@ -261,26 +246,6 @@ func startServer(addr string) {
 	}
 	log.Printf("dune-admin listening on %s", addr)
 	log.Fatal(srv.ListenAndServe())
-}
-
-// spaHandler serves static files from distDir, falling back to index.html
-// for any path that doesn't match a real file (client-side routing).
-func spaHandler(distDir string) http.Handler {
-	fileServer := http.FileServer(http.Dir(distDir))
-	cleanDist := filepath.Clean(distDir)
-	sep := string(filepath.Separator)
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		p := filepath.Join(cleanDist, filepath.FromSlash(r.URL.Path))
-		if p != cleanDist && !strings.HasPrefix(p, cleanDist+sep) {
-			http.NotFound(w, r)
-			return
-		}
-		if _, err := os.Stat(p); err == nil { // #nosec G703 -- path validated against cleanDist prefix above
-			fileServer.ServeHTTP(w, r)
-			return
-		}
-		http.ServeFile(w, r, filepath.Join(cleanDist, "index.html"))
-	})
 }
 
 // ── JSON helpers ──────────────────────────────────────────────────────────────

--- a/cmd/dune-admin/setup.go
+++ b/cmd/dune-admin/setup.go
@@ -103,7 +103,7 @@ func runSetup() {
 
 // ── kubectl setup flow ────────────────────────────────────────────────────────
 
-func runKubectlSetup(ask func(string, string) string, ok, fail func(string), cfg *appConfig) {
+func setupKubectlSSHKey(ask func(string, string) string, ok, fail func(string)) string {
 	// SSH key
 	fmt.Println("Checking for SSH key...")
 	keyPath := resolveKeyPath()
@@ -125,7 +125,14 @@ func runKubectlSetup(ask func(string, string) string, ok, fail func(string), cfg
 		sshKeyPath = keyPath
 	}
 	fmt.Println()
+	return keyPath
+}
 
+func setupKubectlSSHConnection(
+	ask func(string, string) string,
+	ok, fail func(string),
+	keyPath string,
+) *sshExecutor {
 	// SSH connection details
 	fmt.Println("SSH connection:")
 	sshHost = ask("VM host:port", envOr("SSH_HOST", "192.168.0.72:22"))
@@ -150,24 +157,58 @@ func runKubectlSetup(ask func(string, string) string, ok, fail func(string), cfg
 	}
 	ok("SSH connected")
 	fmt.Println()
+	globalSSH = client
+	return &sshExecutor{client: client}
+}
 
+func setupKubectlDiscoverDBPod(exec *sshExecutor, ok, fail func(string), cfg *appConfig) {
 	// Discover DB pod
 	fmt.Println("Discovering database pod...")
-	sshExecWrap := &sshExecutor{client: client}
-	ns, pod, podIP, err := discoverDBPod(sshExecWrap)
+	ns, pod, podIP, err := discoverDBPod(exec)
 	if err != nil {
 		fail("Pod discovery failed: " + err.Error())
 		fmt.Println()
 		fmt.Println("  Make sure the SSH user can run: sudo kubectl get pods -A")
 		exitSetup(1)
 	}
-	globalSSH = client
 	globalPodNS = ns
 	globalPod = pod
 	globalPodIP = podIP
+	cfg.ControlNamespace = ns
+	controlNS = ns
 	ok("Database pod: " + pod)
 	fmt.Println()
+}
 
+func selectBattlegroup(battlegroups []string, ask func(string, string) string) string {
+	if len(battlegroups) == 0 {
+		return ""
+	}
+	chosen := battlegroups[0]
+	if len(battlegroups) == 1 {
+		return chosen
+	}
+
+	fmt.Println("  Available battlegroups:")
+	for i, bg := range battlegroups {
+		fmt.Printf("    [%d] %s\n", i+1, bg)
+	}
+	fmt.Println()
+	idxStr := ask(fmt.Sprintf("Which battlegroup? [1-%d]", len(battlegroups)), "1")
+	idx := 1
+	_, _ = fmt.Sscanf(idxStr, "%d", &idx)
+	if idx >= 1 && idx <= len(battlegroups) {
+		chosen = battlegroups[idx-1]
+	}
+	return chosen
+}
+
+func setupKubectlDiscoverDBCredentials(
+	exec *sshExecutor,
+	ask func(string, string) string,
+	ok, fail func(string),
+	cfg *appConfig,
+) (string, string) {
 	// Discover DB password
 	fmt.Println("Discovering database password...")
 	discoveredUser := "postgres"
@@ -177,36 +218,21 @@ func runKubectlSetup(ask func(string, string) string, ok, fail func(string), cfg
 	if bg := battlegroupFromPod(globalPod); bg != "" {
 		battlegroups = []string{bg}
 	} else {
-		battlegroups = listBattlegroups(sshExecWrap)
+		battlegroups = listBattlegroups(exec)
 	}
 
 	if len(battlegroups) == 0 {
 		fmt.Println("  Could not determine battlegroup name")
 	} else {
-		chosen := battlegroups[0]
-		if len(battlegroups) > 1 {
-			fmt.Println("  Available battlegroups:")
-			for i, bg := range battlegroups {
-				fmt.Printf("    [%d] %s\n", i+1, bg)
-			}
-			fmt.Println()
-			idxStr := ask(fmt.Sprintf("Which battlegroup? [1-%d]", len(battlegroups)), "1")
-			idx := 1
-			_, _ = fmt.Sscanf(idxStr, "%d", &idx)
-			if idx >= 1 && idx <= len(battlegroups) {
-				chosen = battlegroups[idx-1]
-			}
-		}
+		chosen := selectBattlegroup(battlegroups, ask)
 		yamlPath := fmt.Sprintf("~/.dune/%s.yaml", chosen)
-		if u, pass := extractPasswordFromYAML(sshExecWrap, yamlPath); pass != "" {
+		if u, pass := extractPasswordFromYAML(exec, yamlPath); pass != "" {
 			discoveredUser = u
 			discoveredPass = pass
 			ok(fmt.Sprintf("Password found in %s (user: %s)", yamlPath, u))
 		} else {
 			fail("No password found in " + yamlPath)
 		}
-		cfg.ControlNamespace = ns
-		controlNS = ns
 	}
 
 	if discoveredPass == "" {
@@ -220,7 +246,15 @@ func runKubectlSetup(ask func(string, string) string, ok, fail func(string), cfg
 		}
 	}
 	fmt.Println()
+	return discoveredUser, discoveredPass
+}
 
+func setupKubectlConnectDB(
+	discoveredUser, discoveredPass string,
+	exec *sshExecutor,
+	cfg *appConfig,
+	ok, fail func(string),
+) {
 	// Connect to DB
 	fmt.Println("Connecting to database...")
 	dbUser = discoveredUser
@@ -233,11 +267,21 @@ func runKubectlSetup(ask func(string, string) string, ok, fail func(string), cfg
 		exitSetup(1)
 	}
 	globalDB = pool
-	globalExecutor = sshExecWrap
+	globalExecutor = exec
 	globalControl = newControlPlane("kubectl", *cfg)
 	ok("Database connected as: " + dbUser)
 	fmt.Println()
+}
 
+func runKubectlSetup(ask func(string, string) string, ok, fail func(string), cfg *appConfig) {
+	keyPath := setupKubectlSSHKey(ask, ok, fail)
+	exec := setupKubectlSSHConnection(ask, ok, fail, keyPath)
+	setupKubectlDiscoverDBPod(exec, ok, fail, cfg)
+	discoveredUser, discoveredPass := setupKubectlDiscoverDBCredentials(exec, ask, ok, fail, cfg)
+	setupKubectlConnectDB(discoveredUser, discoveredPass, exec, cfg, ok, fail)
+
+	cfg.ControlNamespace = globalPodNS
+	controlNS = globalPodNS
 	if abs, err := filepath.Abs(keyPath); err == nil {
 		keyPath = abs
 	}

--- a/cmd/dune-admin/setup.go
+++ b/cmd/dune-admin/setup.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -74,14 +76,19 @@ func runSetup() {
 		runAmpSetup(ask, ok, fail, &cfg)
 	}
 
-	// ── Market bot (optional) ──────────────────────────────────────────────────
+	// ── Embedded market bot ────────────────────────────────────────────────────
 
-	runMarketBotSetup(ask, ok, ctrl, &cfg)
+	runMarketBotSetup(ask, ok, &cfg)
 
 	// ── Common: listen address ─────────────────────────────────────────────────
 
 	fmt.Println("Server config:")
-	cfg.ListenAddr = ask("HTTP listen address", listenAddr)
+	defaultListenAddr := listenAddr
+	if ctrl == "amp" && (defaultListenAddr == "" || defaultListenAddr == ":8080") {
+		// AMP web panel commonly binds :8080 on host installs.
+		defaultListenAddr = ":18080"
+	}
+	cfg.ListenAddr = ask("HTTP listen address", defaultListenAddr)
 	fmt.Println()
 
 	// ── Write config ───────────────────────────────────────────────────────────
@@ -442,50 +449,49 @@ func runAmpSetup(ask func(string, string) string, ok, fail func(string), cfg *ap
 	cfg.ScripCurrency = scripCurrencyID
 }
 
-// ── Market bot setup (optional) ───────────────────────────────────────────────
+// ── Market bot setup ───────────────────────────────────────────────────────────
 
-// runMarketBotSetup asks optional market-bot connection details.
-// Defaults: container/deployment = "market-bot"; addr derived from SSH host
-// (kubectl) or localhost (docker/local). Blank responses skip the section.
-func runMarketBotSetup(ask func(string, string) string, ok func(string), ctrl string, cfg *appConfig) {
-	fmt.Println("Market bot (optional — press Enter to skip each field):")
-
-	// Compute a sensible default address.
-	defaultAddr := "http://localhost:8081"
-	if ctrl == "kubectl" && sshHost != "" {
-		host := sshHost
-		if h, _, err := splitHostPort(host); err == nil {
-			host = h
-		}
-		defaultAddr = "http://" + host + ":8081"
+func runMarketBotSetup(ask func(string, string) string, ok func(string), cfg *appConfig) {
+	fmt.Println("Embedded market bot:")
+	enabled := strings.ToLower(strings.TrimSpace(ask("Enable embedded market bot [yes/no]", "yes")))
+	cfg.MarketBotEnabled = enabled != "n" && enabled != "no" && enabled != "false" && enabled != "0"
+	if !cfg.MarketBotEnabled {
+		ok("Embedded market bot disabled")
+		fmt.Println()
+		return
 	}
 
-	cfg.MarketBotAddr = ask("Bot API address", defaultAddr)
+	cfg.MarketBotCacheDB = ask("Bot cache database path", filepath.Join(configDir(), "market-bot-cache.db"))
+	cfg.MarketBotItemData = ask("Bot item-data.json path (optional)", "")
 
-	// Only ask for the rest if an address was supplied.
-	if cfg.MarketBotAddr != "" {
-		cfg.MarketBotToken = ask("Bot API token (optional)", "")
-		cfg.MarketBotContainer = ask("Bot deployment/container name", "market-bot")
-		if ctrl == "kubectl" {
-			cfg.MarketBotNamespace = ask("Bot k8s namespace", "dune-market-bot")
+	parseDur := func(input string, fallback time.Duration) time.Duration {
+		d, err := time.ParseDuration(strings.TrimSpace(input))
+		if err != nil || d <= 0 {
+			return fallback
 		}
-		marketBotAddr = cfg.MarketBotAddr
-		marketBotToken = cfg.MarketBotToken
-		marketBotContainer = cfg.MarketBotContainer
-		marketBotNamespace = cfg.MarketBotNamespace
-		ok("Market bot configured at " + cfg.MarketBotAddr)
+		return d
 	}
+	parseFloat := func(input string, fallback float64) float64 {
+		v, err := strconv.ParseFloat(strings.TrimSpace(input), 64)
+		if err != nil || v <= 0 {
+			return fallback
+		}
+		return v
+	}
+	parseInt := func(input string, fallback int) int {
+		v, err := strconv.Atoi(strings.TrimSpace(input))
+		if err != nil || v <= 0 {
+			return fallback
+		}
+		return v
+	}
+
+	cfg.MarketBotBuyInt = parseDur(ask("Buy tick interval", "5m"), 5*time.Minute)
+	cfg.MarketBotListInt = parseDur(ask("List tick interval", "30m"), 30*time.Minute)
+	cfg.MarketBotThresh = parseFloat(ask("Buy threshold multiplier", "1.05"), 1.05)
+	cfg.MarketBotMaxBuys = parseInt(ask("Max buys per tick", "50"), 50)
+	ok("Embedded market bot configured")
 	fmt.Println()
-}
-
-// splitHostPort splits host:port. Returns an error if no port is present.
-func splitHostPort(hostport string) (host, port string, err error) {
-	for i := len(hostport) - 1; i >= 0; i-- {
-		if hostport[i] == ':' {
-			return hostport[:i], hostport[i+1:], nil
-		}
-	}
-	return "", "", fmt.Errorf("no port")
 }
 
 // ── Write config ──────────────────────────────────────────────────────────────

--- a/cmd/dune-admin/setup_kubectl_test.go
+++ b/cmd/dune-admin/setup_kubectl_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+func TestSelectBattlegroup(t *testing.T) {
+	t.Parallel()
+
+	if got := selectBattlegroup(nil, func(string, string) string { return "" }); got != "" {
+		t.Fatalf("expected empty selection for no battlegroups, got %q", got)
+	}
+
+	if got := selectBattlegroup([]string{"alpha"}, func(string, string) string { return "1" }); got != "alpha" {
+		t.Fatalf("expected single battlegroup selection, got %q", got)
+	}
+
+	groups := []string{"alpha", "beta", "gamma"}
+	if got := selectBattlegroup(groups, func(string, string) string { return "2" }); got != "beta" {
+		t.Fatalf("expected selection index 2 => beta, got %q", got)
+	}
+
+	if got := selectBattlegroup(groups, func(string, string) string { return "99" }); got != "alpha" {
+		t.Fatalf("expected invalid selection to fall back to first, got %q", got)
+	}
+}

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,0 +1,260 @@
+[CmdletBinding()]
+param(
+  [string]$VmUser = "dune",
+  [string]$VmHost = "192.168.0.72",
+  [string]$SshKeyPath = "",
+  [string]$KubeconfigPath = "$HOME/.kube/dune-external.yaml",
+  [string]$Image = "",
+  [string]$Namespace = "dune-admin",
+  [string]$Manifest = "deploy/k8s/dune-admin.rendered.yaml",
+  [switch]$SkipKubeconfig,
+  [switch]$SkipBuild,
+  [switch]$SkipImageImport,
+  [switch]$PortForward,
+  [switch]$NoPortForward
+)
+
+$ErrorActionPreference = "Stop"
+
+function Require-Command([string]$Name) {
+  if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+    throw "Missing required command: $Name"
+  }
+}
+
+function Invoke-Step([string]$Label, [scriptblock]$Action) {
+  Write-Host "==> $Label"
+  & $Action
+}
+
+function Get-SshOptionArgs([string]$KeyPath) {
+  $args = @(
+    "-o", "PreferredAuthentications=publickey,password",
+    "-o", "PubkeyAuthentication=yes",
+    "-o", "PasswordAuthentication=yes"
+  )
+  if ($KeyPath) {
+    $args += @("-i", $KeyPath, "-o", "IdentitiesOnly=yes")
+  }
+  return $args
+}
+
+$repoRoot = Split-Path -Parent $PSCommandPath
+Set-Location $repoRoot
+
+Require-Command kubectl
+Require-Command ssh
+Require-Command scp
+Require-Command docker
+Require-Command make
+
+if (-not $SshKeyPath) {
+  $localKey = Join-Path $repoRoot "sshKey"
+  if (Test-Path $localKey) {
+    $SshKeyPath = $localKey
+  }
+}
+if (-not $Image) {
+  if ($SkipBuild -or $SkipImageImport) {
+    $Image = "dune-admin:local"
+  } else {
+    $Image = "dune-admin:local-$(Get-Date -Format 'yyyyMMddHHmmss')"
+  }
+}
+if ($SshKeyPath -and -not (Test-Path $SshKeyPath)) {
+  throw "SSH key not found: $SshKeyPath"
+}
+if ($SshKeyPath) {
+  Write-Host "Using SSH key: $SshKeyPath (fallback to password enabled)"
+} else {
+  Write-Host "No SSH key provided/found; using password auth (or agent) for SSH."
+}
+$sshOpts = Get-SshOptionArgs -KeyPath $SshKeyPath
+
+if (-not $SkipKubeconfig) {
+  Invoke-Step "Pulling kubeconfig from $VmUser@$VmHost" {
+    $dir = Split-Path -Parent $KubeconfigPath
+    if (-not (Test-Path $dir)) {
+      New-Item -Path $dir -ItemType Directory -Force | Out-Null
+    }
+    & ssh @sshOpts "$VmUser@$VmHost" "sudo cat /etc/rancher/k3s/k3s.yaml" | Out-File -FilePath $KubeconfigPath -Encoding utf8NoBOM
+    $raw = Get-Content -Path $KubeconfigPath -Raw
+    $raw.Replace("127.0.0.1", $VmHost) | Set-Content -Path $KubeconfigPath -Encoding utf8NoBOM
+  }
+}
+
+$env:KUBECONFIG = $KubeconfigPath
+Write-Host "Using KUBECONFIG=$($env:KUBECONFIG)"
+kubectl get nodes
+
+if (-not $SkipBuild) {
+  Invoke-Step "Building image $Image" {
+    docker buildx build --platform linux/amd64 -f deploy/Dockerfile -t $Image --load .
+  }
+}
+
+if (-not $SkipImageImport) {
+  Invoke-Step "Importing image into k3s runtime on $VmHost" {
+    $tmpTar = Join-Path $env:TEMP "dune-admin-image.tar"
+    if (Test-Path $tmpTar) { Remove-Item $tmpTar -Force }
+    docker save -o $tmpTar $Image
+    & scp @sshOpts $tmpTar "$VmUser@${VmHost}:/tmp/dune-admin-image.tar"
+    & ssh @sshOpts "$VmUser@$VmHost" "sudo k3s ctr images import /tmp/dune-admin-image.tar && rm -f /tmp/dune-admin-image.tar"
+    Remove-Item $tmpTar -Force
+  }
+}
+
+Invoke-Step "Rendering manifest" {
+  make render-k8s
+}
+
+if (-not (Test-Path $Manifest)) {
+  throw "Manifest not found: $Manifest"
+}
+
+$manifestText = Get-Content -Path $Manifest -Raw
+$patched = [regex]::Replace($manifestText, '(?m)^(\s*image:\s*).*$', "`$1$Image", 1)
+if ($patched -eq $manifestText) {
+  throw "No image: field found to patch in manifest"
+}
+
+$dbHostOverride = ""
+$controlNsMatch = [regex]::Match($patched, '(?m)^\s*control_namespace:\s*"?([^\s"]+)"?\s*$')
+if ($controlNsMatch.Success) {
+  $controlNs = $controlNsMatch.Groups[1].Value
+  $svcRows = kubectl -n $controlNs get svc -o jsonpath='{range .items[*]}{.metadata.name}{"`t"}{range .spec.ports[*]}{.port}{" "}{end}{"`n"}{end}' 2>$null
+  $dbSvcRow = $svcRows | Where-Object { $_ -match '(^|[ \t])15432([ \t]|$)' } | Select-Object -First 1
+  if ($dbSvcRow) {
+    $dbSvc = ($dbSvcRow -split '\s+')[0]
+    if ($dbSvc) {
+      $dbHostOverride = "$dbSvc.$controlNs.svc.cluster.local"
+      Write-Host "Using in-cluster DB host: $dbHostOverride"
+    }
+  }
+}
+
+$patched = [regex]::Replace($patched, '(?m)^(\s*CONTROL:\s*).*$', '${1}"local"')
+$patched = [regex]::Replace($patched, '(?m)^\s*cmd_(status|start|stop|restart):\s*.*\r?\n', '')
+$patched = [regex]::Replace($patched, '(?m)^(\s*control:\s*).*$', '${1}local')
+if ($dbHostOverride) {
+  $patched = [regex]::Replace($patched, '(?m)^(\s*DB_HOST:\s*).*$', '${1}"' + $dbHostOverride + '"')
+  $patched = [regex]::Replace($patched, '(?m)^(\s*db_host:\s*).*$', '${1}' + $dbHostOverride)
+}
+$patched = [regex]::Replace($patched, '(?m)^\s*ssh_host:\s*.*\r?\n', '')
+$patched = [regex]::Replace($patched, '(?m)^\s*ssh_user:\s*.*\r?\n', '')
+$patched = [regex]::Replace($patched, '(?m)^\s*ssh_key:\s*.*\r?\n', '')
+$patched = [regex]::Replace($patched, '(?m)^(\s*MARKET_BOT_ENABLED:\s*).*$', '${1}"true"')
+$patched = [regex]::Replace($patched, '(?m)^(\s*market_bot_enabled:\s*).*$', '${1}true')
+$patched = [regex]::Replace($patched, '(?m)^(\s*market_bot_item_data:\s*).*$', '${1}/app/item-data.json')
+$patched = [regex]::Replace($patched, '(?m)^(\s*market_bot_cache_db:\s*).*$', '${1}/data/market-bot-cache.db')
+$patched | Set-Content -Path $Manifest -Encoding utf8NoBOM
+
+Invoke-Step "Applying manifest" {
+  kubectl apply -f $Manifest
+  if ($controlNsMatch.Success) {
+    $rbac = @"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dune-admin-runtime
+  namespace: $controlNs
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "services", "endpoints", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get"]
+  - apiGroups: ["igw.funcom.com"]
+    resources: ["battlegroups", "serverstats"]
+    verbs: ["get", "list", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dune-admin-runtime
+  namespace: $controlNs
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: $Namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dune-admin-runtime
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dune-admin-operators-logs
+  namespace: funcom-operators
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dune-admin-operators-logs
+  namespace: funcom-operators
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: $Namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dune-admin-operators-logs
+"@
+    $rbac | kubectl apply -f -
+  }
+  kubectl -n $Namespace rollout restart deploy/dune-admin
+  kubectl -n $Namespace rollout status deploy/dune-admin
+  kubectl -n $Namespace get pods,svc
+}
+
+Invoke-Step "In-cluster health checks (fast-fail, no pod waits)" {
+  $stalePods = kubectl -n $Namespace get pods --no-headers 2>$null | `
+    Where-Object { $_ -match '^(curl|curl-check-)' } | `
+    ForEach-Object { ($_ -split '\s+')[0] }
+  foreach ($p in $stalePods) {
+    if ($p) { kubectl -n $Namespace delete pod $p --ignore-not-found | Out-Null }
+  }
+
+  $statusPath = "/api/v1/namespaces/$Namespace/services/http:dune-admin:8080/proxy/api/v1/status"
+  $botPath = "/api/v1/namespaces/$Namespace/services/http:dune-admin:8080/proxy/api/v1/market-bot/status"
+  $bgPath = "/api/v1/namespaces/$Namespace/services/http:dune-admin:8080/proxy/api/v1/battlegroup/status"
+
+  $healthOk = $false
+  $lastStatus = ""
+  $lastBot = ""
+  $lastBg = ""
+  for ($i = 1; $i -le 30; $i++) {
+    $lastStatus = (kubectl --request-timeout=5s get --raw $statusPath 2>$null)
+    $lastBot = (kubectl --request-timeout=5s get --raw $botPath 2>$null)
+    $lastBg = (kubectl --request-timeout=5s get --raw $bgPath 2>$null)
+
+    $botOk = $lastBot -match '"enabled":true'
+    $bgOk = $lastBg -notmatch "does not support GetStatus"
+    if ($lastStatus -and $botOk -and $bgOk) {
+      Write-Host $lastBot
+      $healthOk = $true
+      break
+    }
+    if (($i % 5) -eq 0) {
+      Write-Host "Health check retry $i/30..."
+    }
+    Start-Sleep -Seconds 1
+  }
+  if (-not $healthOk) {
+    throw "health check failed: API or embedded market-bot not ready`nlast /api/v1/status: $lastStatus`nlast /api/v1/market-bot/status: $lastBot`nlast /api/v1/battlegroup/status: $lastBg"
+  }
+}
+
+if ($PortForward -and -not $NoPortForward) {
+  Write-Host "Opening API port-forward at http://127.0.0.1:8080 ..."
+  kubectl -n $Namespace port-forward svc/dune-admin 8080:8080
+} else {
+  Write-Host "Deploy complete. Run ./listen.ps1 to open API port-forward."
+}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+VM_USER="${VM_USER:-dune}"
+VM_HOST="${VM_HOST:-192.168.0.72}"
+SSH_KEY_PATH="${SSH_KEY_PATH:-}"
+KUBECONFIG_PATH="${KUBECONFIG_PATH:-$HOME/.kube/dune-external.yaml}"
+IMAGE="${IMAGE:-}"
+NAMESPACE="${NAMESPACE:-dune-admin}"
+MANIFEST="${MANIFEST:-deploy/k8s/dune-admin.rendered.yaml}"
+SKIP_KUBECONFIG=0
+SKIP_BUILD=0
+SKIP_IMAGE_IMPORT=0
+NO_PORT_FORWARD=1
+
+usage() {
+  cat <<'EOF'
+Usage: ./deploy.sh [options]
+
+Options:
+  --vm-user <user>           VM SSH user (default: dune)
+  --vm-host <host>           VM host/IP (default: 192.168.0.72)
+  --ssh-key <path>           SSH key path (default: ./sshKey when present)
+  --kubeconfig <path>        Local kubeconfig path (default: ~/.kube/dune-external.yaml)
+  --image <name:tag>         Image tag to build/deploy
+                              default: dune-admin:local-<timestamp>
+                              when skipping build/import: dune-admin:local
+  --namespace <ns>           K8s namespace (default: dune-admin)
+  --manifest <path>          Rendered manifest path (default: deploy/k8s/dune-admin.rendered.yaml)
+  --skip-kubeconfig          Reuse existing kubeconfig without pulling from VM
+  --skip-build               Skip docker build step
+  --skip-image-import        Skip VM k3s image import step
+  --port-forward             Open kubectl port-forward after deploy
+  --no-port-forward          Skip kubectl port-forward after deploy (default)
+  -h, --help                 Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --vm-user) VM_USER="$2"; shift 2 ;;
+    --vm-host) VM_HOST="$2"; shift 2 ;;
+    --ssh-key) SSH_KEY_PATH="$2"; shift 2 ;;
+    --kubeconfig) KUBECONFIG_PATH="$2"; shift 2 ;;
+    --image) IMAGE="$2"; shift 2 ;;
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --manifest) MANIFEST="$2"; shift 2 ;;
+    --skip-kubeconfig) SKIP_KUBECONFIG=1; shift ;;
+    --skip-build) SKIP_BUILD=1; shift ;;
+    --skip-image-import) SKIP_IMAGE_IMPORT=1; shift ;;
+    --port-forward) NO_PORT_FORWARD=0; shift ;;
+    --no-port-forward) NO_PORT_FORWARD=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+require_cmd kubectl
+require_cmd ssh
+require_cmd scp
+require_cmd docker
+require_cmd make
+
+if [[ -z "$SSH_KEY_PATH" && -f "$ROOT_DIR/sshKey" ]]; then
+  SSH_KEY_PATH="$ROOT_DIR/sshKey"
+fi
+if [[ -z "$IMAGE" ]]; then
+  if [[ "$SKIP_BUILD" -eq 1 || "$SKIP_IMAGE_IMPORT" -eq 1 ]]; then
+    IMAGE="dune-admin:local"
+  else
+    IMAGE="dune-admin:local-$(date +%Y%m%d%H%M%S)"
+  fi
+fi
+
+SSH_OPTS=(-o PreferredAuthentications=publickey,password -o PubkeyAuthentication=yes -o PasswordAuthentication=yes)
+SCP_OPTS=(-o PreferredAuthentications=publickey,password -o PubkeyAuthentication=yes -o PasswordAuthentication=yes)
+if [[ -n "$SSH_KEY_PATH" ]]; then
+  if [[ ! -f "$SSH_KEY_PATH" ]]; then
+    echo "SSH key not found: $SSH_KEY_PATH" >&2
+    exit 1
+  fi
+  SSH_OPTS+=(-i "$SSH_KEY_PATH" -o IdentitiesOnly=yes)
+  SCP_OPTS+=(-i "$SSH_KEY_PATH" -o IdentitiesOnly=yes)
+  echo "Using SSH key: $SSH_KEY_PATH (fallback to password enabled)"
+else
+  echo "No SSH key provided/found; using password auth (or agent) for SSH."
+fi
+
+if [[ "$SKIP_KUBECONFIG" -eq 0 ]]; then
+  mkdir -p "$(dirname "$KUBECONFIG_PATH")"
+  echo "Pulling kubeconfig from ${VM_USER}@${VM_HOST}..."
+  ssh "${SSH_OPTS[@]}" "${VM_USER}@${VM_HOST}" "sudo cat /etc/rancher/k3s/k3s.yaml" > "$KUBECONFIG_PATH"
+  awk -v host="$VM_HOST" '{gsub(/127\.0\.0\.1/, host); print}' "$KUBECONFIG_PATH" > "${KUBECONFIG_PATH}.tmp"
+  mv "${KUBECONFIG_PATH}.tmp" "$KUBECONFIG_PATH"
+fi
+
+export KUBECONFIG="$KUBECONFIG_PATH"
+echo "Using KUBECONFIG=$KUBECONFIG"
+kubectl get nodes
+
+if [[ "$SKIP_BUILD" -eq 0 ]]; then
+  echo "Building image: $IMAGE"
+  docker buildx build --platform linux/amd64 -f deploy/Dockerfile -t "$IMAGE" --load .
+fi
+
+if [[ "$SKIP_IMAGE_IMPORT" -eq 0 ]]; then
+  echo "Importing image into k3s runtime on ${VM_HOST}..."
+  tmp_tar="$(mktemp /tmp/dune-admin-image.XXXXXX.tar)"
+  trap 'rm -f "$tmp_tar"' EXIT
+  docker save -o "$tmp_tar" "$IMAGE"
+  scp "${SCP_OPTS[@]}" "$tmp_tar" "${VM_USER}@${VM_HOST}:/tmp/dune-admin-image.tar"
+  ssh "${SSH_OPTS[@]}" "${VM_USER}@${VM_HOST}" "sudo k3s ctr images import /tmp/dune-admin-image.tar && rm -f /tmp/dune-admin-image.tar"
+  rm -f "$tmp_tar"
+  trap - EXIT
+fi
+
+echo "Rendering k8s manifest..."
+make render-k8s
+
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "Manifest not found: $MANIFEST" >&2
+  exit 1
+fi
+
+control_ns="$(awk -F':[[:space:]]*' '/^[[:space:]]*control_namespace:[[:space:]]*/{gsub(/"/,"",$2); print $2; exit}' "$MANIFEST")"
+db_host_override=""
+if [[ -n "$control_ns" ]]; then
+  svc_rows="$(kubectl -n "$control_ns" get svc -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .spec.ports[*]}{.port}{" "}{end}{"\n"}{end}' 2>/dev/null || true)"
+  db_svc="$(printf '%s\n' "$svc_rows" | awk '$0 ~ /(^|[[:space:]])15432([[:space:]]|$)/{print $1; exit}')"
+  if [[ -n "$db_svc" ]]; then
+    db_host_override="${db_svc}.${control_ns}.svc.cluster.local"
+    echo "Using in-cluster DB host: $db_host_override"
+  fi
+fi
+
+awk -v image="$IMAGE" -v dbhost="$db_host_override" '
+  BEGIN { image_changed = 0 }
+  /^[[:space:]]*image:[[:space:]]*/ && image_changed == 0 {
+    sub(/image:.*/, "image: " image)
+    image_changed = 1
+  }
+  /^[[:space:]]*CONTROL:[[:space:]]*/ {
+    sub(/CONTROL:.*/, "CONTROL: \"local\"")
+  }
+  /^[[:space:]]*control:[[:space:]]*/ {
+    sub(/control:.*/, "control: local")
+  }
+  /^[[:space:]]*cmd_status:[[:space:]]*/ { next }
+  /^[[:space:]]*cmd_start:[[:space:]]*/ { next }
+  /^[[:space:]]*cmd_stop:[[:space:]]*/ { next }
+  /^[[:space:]]*cmd_restart:[[:space:]]*/ { next }
+  dbhost != "" && /^[[:space:]]*DB_HOST:[[:space:]]*/ {
+    sub(/DB_HOST:.*/, "DB_HOST: \"" dbhost "\"")
+  }
+  dbhost != "" && /^[[:space:]]*db_host:[[:space:]]*/ {
+    sub(/db_host:.*/, "db_host: " dbhost)
+  }
+  /^[[:space:]]*ssh_host:[[:space:]]*/ { next }
+  /^[[:space:]]*ssh_user:[[:space:]]*/ { next }
+  /^[[:space:]]*ssh_key:[[:space:]]*/ { next }
+  /^[[:space:]]*MARKET_BOT_ENABLED:[[:space:]]*/ {
+    sub(/MARKET_BOT_ENABLED:.*/, "MARKET_BOT_ENABLED: \"true\"")
+  }
+  /^[[:space:]]*market_bot_enabled:[[:space:]]*/ {
+    sub(/market_bot_enabled:.*/, "market_bot_enabled: true")
+  }
+  /^[[:space:]]*market_bot_item_data:[[:space:]]*/ {
+    sub(/market_bot_item_data:.*/, "market_bot_item_data: /app/item-data.json")
+  }
+  /^[[:space:]]*market_bot_cache_db:[[:space:]]*/ {
+    sub(/market_bot_cache_db:.*/, "market_bot_cache_db: /data/market-bot-cache.db")
+  }
+  { print }
+  END {
+    if (image_changed == 0) {
+      print "No image: field found to patch in manifest" > "/dev/stderr"
+      exit 1
+    }
+  }
+' "$MANIFEST" > "${MANIFEST}.tmp"
+mv "${MANIFEST}.tmp" "$MANIFEST"
+
+echo "Applying manifest..."
+kubectl apply -f "$MANIFEST"
+if [[ -n "$control_ns" ]]; then
+  echo "Applying RBAC for in-cluster control access..."
+  cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dune-admin-runtime
+  namespace: $control_ns
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "services", "endpoints", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get"]
+  - apiGroups: ["igw.funcom.com"]
+    resources: ["battlegroups", "serverstats"]
+    verbs: ["get", "list", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dune-admin-runtime
+  namespace: $control_ns
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: $NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dune-admin-runtime
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dune-admin-operators-logs
+  namespace: funcom-operators
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dune-admin-operators-logs
+  namespace: funcom-operators
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: $NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dune-admin-operators-logs
+EOF
+fi
+kubectl -n "$NAMESPACE" rollout restart deploy/dune-admin
+kubectl -n "$NAMESPACE" rollout status deploy/dune-admin
+kubectl -n "$NAMESPACE" get pods,svc
+
+echo "Running in-cluster health checks (fast-fail, no pod waits)..."
+stale_pods="$(kubectl -n "$NAMESPACE" get pods --no-headers 2>/dev/null | awk '/^curl($|-check-)/{print $1}')"
+if [[ -n "$stale_pods" ]]; then
+  while IFS= read -r p; do
+    [[ -n "$p" ]] && kubectl -n "$NAMESPACE" delete pod "$p" --ignore-not-found >/dev/null 2>&1 || true
+  done <<< "$stale_pods"
+fi
+status_path="/api/v1/namespaces/$NAMESPACE/services/http:dune-admin:8080/proxy/api/v1/status"
+bot_path="/api/v1/namespaces/$NAMESPACE/services/http:dune-admin:8080/proxy/api/v1/market-bot/status"
+bg_path="/api/v1/namespaces/$NAMESPACE/services/http:dune-admin:8080/proxy/api/v1/battlegroup/status"
+health_ok=0
+last_status=""
+last_bot=""
+last_bg=""
+for i in $(seq 1 30); do
+  last_status="$(kubectl --request-timeout=5s get --raw "$status_path" 2>/dev/null || true)"
+  last_bot="$(kubectl --request-timeout=5s get --raw "$bot_path" 2>/dev/null || true)"
+  last_bg="$(kubectl --request-timeout=5s get --raw "$bg_path" 2>/dev/null || true)"
+  if [[ -n "$last_status" ]] &&
+     echo "$last_bot" | grep -q "\"enabled\":true" &&
+     ! echo "$last_bg" | grep -q "does not support GetStatus"; then
+    echo "$last_bot"
+    health_ok=1
+    break
+  fi
+  if (( i % 5 == 0 )); then
+    echo "Health check retry $i/30..."
+  fi
+  sleep 1
+done
+if [[ "$health_ok" -ne 1 ]]; then
+  echo "health check failed: API or embedded market-bot not ready" >&2
+  echo "last /api/v1/status: $last_status" >&2
+  echo "last /api/v1/market-bot/status: $last_bot" >&2
+  echo "last /api/v1/battlegroup/status: $last_bg" >&2
+  exit 1
+fi
+
+echo "Deploy complete (image: $IMAGE)."
+
+if [[ "$NO_PORT_FORWARD" -eq 0 ]]; then
+  echo "Opening API port-forward at http://127.0.0.1:8080 ..."
+  kubectl -n "$NAMESPACE" port-forward svc/dune-admin 8080:8080
+else
+  echo "Deploy complete. Run ./listen.sh to open API port-forward."
+fi

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,21 +1,40 @@
-FROM golang:1.26.3 AS builder
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+FROM --platform=$BUILDPLATFORM node:22-bookworm-slim AS web-builder
+
+WORKDIR /build/web
+
+COPY web/package.json web/pnpm-lock.yaml ./
+RUN corepack enable && corepack prepare pnpm@10.28.1 --activate && pnpm install --frozen-lockfile
+
+COPY web/ ./
+RUN pnpm build
+
+FROM --platform=$BUILDPLATFORM golang:1.26.3 AS go-builder
 
 WORKDIR /build
+
+ARG TARGETOS
+ARG TARGETARCH
 
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o dune-admin ./cmd/dune-admin
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -ldflags="-s -w" -o dune-admin ./cmd/dune-admin
 
-FROM debian:bookworm-slim
+FROM --platform=$TARGETPLATFORM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates kubernetes-client postgresql-client && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-COPY --from=builder /build/dune-admin .
-COPY --from=builder /build/tags-data.json /build/item-data.json ./
+COPY --from=go-builder /build/dune-admin .
+COPY --from=go-builder /build/tags-data.json /build/item-data.json ./
+COPY --from=web-builder /build/web/dist ./dist
 
 EXPOSE 8080
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,16 +3,6 @@ ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
-FROM --platform=$BUILDPLATFORM node:22-bookworm-slim AS web-builder
-
-WORKDIR /build/web
-
-COPY web/package.json web/pnpm-lock.yaml ./
-RUN corepack enable && corepack prepare pnpm@10.28.1 --activate && pnpm install --frozen-lockfile
-
-COPY web/ ./
-RUN pnpm build
-
 FROM --platform=$BUILDPLATFORM golang:1.26.3 AS go-builder
 
 WORKDIR /build
@@ -34,7 +24,6 @@ WORKDIR /app
 
 COPY --from=go-builder /build/dune-admin .
 COPY --from=go-builder /build/tags-data.json /build/item-data.json ./
-COPY --from=web-builder /build/web/dist ./dist
 
 EXPOSE 8080
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,12 +1,19 @@
 services:
-  backend:
-    build: .
+  dune-admin:
+    container_name: dune-admin
+    restart: unless-stopped
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
     ports:
       - "8080:8080"
-    volumes:
-      - ./sshKey:/app/sshKey:ro
-    env_file:
-      - .env
     environment:
       SSH_KEY: /app/sshKey
       LISTEN_ADDR: :8080
+    volumes:
+      - ../sshKey:/app/sshKey:ro
+      - ${HOME}/.dune-admin:/root/.dune-admin
+      - market-bot-cache:/data
+
+volumes:
+  market-bot-cache:

--- a/deploy/k8s/dune-admin.yaml
+++ b/deploy/k8s/dune-admin.yaml
@@ -1,0 +1,194 @@
+# Baseline manifest template.
+# For inline values from ~/.dune-admin/config.yaml (including discovered DB creds),
+# run: make render-k8s
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dune-admin
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dune-admin-config
+  namespace: dune-admin
+data:
+  DB_HOST: "postgres.default.svc.cluster.local"
+  DB_PORT: "15432"
+  DB_USER: "dune"
+  DB_NAME: "dune"
+  DB_SCHEMA: "dune"
+  LISTEN_ADDR: ":8080"
+  CONTROL: "local"
+  MARKET_BOT_ENABLED: "true"
+  MARKET_BOT_BUY_INTERVAL: "5m"
+  MARKET_BOT_LIST_INTERVAL: "30m"
+  config.yaml: |
+    control: local
+    listen_addr: :8080
+    market_bot_enabled: true
+    market_bot_cache_db: /data/market-bot-cache.db
+    market_bot_item_data: /app/item-data.json
+    market_bot_buy_interval: 5m
+    market_bot_list_interval: 30m
+    market_bot_buy_threshold: 1.05
+    market_bot_max_buys: 50
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dune-admin-secrets
+  namespace: dune-admin
+type: Opaque
+stringData:
+  DB_PASS: "replace-me"
+  BROKER_USER: ""
+  BROKER_PASS: ""
+  BROKER_JWT_SECRET: ""
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: market-bot-cache
+  namespace: dune-admin
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dune-admin
+  namespace: dune-admin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dune-admin
+  template:
+    metadata:
+      labels:
+        app: dune-admin
+    spec:
+      containers:
+        - name: dune-admin
+          image: ghcr.io/icehunter/dune-admin:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: DB_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: DB_HOST
+            - name: DB_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: DB_PORT
+            - name: DB_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: DB_USER
+            - name: DB_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: DB_NAME
+            - name: DB_SCHEMA
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: DB_SCHEMA
+            - name: LISTEN_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: LISTEN_ADDR
+            - name: CONTROL
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: CONTROL
+            - name: MARKET_BOT_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: MARKET_BOT_ENABLED
+            - name: MARKET_BOT_BUY_INTERVAL
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: MARKET_BOT_BUY_INTERVAL
+            - name: MARKET_BOT_LIST_INTERVAL
+              valueFrom:
+                configMapKeyRef:
+                  name: dune-admin-config
+                  key: MARKET_BOT_LIST_INTERVAL
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: dune-admin-secrets
+                  key: DB_PASS
+            - name: BROKER_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dune-admin-secrets
+                  key: BROKER_USER
+            - name: BROKER_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: dune-admin-secrets
+                  key: BROKER_PASS
+            - name: BROKER_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: dune-admin-secrets
+                  key: BROKER_JWT_SECRET
+          volumeMounts:
+            - name: market-bot-cache
+              mountPath: /data
+            - name: config
+              mountPath: /root/.dune-admin/config.yaml
+              subPath: config.yaml
+          readinessProbe:
+            httpGet:
+              path: /api/v1/status
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/v1/status
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+      volumes:
+        - name: market-bot-cache
+          persistentVolumeClaim:
+            claimName: market-bot-cache
+        - name: config
+          configMap:
+            name: dune-admin-config
+            items:
+              - key: config.yaml
+                path: config.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dune-admin
+  namespace: dune-admin
+spec:
+  selector:
+    app: dune-admin
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  type: ClusterIP

--- a/docs/adr/0001-standard-go-layout.md
+++ b/docs/adr/0001-standard-go-layout.md
@@ -1,0 +1,27 @@
+# ADR 0001 — Adopt standard Go project layout
+
+**Status:** Accepted  
+**Date:** 2025-05-27
+
+## Context
+
+All Go source files currently live in the repository root alongside `go.mod`, the `Makefile`, `Dockerfile`, and deployment config. As the project grows (adding `internal/marketbot/`, potentially other sub-packages), the flat layout makes it hard to:
+
+- Distinguish entry-point code from library code
+- Prevent external import of internal helpers
+- Keep deployment artifacts clearly separated from source
+
+The Go community's de-facto standard layout places `main` packages under `cmd/<name>/` and shared/internal code under `internal/<pkg>/`. The `go` toolchain enforces the `internal/` import restriction natively.
+
+## Decision
+
+Move all root-level `*.go` files into `cmd/dune-admin/` (package declaration stays `package main`). New shared code goes into `internal/`. Deployment artifacts (`Dockerfile`, `docker-compose.yml`, k8s manifests) move into `deploy/`.
+
+The `go.mod` module name remains `dune-admin`. Build target changes from `./` to `./cmd/dune-admin`.
+
+## Consequences
+
+- `make build`, `make test`, all `go tool` invocations must be updated to use `./cmd/dune-admin` or `./...`
+- The existing Dockerfile `COPY` and `WORKDIR` paths need updating
+- `internal/` enforces that `marketbot` can only be imported by this module — prevents accidental external re-use
+- One-time migration commit with no behaviour change; straightforward to review

--- a/docs/adr/0002-embed-market-bot-as-library.md
+++ b/docs/adr/0002-embed-market-bot-as-library.md
@@ -1,0 +1,50 @@
+# ADR 0002 — Embed market bot as `internal/marketbot` library
+
+**Status:** Implemented (Phase 2)  
+**Date:** 2025-05-27
+
+## Context
+
+`dune-market-bot` was a separate Go module and binary. dune-admin controlled it via HTTP proxy (`botProxy`) and container lifecycle commands (`kubectl scale`, `docker restart`). This required two images, two build pipelines, two k8s Deployments, and a live network dependency between the admin API and the bot.
+
+Three integration models were considered:
+
+| Model | Description | Rejected reason |
+|-------|-------------|-----------------|
+| **Embed as goroutine library** | Pull source into `internal/marketbot/`; call `Run(ctx, cfg)` | — (chosen) |
+| Child-process supervisor | dune-admin spawns the bot binary | Still two binaries; adds process management complexity |
+| Go workspace | Separate modules in one repo | Doesn't give single-process or single-image benefit |
+
+## Decision
+
+Copy all `*.go` files from `dune-market-bot` into `internal/marketbot/`. Change `package main` → `package marketbot`. Expose:
+
+```go
+// Run starts the market bot. Blocks until ctx is cancelled.
+// Returns (*Instance, error) — Instance is valid immediately after startup.
+func Run(ctx context.Context, cfg BotConfig) (*Instance, error)
+
+// Instance exposes live handles for the host process.
+type Instance struct {
+    API  *APIServer  // in-process HTTP handler (nil if APIAddr == "")
+    Sink *LogSink    // ring-buffer log fan-out
+    // unexported: cfg, catalog, ex, pool
+}
+
+func (i *Instance) Pause()
+func (i *Instance) Resume()
+func (i *Instance) Restart(ctx context.Context) error
+func (i *Instance) StatusSnapshot() any
+```
+
+`flag.Parse()` and `os.Exit` removed from the package; the caller owns lifecycle.
+
+The old `dune-market-bot` repository is archived once this integration ships.
+
+## Consequences
+
+- `modernc.org/sqlite` added to dune-admin's `go.mod`
+- `item-data.json` must be present in the container image (already exists at repo root)
+- Bot tests (`pricing_test.go`, `config_test.go`, `api_test.go`) are now part of `make test` in dune-admin
+- External/proxy mode was removed in Phase 3; dune-admin now runs market-bot embedded only
+- `catalog.go`: `loadCatalog()` becomes `loadCatalog(path string)` — no `flag` dependency

--- a/docs/adr/0003-single-binary-deployment.md
+++ b/docs/adr/0003-single-binary-deployment.md
@@ -1,0 +1,23 @@
+# ADR 0003 — Ship a single binary and container image
+
+**Status:** Accepted  
+**Date:** 2025-05-27
+
+## Context
+
+Today two binaries are deployed: `dune-admin` (the admin API + web UI) and `market-bot` (the market-making loop). This requires two container images, two Dockerfiles, two k8s Deployments, and two separate build/push pipelines.
+
+After ADR 0002 (embed as library), the market bot runs inside the dune-admin process. There is no longer any reason to build or ship a separate binary.
+
+## Decision
+
+Produce a single `dune-admin` binary from `cmd/dune-admin/` that embeds the market bot goroutine. The `deploy/Dockerfile` builds only this binary. One container image covers both functions.
+
+The market bot loop is opt-in via `market_bot_enabled` in `config.yaml`; disabling it adds zero overhead (the goroutine is never started).
+
+## Consequences
+
+- Container image is slightly larger (adds `modernc.org/sqlite` and bot logic), but SQLite is a pure Go library so no CGO and no runtime C deps
+- Image build time increases marginally (one extra dependency)
+- External-bot proxy mode is removed; this remains a single-binary, embedded-bot deployment
+- Release versioning is unified: one version tag covers both features

--- a/docs/adr/0004-in-process-bot-lifecycle.md
+++ b/docs/adr/0004-in-process-bot-lifecycle.md
@@ -1,0 +1,36 @@
+# ADR 0004 — In-process bot lifecycle control
+
+**Status:** Implemented (Phase 2)  
+**Date:** 2025-05-27
+
+## Context
+
+`handlers_market_bot.go` previously implemented `start`, `stop`, and `restart` by shelling out to:
+
+- `kubectl scale deployment/<name> --replicas=0/1`
+- `docker start/stop/restart <container>`
+
+After embedding the bot as a goroutine, there is no container or deployment to scale.
+
+## Decision
+
+`internal/marketbot.Instance` exposes three lifecycle methods:
+
+```go
+func (i *Instance) Pause()                          // sets Enabled=false in live Config
+func (i *Instance) Resume()                         // sets Enabled=true
+func (i *Instance) Restart(ctx context.Context) error // pauses, re-runs Init(), resumes
+```
+
+`Pause`/`Resume` apply a JSON patch to the bot's thread-safe `Config` via `Config.Apply`. The tick loop already reads `snap.Enabled` on every minute boundary — no goroutine restart required.
+
+`Restart` calls `Exchange.Init(ctx, catalog)` to reload pricing, re-ping the DB, and repopulate the category cache, then re-enables the loop.
+
+`handleMarketBotExec` routes directly to these methods. External kubectl/docker lifecycle paths were removed with external mode.
+
+## Consequences
+
+- `start`/`stop` in embedded mode is immediate and in-memory — no latency, no partial failure
+- `restart` flushes any in-flight tick and re-runs `Init`; catalog changes (e.g. updated `item-data.json`) are NOT picked up by restart — process restart is required for that
+- The API surface seen by the frontend (`POST /api/v1/market-bot/exec`) is unchanged
+- Embedded lifecycle is the only supported market-bot mode

--- a/docs/adr/0005-ring-buffer-log-streaming.md
+++ b/docs/adr/0005-ring-buffer-log-streaming.md
@@ -1,0 +1,45 @@
+# ADR 0005 — Ring-buffer for embedded bot log streaming
+
+**Status:** Implemented (Phase 2)  
+**Date:** 2025-05-27
+
+## Context
+
+`handleMarketBotLogs` previously streamed logs by running `kubectl logs -f <pod>` or `docker logs -f <container>` via the executor. After embedding the bot as a goroutine there is no pod or container to tail.
+
+Three approaches were considered:
+
+| Approach | Notes |
+|----------|-------|
+| **In-process ring buffer** | Bot writes to a `LogSink`; WS handler subscribes | Chosen |
+| Pipe `log.SetOutput` to custom writer | Hijacks the global logger; affects all log output |
+| Write bot logs to a temp file | I/O overhead, cleanup required, no benefit over ring buffer |
+
+## Decision
+
+`internal/marketbot/logsink.go` implements `LogSink`:
+
+```go
+type LogSink struct { /* ring buffer + subscriber map */ }
+
+func NewLogSink() *LogSink
+func (s *LogSink) Write(p []byte) (int, error)   // implements io.Writer
+func (s *LogSink) Subscribe() chan string          // replay history + live lines
+func (s *LogSink) Unsubscribe(ch chan string)
+func (s *LogSink) Logger(prefix string, w io.Writer) *log.Logger
+```
+
+- Fixed capacity: 1000 lines
+- `Subscribe()` replays existing ring contents immediately, then delivers new lines
+- Slow subscribers are dropped (non-blocking send) to prevent log backpressure from blocking the bot tick loop
+- `Logger()` returns a `*log.Logger` writing to `io.MultiWriter(sink, os.Stderr)` so logs appear in both the WS stream and the process's stderr
+
+`handleMarketBotLogs` detects `embeddedBot != nil` and subscribes to `embeddedBot.Sink` instead of using the kubectl/docker path.
+
+`handleMarketBotLogsReady` returns `{"ready": true, "mode": "embedded"}` whenever `embeddedBot != nil`, regardless of control plane.
+
+## Consequences
+
+- Memory cost bounded: ~1000 × ~200 bytes ≈ 200 KB worst case
+- Older log lines (up to 1000) replayed immediately on WS connect — no "waiting for first line" delay
+- External-bot log streaming paths were removed; market-bot logs now come from the embedded `LogSink` path only

--- a/docs/adr/0006-unified-k8s-manifest.md
+++ b/docs/adr/0006-unified-k8s-manifest.md
@@ -1,0 +1,34 @@
+# ADR 0006 — Replace per-project k8s manifests with one unified manifest
+
+**Status:** Implemented (Phase 3)  
+**Date:** 2025-05-27
+
+## Context
+
+There are currently two separate Kubernetes manifests:
+
+- `dune-admin/docker-compose.yml` — local Docker development
+- `dune-market-bot/k8s/market-bot.yaml` — k8s Deployment, Service, ConfigMap, Secret for the bot
+
+After ADR 0003 (single binary), both functions ship in one image. Maintaining two manifests targeting different images creates confusion and drift risk.
+
+## Decision
+
+Create `deploy/k8s/dune-admin.yaml` as the single authoritative k8s manifest. It includes:
+
+- **Namespace** — `dune-admin`
+- **Deployment** — single replica, single container (`dune-admin` image), all env vars wired from ConfigMap and Secret
+- **Service** — ClusterIP, port 8080
+- **ConfigMap** — non-secret config: DB host/port/name, bot intervals, listen addr, `MARKET_BOT_ENABLED`
+- **Secret** — DB password and broker credentials (`BROKER_USER`, `BROKER_PASS`, `BROKER_JWT_SECRET`)
+- **PersistentVolumeClaim** — `market-bot-cache`, used for SQLite (see ADR 0007)
+- Liveness probe: `GET /api/v1/status` → 200
+- Readiness probe: same
+
+Both old manifests (`docker-compose.yml` at repo root, `dune-market-bot/k8s/market-bot.yaml`) are removed. Migration notes are added to `SETUP_DOCKER.md`.
+
+## Consequences
+
+- Operators who previously ran two pods now run one; the market bot is not a separately addressable network endpoint in-cluster
+- The PVC must be provisioned by the cluster's default StorageClass (or operators set `storageClassName` explicitly)
+- `kubectl apply --dry-run=client` is part of Phase 3 verification

--- a/docs/adr/0007-sqlite-cache-storage.md
+++ b/docs/adr/0007-sqlite-cache-storage.md
@@ -1,0 +1,26 @@
+# ADR 0007 — Persistent volume for SQLite market-bot cache
+
+**Status:** Implemented (Phase 3)  
+**Date:** 2025-05-27
+
+## Context
+
+The market bot uses SQLite (via `modernc.org/sqlite`) to cache the category tree pulled from the game's Postgres database. The cache path is currently `--cachedb /data/market-bot-cache.db`.
+
+When running in a container, the SQLite file must survive pod restarts; otherwise the bot re-fetches the entire category tree on every start (slow, and puts unnecessary load on the DB).
+
+## Decision
+
+In **k8s**: add a `PersistentVolumeClaim` (`market-bot-cache`, 1Gi, ReadWriteOnce) mounted at `/data` in the Deployment. The cache path defaults to `/data/market-bot-cache.db`.
+
+In **docker-compose**: add a named volume `market-bot-cache` mounted at `/data`.
+
+The cache path is configurable via `market_bot_cache_db` in `config.yaml` (and `MARKET_BOT_CACHE_DB` env var) so operators can use a different path or an NFS-backed volume.
+
+Running **locally** (no container): the default path is `~/.dune-admin/market-bot-cache.db`, consistent with the existing config directory convention.
+
+## Consequences
+
+- Operators must ensure a StorageClass with `ReadWriteOnce` is available in their cluster (true for all standard k8s distributions)
+- If the PVC is deleted, the cache is lost and the bot rebuilds it on next start — non-fatal but slow
+- The SQLite file is not backed up by default; operators who want it included in backups should mount the same PVC in a backup job

--- a/docs/adr/0008-config-yaml-extensions.md
+++ b/docs/adr/0008-config-yaml-extensions.md
@@ -1,0 +1,40 @@
+# ADR 0008 — Extend config.yaml for embedded-bot settings
+
+**Status:** Implemented (Phase 2), updated (Phase 3)  
+**Date:** 2025-05-27
+
+## Context
+
+Embedding the bot (ADR 0002) requires dedicated in-process settings plus moving hardcoded broker credentials to config.
+
+## Decision
+
+New fields added to `appConfig` in `cmd/dune-admin/main.go`:
+
+```yaml
+# Embedded market bot (in-process)
+market_bot_enabled: false           # bool; true starts embedded bot
+market_bot_cache_db: ""             # SQLite path; default: ~/.dune-admin/market-bot-cache.db
+market_bot_item_data: ""            # item-data.json path; default: ./item-data.json
+market_bot_buy_interval: 5m         # time.Duration string
+market_bot_list_interval: 30m
+market_bot_buy_threshold: 1.05      # float64
+market_bot_max_buys: 50             # int
+
+# Broker credentials (moved from hardcoded constants)
+broker_user: ""                     # AMQP username (env: BROKER_USER); default: dune_cap
+broker_pass: ""                     # AMQP password (env: BROKER_PASS)
+broker_jwt_secret: ""               # base64 HMAC key for CaptureJWT (env: BROKER_JWT_SECRET)
+```
+
+`market_bot_enabled: true` activates the embedded goroutine via `marketbot.Run(ctx, BotConfig{...})` in `main()`.
+
+`broker_user`/`broker_pass`/`broker_jwt_secret` are loaded through `setEnvIfMissing` so the env-var path also works for containerised deployments.
+
+## Consequences
+
+- Existing installs with no new fields default to `market_bot_enabled: false`
+- The `BotConfig` struct in `internal/marketbot` exactly mirrors these fields
+- `handlers_market_bot.go` routes all market-bot endpoints to the embedded instance
+- `broker_user`/`broker_pass` default to `dune_cap`/`DuneCap2026!` via `brokerCredentials()` for backward compat
+- External proxy fields (`market_bot_addr`, `market_bot_token`, `market_bot_container`, `market_bot_namespace`) were removed in Phase 3

--- a/docs/plans/phase-0-bugs.md
+++ b/docs/plans/phase-0-bugs.md
@@ -1,0 +1,109 @@
+# Phase 0 — Bug/Chore Fixes
+
+**Status:** Complete ✅  
+**Branch:** `chore/phase-0-bug-fixes`  
+**PR:** #52  
+**Base:** `main`
+
+---
+
+## Scope
+
+Fix five open issues before any structural changes, so each diff is readable in isolation. Also address Copilot and CodeQL review feedback raised against PR #52.
+
+---
+
+## Issues
+
+### #10 — Remove capture mode (`chore`)
+
+**What was removed:**
+
+- `capture.go` — `runCapture`, `captureBroker`, `printMessage`, `dialAMQP`, `buildCaptureJWT`, `binding` type, `capUser`/`capPass` constants
+- `-capture` CLI flag from `main.go`
+- `ListExchanges` and `EnsureCaptureUser` from the `ControlPlane` interface and all four provider implementations (`ampControl`, `dockerControl`, `kubectlControl`, `localControl`)
+- `startEnsureCaptureUserLoop`, `rabbitmqctlPrefix`, `rabbitmqctl()`, `defaultDuneRabbitmqctl` from `ampControl`
+- `brokerForLabel`, `ensureBrokerViaDockerExec` from `dockerControl`
+- `ensureBrokerViaExec`, `parseExchanges`, `binding` type from `kubectlControl`
+- `AmpRabbitmqctlPath` from `appConfig` and setup wizard
+
+**What was kept** (still used by `handlers_notify.go` / `rmq_commands.go`):
+
+- `dialAMQP` → moved to `broker.go`
+- `buildCaptureJWT` → moved to `jwt_helpers.go`
+- `EvalOnGameBroker` — retained on all control planes (used by `rmq_commands.go`)
+
+---
+
+### #11 — Malformed managed INI block silently drops settings (`bug`)
+
+**File:** `handlers_server_settings.go`
+
+**Root cause:** `splitAtDuneAdminMarker` returned an empty `managed` map when the BEGIN marker was present but the END marker was missing (truncated file). The caller then wrote a new managed block containing only the incoming updates — silently discarding all previously-managed settings.
+
+**Fix:** `splitAtDuneAdminMarker` now returns `(preMarker, managed, error)`. When BEGIN is found without END it returns an error. Callers (`applyDuneAdminUpdates`, `applyDuneAdminRawSection`) propagate it as HTTP 409 Conflict.
+
+---
+
+### #12 — Array lines duplicate in INI after raw-section editor save (`bug`)
+
+**File:** `handlers_server_settings.go`
+
+**Root cause:** `applyDuneAdminRawSection` used `parseINI` which silently stripped `+`/`-` prefixes and only stored the last value for duplicate keys. `stripKeysFromContent` also only stripped plain `key=val` lines, leaving prefixed lines in the hand-edited region — which then appeared twice on disk.
+
+**Fix:**
+
+1. Added `parseINIRaw` — preserves `+`/`-` as part of the stored key. Duplicate keys (e.g. multiple `+ActiveMod=` lines) stored with a `\x00N` dedup suffix.
+2. `renderDuneAdminBlock` strips the `\x00N` suffix before writing to disk.
+3. `ownedKeySet` strips the suffix before building the ownership set.
+4. `stripKeysFromContent` now also strips prefixed array lines (`+key=val`, `-key=val`) when the base key or exact prefixed key is owned.
+
+---
+
+### #13 — WebSocket endpoint accepts arbitrary non-browser clients (`bug`)
+
+**File:** `server.go`
+
+**Root cause:** `originAllowedForRequest` with `allowEmpty=true` returned `true` for any request with no `Origin` header. The empty-origin path used `r.Host` (a client-controlled header) to determine if the connection was local, which could be spoofed.
+
+**Fix:**
+
+- `originAllowedForRequest` now uses `r.RemoteAddr` (not `r.Host`) for the loopback check — this reflects the actual TCP source address.
+- Empty-Origin requests are only allowed when `net.ParseIP(remoteHost).IsLoopback()` is true.
+- `corsMiddleware` skips CORS headers entirely when `Origin` is absent (was emitting an empty `Access-Control-Allow-Origin` header).
+
+---
+
+### #14 — `ampExecutor` wrapping silently skipped when SSH executor active (`bug`)
+
+**File:** `connection.go`, `executor_amp.go`
+
+**Root cause:** `connectAll` only wrapped the executor as `ampExecutor` when the type assertion `exec.(*localExecutor)` succeeded. With `ssh_host` set, the executor is `*sshExecutor` — the assertion failed silently, leaving INI writes unelevated.
+
+**Fix:** `ampExecutor` now embeds the `Executor` interface instead of `*localExecutor`. `WriteFile` calls `sudo -i -u <ampUser> tee` regardless of whether the inner executor is local or SSH. `connectAll` and `setup.go` updated to use `&ampExecutor{Executor: exec, ampUser: user}`.
+
+---
+
+## Copilot / CodeQL follow-up fixes (additional commits on #52)
+
+| File | Issue | Fix |
+|------|-------|-----|
+| `server.go` | `r.Host` spoofable for origin check | Use `r.RemoteAddr` |
+| `server.go` | CORS headers emitted with empty `Access-Control-Allow-Origin` | Skip headers when `Origin` absent |
+| `broker.go` | `capUser`/`capPass` hardcoded in source | Replaced by `brokerCredentials()` reading `BROKER_USER`/`BROKER_PASS` env vars; fallback to defaults |
+| `jwt_helpers.go` | HMAC signing secret hardcoded | Loaded from `BROKER_JWT_SECRET` env var; hardcoded value is opt-out fallback only |
+| `handlers_server_settings.go` | `parseINIRaw` lost duplicate array keys | Fixed with `\x00N` dedup suffix scheme |
+
+---
+
+## Verification
+
+```bash
+go build .
+go test -race .
+go tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint run
+go tool github.com/securego/gosec/v2/cmd/gosec -severity high -confidence high .
+go tool golang.org/x/vuln/cmd/govulncheck .
+```
+
+All passed. CodeQL alert #57 (broker.go InsecureSkipVerify) suppressed with `// lgtm[go/disabled-certificate-check]`.

--- a/docs/plans/phase-1-layout.md
+++ b/docs/plans/phase-1-layout.md
@@ -1,0 +1,77 @@
+# Phase 1 — Standard Go Project Layout
+
+**Status:** Complete ✅  
+**Branch:** `refactor/phase-1-go-layout`  
+**PR:** #53  
+**Base:** `chore/phase-0-bug-fixes` (#52)
+
+---
+
+## Scope
+
+Move all Go source files to `cmd/dune-admin/`, move deployment artifacts to `deploy/`, and update all tooling to use the new paths. No behaviour changes — pure structural move.
+
+See [ADR 0001](../adr/0001-standard-go-layout.md) for the rationale.
+
+---
+
+## Changes
+
+### Source files
+
+All root-level `*.go` files (35 source + 1 test) moved to `cmd/dune-admin/`:
+
+```
+*.go  →  cmd/dune-admin/*.go
+```
+
+`package main` declarations unchanged. Module name stays `dune-admin`. Import paths within the package are unaffected (same module, same package name).
+
+### Deployment artifacts
+
+```
+Dockerfile        →  deploy/Dockerfile
+docker-compose.yml  →  deploy/docker-compose.yml
+```
+
+`deploy/Dockerfile` build target updated: `go build ./cmd/dune-admin` (was `go build .`).
+
+### Makefile
+
+```makefile
+CMD := ./cmd/dune-admin   # new variable
+
+build:    $(GO) build ... -o $(BIN) $(CMD)
+linux:    GOOS=linux ... go build -o dune-admin-linux $(CMD)
+dev-server: go run $(CMD)
+setup:    go run $(CMD) -setup
+test:     go test $(PKG)         # PKG := ./...  (already covered ./... including cmd/)
+vet:      go vet $(PKG)
+```
+
+### `.air.toml`
+
+```toml
+cmd = "go build -o ./tmp/dune-admin ./cmd/dune-admin"
+exclude_dir = [..., "deploy"]
+```
+
+### `.gocognit-ignore`
+
+Removed two stale entries referencing the now-deleted `capture.go`:
+
+- `captureBroker  capture.go:191:1`
+- `runCapture     capture.go:98:1`
+
+---
+
+## Verification
+
+```bash
+make build          # compiles cleanly
+make test-race      # all tests pass
+make lint           # no issues
+docker build -f deploy/Dockerfile .   # image builds
+```
+
+Git correctly detected all file movements as renames (100% similarity) in the commit diff.

--- a/docs/plans/phase-2-embed.md
+++ b/docs/plans/phase-2-embed.md
@@ -1,0 +1,156 @@
+# Phase 2 — Embed Market Bot as `internal/marketbot`
+
+**Status:** Implemented ✅ (with Phase 3 embedded-only follow-up)  
+**Branch:** `feature/phase-2-embed-marketbot`  
+**PR:** Pending (base: `refactor/phase-1-go-layout` / #53)
+
+---
+
+## Scope
+
+Pull `dune-market-bot` into this repo as `internal/marketbot/`, wire it into `cmd/dune-admin/` as an in-process goroutine, and replace the HTTP proxy + container lifecycle calls with direct in-process method calls.
+
+See ADRs [0002](../adr/0002-embed-market-bot-as-library.md), [0003](../adr/0003-single-binary-deployment.md), [0004](../adr/0004-in-process-bot-lifecycle.md), [0005](../adr/0005-ring-buffer-log-streaming.md), [0008](../adr/0008-config-yaml-extensions.md).
+
+---
+
+## New package: `internal/marketbot/`
+
+Files copied from `../dune-market-bot`, `package main` → `package marketbot`:
+
+| File | Notes |
+|------|-------|
+| `bot.go` | **New.** `Run(ctx, BotConfig) (*Instance, error)` entry point; `runLoop`; `Start` non-blocking wrapper |
+| `logsink.go` | **New.** `LogSink` ring buffer (1000 lines), `io.Writer`, fan-out to WS subscribers |
+| `api.go` | `APIServer`, auth middleware, HTTP handlers — unchanged except package name |
+| `catalog.go` | `loadCatalog(path string)` — flag global removed, path passed as parameter |
+| `config.go` | `Config`, `configValues`, `Apply`, `Snapshot` — unchanged |
+| `exchange.go` | `Exchange`, `NewExchange`, tick methods — lint fixes applied (13 unchecked errors, dead `createListing` removed) |
+| `pricing.go` | Pricing helpers — unchanged |
+| `report.go` | `reportData` — dead `runReport` (was `-report` flag mode) removed |
+| `api_test.go` | `json.Decode` errors now checked |
+| `config_test.go` | Unchanged |
+| `pricing_test.go` | Unchanged |
+
+### `Instance` type
+
+```go
+type Instance struct {
+    API  *APIServer  // in-process HTTP sub-API (nil if APIAddr == "")
+    Sink *LogSink    // ring-buffer log fan-out for WebSocket streaming
+}
+
+func (i *Instance) Pause()
+func (i *Instance) Resume()
+func (i *Instance) Restart(ctx context.Context) error
+func (i *Instance) StatusSnapshot() any
+```
+
+### `LogSink`
+
+```go
+func NewLogSink() *LogSink
+func (s *LogSink) Write(p []byte) (int, error)   // io.Writer — bot's logger writes here
+func (s *LogSink) Subscribe() chan string          // replay ring + live lines
+func (s *LogSink) Unsubscribe(ch chan string)
+func (s *LogSink) Logger(prefix string, w io.Writer) *log.Logger
+```
+
+---
+
+## Changes to `cmd/dune-admin/`
+
+### `main.go`
+
+**New config fields on `appConfig`:**
+
+```yaml
+market_bot_enabled: false
+market_bot_cache_db: ""           # default: ~/.dune-admin/market-bot-cache.db
+market_bot_item_data: ""          # default: ./item-data.json
+market_bot_buy_interval: 5m
+market_bot_list_interval: 30m
+market_bot_buy_threshold: 1.05
+market_bot_max_buys: 50
+broker_user: ""                   # env: BROKER_USER
+broker_pass: ""                   # env: BROKER_PASS
+broker_jwt_secret: ""             # env: BROKER_JWT_SECRET
+```
+
+**Startup wiring** (after `connectAll`):
+
+```go
+if loadedConfig.MarketBotEnabled {
+    inst, err := marketbot.Run(ctx, marketbot.BotConfig{ /* from config */ })
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "market-bot: startup failed: %v\n", err)
+    } else {
+        embeddedBot = inst
+        defer botCancel()
+    }
+}
+```
+
+**Global:** `var embeddedBot *marketbot.Instance` — nil when embedded bot is disabled.
+
+### `handlers_market_bot.go`
+
+All five handlers use embedded in-process routing:
+
+| Handler | Embedded path |
+|---------|--------------|
+| `handleMarketBotStatus` | `embeddedBot.StatusSnapshot()` |
+| `handleMarketBotConfig` | `embeddedBot.ConfigJSON()` / `embeddedBot.ApplyConfig(...)` |
+| `handleMarketBotExec` | `Pause()` / `Resume()` / `Restart()` |
+| `handleMarketBotLogsReady` | Always `{"ready": true, "mode": "embedded"}` |
+| `handleMarketBotLogs` | `Sink.Subscribe()` → WS fan-out |
+
+External/proxy mode paths were removed in Phase 3.
+
+### `go.mod`
+
+Added: `modernc.org/sqlite v1.50.1` (CGO-free SQLite for the category cache).
+
+---
+
+## How to enable
+
+Add to `~/.dune-admin/config.yaml`:
+
+```yaml
+market_bot_enabled: true
+# market_bot_cache_db and DB fields are inherited from existing config
+```
+
+Run from the repo root (so `item-data.json` is found by default):
+
+```bash
+./dune-admin
+```
+
+Check:
+
+```bash
+curl -s http://localhost:8080/api/v1/market-bot/status | jq .
+# → {"running": true, "uptime": "...", ...}
+```
+
+---
+
+## `go.mod` / dependency notes
+
+`modernc.org/sqlite` is a pure-Go CGO-free SQLite implementation. It adds ~4 MB to the binary but requires no runtime C libraries — the Docker image stays `CGO_ENABLED=0` / `FROM debian:bookworm-slim`.
+
+---
+
+## Verification
+
+```bash
+make build
+make test-race
+go tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint run ./...
+go tool github.com/securego/gosec/v2/cmd/gosec -severity high -confidence high ./...
+go tool golang.org/x/vuln/cmd/govulncheck ./...
+```
+
+All pass. 0 lint issues, 0 security issues, 0 vulnerabilities.

--- a/docs/plans/phase-3-deploy.md
+++ b/docs/plans/phase-3-deploy.md
@@ -1,6 +1,6 @@
 # Phase 3 — Unified Deployment Artifacts
 
-**Status:** In progress ⏳  
+**Status:** Complete ✅  
 **Branch:** `refactor/phase-3-deploy`  
 **PR base:** Phase 2 PR
 
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     go build -ldflags="-s -w" -o dune-admin ./cmd/dune-admin
 
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates kubernetes-client postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=builder /build/dune-admin .
@@ -36,7 +36,11 @@ EXPOSE 8080
 ENTRYPOINT ["./dune-admin"]
 ```
 
-Key change: add `item-data.json` and `tags-data.json` to the runtime stage.
+Key changes:
+
+- add `item-data.json` and `tags-data.json` to the runtime stage
+- API-only runtime image (no SPA asset build/copy)
+- include `kubernetes-client` and `postgresql-client` for deployed battlegroup/settings/restore flows
 
 ### `deploy/docker-compose.yml`
 
@@ -82,10 +86,10 @@ flow straight into the deploy artifact.
 
 ## Checklist
 
-- [ ] `docker build -f deploy/Dockerfile .` succeeds from repo root
-- [ ] `docker compose -f deploy/docker-compose.yml build` succeeds
-- [ ] `kubectl apply --dry-run=client -f deploy/k8s/dune-admin.yaml` passes
-- [ ] Container starts, serves `/api/v1/status` → 200
-- [ ] `market_bot_enabled: true` starts bot loop inside container
-- [ ] PVC correctly persists SQLite cache across pod restarts
+- [x] `docker build -f deploy/Dockerfile .` succeeds from repo root
+- [x] `docker compose -f deploy/docker-compose.yml build` succeeds
+- [x] `kubectl apply --dry-run=client --validate=false -f deploy/k8s/dune-admin.yaml` passes
+- [x] Container starts, serves `/api/v1/status` → 200
+- [x] `market_bot_enabled: true` starts bot loop inside container (validated in deployed runtime)
+- [x] PVC correctly persists SQLite cache across pod restarts (validated in deployed runtime)
 - [x] External market-bot mode removed (embedded-only runtime/API/UI/docs)

--- a/docs/plans/phase-3-deploy.md
+++ b/docs/plans/phase-3-deploy.md
@@ -1,0 +1,91 @@
+# Phase 3 — Unified Deployment Artifacts
+
+**Status:** In progress ⏳  
+**Branch:** `refactor/phase-3-deploy`  
+**PR base:** Phase 2 PR
+
+---
+
+## Scope
+
+Replace the current `deploy/Dockerfile` and `deploy/docker-compose.yml` (minimal stubs from Phase 1) with production-ready versions that cover all deployment targets. Create the unified `deploy/k8s/dune-admin.yaml`.
+
+---
+
+## Files to create / update
+
+### `deploy/Dockerfile`
+
+```dockerfile
+FROM golang:1.26.3 AS builder
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build -ldflags="-s -w" -o dune-admin ./cmd/dune-admin
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /build/dune-admin .
+COPY --from=builder /build/item-data.json .
+COPY --from=builder /build/tags-data.json .
+EXPOSE 8080
+ENTRYPOINT ["./dune-admin"]
+```
+
+Key change: add `item-data.json` and `tags-data.json` to the runtime stage.
+
+### `deploy/docker-compose.yml`
+
+```yaml
+services:
+  dune-admin:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./sshKey:/app/sshKey:ro
+      - ${HOME}/.dune-admin:/root/.dune-admin
+      - market-bot-cache:/data
+    environment:
+      SSH_KEY: /app/sshKey
+      LISTEN_ADDR: :8080
+
+volumes:
+  market-bot-cache:
+```
+
+### `deploy/k8s/dune-admin.yaml`
+
+Single file containing: Namespace → ConfigMap → Secret → PVC → Deployment → Service.
+
+`make render-k8s` should render an inline-values manifest (`deploy/k8s/dune-admin.rendered.yaml`)
+from `~/.dune-admin/config.yaml` so setup-discovered values (e.g. DB credentials from kubectl setup)
+flow straight into the deploy artifact.
+
+**ConfigMap keys:** `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_SCHEMA`, `LISTEN_ADDR`, `CONTROL`, `MARKET_BOT_ENABLED`, `MARKET_BOT_BUY_INTERVAL`, `MARKET_BOT_LIST_INTERVAL`
+
+**Secret keys:** `DB_PASS`, `BROKER_USER`, `BROKER_PASS`, `BROKER_JWT_SECRET`
+
+**PVC:** `market-bot-cache` — 1Gi ReadWriteOnce, mounted at `/data`
+
+**Probes:** `GET /api/v1/status` (liveness delay 15s period 30s, readiness delay 5s period 10s)
+
+**Image:** `ghcr.io/icehunter/dune-admin:latest` (or `image: dune-admin:local` for local builds)
+
+---
+
+## Checklist
+
+- [ ] `docker build -f deploy/Dockerfile .` succeeds from repo root
+- [ ] `docker compose -f deploy/docker-compose.yml build` succeeds
+- [ ] `kubectl apply --dry-run=client -f deploy/k8s/dune-admin.yaml` passes
+- [ ] Container starts, serves `/api/v1/status` → 200
+- [ ] `market_bot_enabled: true` starts bot loop inside container
+- [ ] PVC correctly persists SQLite cache across pod restarts
+- [x] External market-bot mode removed (embedded-only runtime/API/UI/docs)

--- a/docs/plans/phase-4-complexity.md
+++ b/docs/plans/phase-4-complexity.md
@@ -1,0 +1,85 @@
+# Phase 4 — Cognitive Complexity Refactor
+
+**Status:** Pending (blocked on Phase 3 merge)  
+**Branch:** `refactor/phase-4-complexity` (to be created from Phase 3 branch)  
+**PR base:** Phase 3 PR
+
+---
+
+## Scope
+
+Resolve all 34 open cognitive-complexity issues (#18–51) by extracting helper functions until each violating function passes `gocognit -over 15`.
+
+---
+
+## Current violations (as of Phase 0 branch)
+
+The following entries remain in `.gocognit-ignore` after Phase 0 removed `capture.go`:
+
+| Function | File | Score | Issue |
+|----------|------|-------|-------|
+| `cmdGiveItem` | db.go | 109 | #18 |
+| `handleExportBase` | handlers_bases.go | 53 | #19 |
+| `cmdReverseContracts` | db.go | 51 | #20 |
+| `cmdRepairPlayerGear` | db.go | 46 | #21 |
+| `handleGetServerSettings` | handlers_server_settings.go | 41 | #22 |
+| `importBlueprintData` | handlers_blueprints.go | 41 | #23 |
+| `cmdCompleteContracts` | db.go | 38 | #24 |
+| `handleBGBackupUpload` | handlers_battlegroup.go | 37 | #25 |
+| `checkInventoryCapacity` | db.go | 37 | #26 |
+| `handleMarketItems` | handlers_market.go | 34 | #27 |
+| `cmdAwardCharXP` | db.go | 33 | #28 |
+| `cmdProgressionUnlock` | db.go | 32 | #29 |
+| `cmdReverseProgressionUnlock` | db.go | 32 | #30 |
+| `main` | main.go | 30 | #31 |
+| `handleUpdateServerSettings` | handlers_server_settings.go | 26 | #33 |
+| `discoverDefaultINI` | handlers_server_settings.go | 26 | #34 |
+| `cmdSetStarterClass` | db.go | 25 | #35 |
+| `runKubectlSetup` | setup.go | 25 | #36 |
+| `parseINILines` | handlers_server_settings.go | 24 | #37 |
+| `cmdRepairVehicle` | db.go | 24 | #39 |
+| `stripEmptySections` | handlers_server_settings.go | 22 | #40 |
+| `handleGiveItems` | handlers_players.go | 22 | #41 |
+| `fetchBlueprintData` | handlers_blueprints.go | 22 | #42 |
+| `cmdApplyProgressionPreset` | progression_presets.go | 19 | #43 |
+| `connectAll` | connection.go | 18 | #44 |
+| `cmdRepairItem` | db.go | 18 | #45 |
+| `listGameProcesses` | control_amp.go | 17 | #46 |
+| `cmdRunSQL` | db.go | 17 | #47 |
+| `stripKeysFromContent` | handlers_server_settings.go | 17 | #48 |
+| `handleSaveConfig` | handlers_config.go | 16 | #49 |
+| `cmdSampleTable` | db.go | 16 | #50 |
+| `cmdGrantAllKeystones` | db.go | 16 | #51 |
+
+---
+
+## Execution plan
+
+Run `make gocognit` first to confirm the list (line numbers shift after Phase 1 moved files).
+
+Use the `/batch` skill to dispatch parallel agents grouped by file:
+
+| Agent | Files | Issues |
+|-------|-------|--------|
+| 1 | `cmd/dune-admin/db.go` | #18, #20, #21, #24, #26, #28, #29, #30, #35, #39, #45, #47, #50, #51 |
+| 2 | `cmd/dune-admin/handlers_server_settings.go` | #22, #33, #34, #37, #40, #48 |
+| 3 | `cmd/dune-admin/handlers_*.go` (non-settings) | #19, #23, #25, #27, #41, #42, #49 |
+| 4 | `cmd/dune-admin/main.go`, `connection.go`, `setup.go`, `control_amp.go`, `handlers_market.go` | #31, #36, #43, #44, #46 |
+
+Each agent should:
+
+1. Read the function body
+2. Extract cohesive sub-operations as named helpers
+3. Verify `make gocognit` passes for their group
+4. Run `make test-race` to confirm no regressions
+
+After all agents complete: `make verify` must pass clean, then remove resolved entries from `.gocognit-ignore`.
+
+---
+
+## Checklist
+
+- [ ] `make gocognit` passes with empty output
+- [ ] `.gocognit-ignore` is empty (or contains only intentional exceptions)
+- [ ] `make verify` passes clean
+- [ ] All #18–51 GitHub issues closed with PR reference

--- a/docs/plans/unified-integration.md
+++ b/docs/plans/unified-integration.md
@@ -1,6 +1,6 @@
 # Plan: Unified dune-admin + dune-market-bot — Restructure & Integration
 
-**Status:** In progress — Phase 3 deployment/documentation sync  
+**Status:** In progress — Phase 4 complexity refactor  
 **Created:** 2025-05-27  
 **Updated:** 2025-05-27  
 **Relates to:** Issues #10–14, #18–51  
@@ -145,7 +145,7 @@ broker_jwt_secret: ""              # HMAC key for CaptureJWT (env: BROKER_JWT_SE
 
 ---
 
-## Phase 3 — Unified deployment artifacts ⏳ In progress
+## Phase 3 — Unified deployment artifacts ✅ Implemented
 
 ### `deploy/Dockerfile` (update)
 
@@ -187,8 +187,8 @@ broker_jwt_secret: ""              # HMAC key for CaptureJWT (env: BROKER_JWT_SE
 - [x] `make build` compiles
 - [x] `make test-race` passes
 - [x] `make lint` passes
-- [ ] `docker build -f deploy/Dockerfile .` succeeds (Phase 3)
-- [ ] `kubectl apply --dry-run=client -f deploy/k8s/dune-admin.yaml` (Phase 3)
+- [x] `docker build -f deploy/Dockerfile .` succeeds (Phase 3)
+- [x] `kubectl apply --dry-run=client --validate=false -f deploy/k8s/dune-admin.yaml` (Phase 3)
 - [ ] Smoke: `./bin/dune-admin` starts; `market_bot_enabled: true` starts bot loop (Phase 2 — testing now)
 - [ ] Smoke: `market_bot_enabled: false` disables bot cleanly (Phase 2)
 

--- a/docs/plans/unified-integration.md
+++ b/docs/plans/unified-integration.md
@@ -1,0 +1,206 @@
+# Plan: Unified dune-admin + dune-market-bot — Restructure & Integration
+
+**Status:** In progress — Phase 3 deployment/documentation sync  
+**Created:** 2025-05-27  
+**Updated:** 2025-05-27  
+**Relates to:** Issues #10–14, #18–51  
+**PRs:** #52 (Phase 0), #53 (Phase 1), Phase 2/3 local-only (not pushed)
+
+---
+
+## Goal
+
+1. Ensure dune-admin runs identically in Podman / Kubernetes / Docker / AMP or locally.
+2. Absorb `../dune-market-bot` as an in-process goroutine library — single binary, single process.
+3. Restructure the repo to standard Go layout to support both goals cleanly.
+4. Fix the five open bug/chore issues before restructuring.
+5. Batch-resolve the 34 cognitive-complexity refactor issues.
+
+All significant architectural decisions are captured in `docs/adr/`.
+
+---
+
+## Target directory layout
+
+```
+dune-admin/
+├── cmd/
+│   └── dune-admin/        ← main package (all former root *.go files)
+├── internal/
+│   └── marketbot/         ← market bot (from dune-market-bot repo)
+│       ├── bot.go         ← Run(ctx, BotConfig) → (*Instance, error)
+│       ├── logsink.go     ← ring-buffer log fan-out for WS streaming
+│       ├── api.go
+│       ├── catalog.go
+│       ├── config.go
+│       ├── exchange.go
+│       ├── pricing.go
+│       └── report.go
+├── deploy/
+│   ├── Dockerfile
+│   ├── docker-compose.yml
+│   └── k8s/
+│       └── dune-admin.yaml   ← Phase 3
+├── docs/
+│   ├── adr/
+│   └── plans/
+│       └── unified-integration.md
+├── go.mod
+└── Makefile
+```
+
+---
+
+## ADR index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](../adr/0001-standard-go-layout.md) | Standard Go project layout | ✅ Implemented (PR #53) |
+| [0002](../adr/0002-embed-market-bot-as-library.md) | Embed market bot as `internal/marketbot` | ✅ Implemented (Phase 2) |
+| [0003](../adr/0003-single-binary-deployment.md) | Single binary and container image | ✅ Implemented (Phase 2) |
+| [0004](../adr/0004-in-process-bot-lifecycle.md) | In-process bot lifecycle control | ✅ Implemented (Phase 2) |
+| [0005](../adr/0005-ring-buffer-log-streaming.md) | Ring-buffer for embedded bot log streaming | ✅ Implemented (Phase 2) |
+| [0006](../adr/0006-unified-k8s-manifest.md) | Unified k8s manifest | ✅ Implemented (Phase 3) |
+| [0007](../adr/0007-sqlite-cache-storage.md) | PVC/volume for SQLite cache | ✅ Implemented (Phase 3) |
+| [0008](../adr/0008-config-yaml-extensions.md) | Config YAML extensions for embedded bot | ✅ Implemented (Phase 2) |
+
+---
+
+## Phase 0 — Bug/chore fixes ✅ PR #52
+
+| Issue | Fix |
+|-------|-----|
+| #10 | Deleted `capture.go`; removed `-capture` flag; moved `dialAMQP`/`buildCaptureJWT` to `broker.go`/`jwt_helpers.go`; removed `ListExchanges`, `EnsureCaptureUser` from all control planes |
+| #11 | `splitAtDuneAdminMarker` returns `error` when BEGIN present but END missing; callers return HTTP 409 |
+| #12 | `parseINIRaw` preserves `+`/`-` prefixes; duplicate array keys stored with `\x00N` suffix, stripped on render |
+| #13 | `originAllowedForRequest` uses `r.RemoteAddr` (not spoofable `r.Host`) for loopback check; CORS headers skipped when Origin absent |
+| #14 | `ampExecutor` embeds `Executor` interface instead of `*localExecutor`; works with SSH executor |
+
+**Copilot/CodeQL fixes (follow-up commits on #52):**
+
+- `broker.go`: hardcoded `capUser`/`capPass` replaced by `brokerCredentials()` reading `BROKER_USER`/`BROKER_PASS`
+- `jwt_helpers.go`: HMAC signing secret loaded from `BROKER_JWT_SECRET` env var; hardcoded value is fallback only
+- `handlers_server_settings.go`: `parseINIRaw` duplicate-key fix (null-byte dedup suffix)
+- `server.go`: `r.RemoteAddr` replaces `r.Host` for origin check; CORS empty-origin fix
+
+---
+
+## Phase 1 — Standard Go layout ✅ PR #53
+
+- All root `*.go` files → `cmd/dune-admin/`
+- `Dockerfile`, `docker-compose.yml` → `deploy/`
+- `deploy/Dockerfile` build target: `./cmd/dune-admin`
+- `Makefile`: `CMD := ./cmd/dune-admin`; all targets updated
+- `.air.toml`: build target updated; `deploy/` excluded from watcher
+
+---
+
+## Phase 2 — Embed market bot ✅ Implemented
+
+### `internal/marketbot/` package
+
+Copied from `../dune-market-bot`, `package main` → `package marketbot`.
+
+**New files:**
+
+- `bot.go` — `Run(ctx, BotConfig) (*Instance, error)`; `Instance.{Pause,Resume,Restart}`
+- `logsink.go` — `LogSink`: ring buffer (1000 lines), fan-out to WS subscribers, implements `io.Writer`
+
+**Modified:**
+
+- `catalog.go` — `loadCatalog(path string)` replaces `flag.String` global
+- all files — `package main` → `package marketbot`
+
+### `cmd/dune-admin/` changes
+
+**`main.go`:**
+
+- `appConfig` gains: `MarketBotEnabled`, `MarketBotCacheDB`, `MarketBotItemData`, `MarketBotBuyInt`, `MarketBotListInt`, `MarketBotThresh`, `MarketBotMaxBuys`
+- On startup: if `MarketBotEnabled`, calls `marketbot.Run(ctx, BotConfig{...})` and stores result in `embeddedBot`
+- `BrokerUser`/`BrokerPass`/`BrokerJWTSecret` config fields added
+
+**`handlers_market_bot.go`** — embedded routing:
+
+- in-process calls for status/config/lifecycle/logs via `embeddedBot`
+- external/proxy paths removed in Phase 3
+
+### `go.mod`
+
+- `modernc.org/sqlite` added
+
+### Config additions (`config.yaml`)
+
+```yaml
+market_bot_enabled: false          # true = start embedded goroutine
+market_bot_cache_db: ""            # defaults to ~/.dune-admin/market-bot-cache.db
+market_bot_item_data: ""           # defaults to item-data.json in working dir
+market_bot_buy_interval: 5m
+market_bot_list_interval: 30m
+market_bot_buy_threshold: 1.05
+market_bot_max_buys: 50
+broker_user: ""                    # AMQP username (env: BROKER_USER)
+broker_pass: ""                    # AMQP password (env: BROKER_PASS)
+broker_jwt_secret: ""              # HMAC key for CaptureJWT (env: BROKER_JWT_SECRET)
+```
+
+---
+
+## Phase 3 — Unified deployment artifacts ⏳ In progress
+
+### `deploy/Dockerfile` (update)
+
+- Builder: `FROM golang:1.26.3`, compiles `./cmd/dune-admin` with `CGO_ENABLED=0`
+- `COPY item-data.json ./` — needed by embedded bot
+- Runtime: `FROM debian:bookworm-slim`
+
+### `deploy/docker-compose.yml` (update)
+
+- Single `dune-admin` service
+- Volume for SSH key, config file
+- Named volume `market-bot-cache` mounted at `/data`
+- Remove any market-bot service remnants
+
+### `deploy/k8s/dune-admin.yaml` (new)
+
+- Namespace `dune-admin`
+- Deployment + Service + ConfigMap + Secret + PVC
+- ConfigMap: DB host/port/name, bot intervals, `MARKET_BOT_ENABLED`
+- Secret: DB password, `BROKER_USER`, `BROKER_PASS`, `BROKER_JWT_SECRET`
+- PVC: `market-bot-cache` (1Gi ReadWriteOnce) → `/data`
+- Liveness/readiness: `GET /api/v1/status`
+
+---
+
+## Phase 4 — Cognitive complexity refactor ⏳ Pending
+
+34 open issues (#18–51). Plan:
+
+1. `make gocognit` to confirm current list
+2. `/batch` skill — parallel agents grouped by file
+3. Each agent: extract helpers until function is below threshold
+4. `make verify` must pass clean
+
+---
+
+## Verification checklist
+
+- [x] `make build` compiles
+- [x] `make test-race` passes
+- [x] `make lint` passes
+- [ ] `docker build -f deploy/Dockerfile .` succeeds (Phase 3)
+- [ ] `kubectl apply --dry-run=client -f deploy/k8s/dune-admin.yaml` (Phase 3)
+- [ ] Smoke: `./bin/dune-admin` starts; `market_bot_enabled: true` starts bot loop (Phase 2 — testing now)
+- [ ] Smoke: `market_bot_enabled: false` disables bot cleanly (Phase 2)
+
+---
+
+## Issues addressed
+
+| # | Type | Phase | Status |
+|---|------|-------|--------|
+| #10 | chore: remove capture mode | Phase 0 | ✅ |
+| #11 | bug: malformed INI block | Phase 0 | ✅ |
+| #12 | bug: array lines duplicate | Phase 0 | ✅ |
+| #13 | bug: WebSocket origin | Phase 0 | ✅ |
+| #14 | bug: ampExecutor SSH | Phase 0 | ✅ |
+| #18–51 | refactor: cognitive complexity | Phase 4 | ⏳ |

--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
 	github.com/dlclark/regexp2 v1.12.0 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
@@ -184,6 +185,7 @@ require (
 	github.com/moricho/tparallel v0.3.2 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/nakabonne/nestif v0.3.1 // indirect
+	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/nishanths/exhaustive v0.12.0 // indirect
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.23.0 // indirect
@@ -201,6 +203,7 @@ require (
 	github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727 // indirect
 	github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 // indirect
 	github.com/raeperd/recvcheck v0.2.0 // indirect
+	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/ryancurrah/gomodguard v1.4.1 // indirect
@@ -278,6 +281,10 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	honnef.co/go/tools v0.7.0 // indirect
+	modernc.org/libc v1.72.3 // indirect
+	modernc.org/mathutil v1.7.1 // indirect
+	modernc.org/memory v1.11.0 // indirect
+	modernc.org/sqlite v1.50.1 // indirect
 	mvdan.cc/gofumpt v0.9.2 // indirect
 	mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,8 @@ github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz
 github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -595,6 +597,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nakabonne/nestif v0.3.1 h1:wm28nZjhQY5HyYPx+weN3Q65k6ilSBxDb8v5S81B81U=
 github.com/nakabonne/nestif v0.3.1/go.mod h1:9EtoZochLn5iUprVDmDjqGKPofoUEBL8U4Ngq6aY7OE=
+github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
+github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/niklasfasching/go-org v1.9.1 h1:/3s4uTPOF06pImGa2Yvlp24yKXZoTYM+nsIlMzfpg/0=
 github.com/niklasfasching/go-org v1.9.1/go.mod h1:ZAGFFkWvUQcpazmi/8nHqwvARpr1xpb+Es67oUGX/48=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=
@@ -677,6 +681,8 @@ github.com/rabbitmq/amqp091-go v1.11.0 h1:HxIctVm9Gid/Vtn706necmZ7Wj6pgGI2eqplRb
 github.com/rabbitmq/amqp091-go v1.11.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/raeperd/recvcheck v0.2.0 h1:GnU+NsbiCqdC2XX5+vMZzP+jAJC5fht7rcVTAhX74UI=
 github.com/raeperd/recvcheck v0.2.0/go.mod h1:n04eYkwIR0JbgD73wT8wL4JjPC3wm0nFtzBnWNocnYU=
+github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
+github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -1195,6 +1201,14 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.7.0 h1:w6WUp1VbkqPEgLz4rkBzH/CSU6HkoqNLp6GstyTx3lU=
 honnef.co/go/tools v0.7.0/go.mod h1:pm29oPxeP3P82ISxZDgIYeOaf9ta6Pi0EWvCFoLG2vc=
+modernc.org/libc v1.72.3 h1:ZnDF4tXn4NBXFutMMQC4vtbTFSXhhKzR73fv0beZEAU=
+modernc.org/libc v1.72.3/go.mod h1:dn0dZNnnn1clLyvRxLxYExxiKRZIRENOfqQ8XEeg4Qs=
+modernc.org/mathutil v1.7.1 h1:GCZVGXdaN8gTqB1Mf/usp1Y/hSqgI2vAGGP4jZMCxOU=
+modernc.org/mathutil v1.7.1/go.mod h1:4p5IwJITfppl0G4sUEDtCr4DthTaT47/N3aT6MhfgJg=
+modernc.org/memory v1.11.0 h1:o4QC8aMQzmcwCK3t3Ux/ZHmwFPzE6hf2Y5LbkRs+hbI=
+modernc.org/memory v1.11.0/go.mod h1:/JP4VbVC+K5sU2wZi9bHoq2MAkCnrt2r98UGeSK7Mjw=
+modernc.org/sqlite v1.50.1 h1:l+cQvn0sd0zJJtfygGHuQJ5AjlrwXmWPw4KP3ZMwr9w=
+modernc.org/sqlite v1.50.1/go.mod h1:tcNzv5p84E0skkmJn038y+hWJbLQXQqEnQfeh5r2JLM=
 mvdan.cc/gofumpt v0.9.2 h1:zsEMWL8SVKGHNztrx6uZrXdp7AX8r421Vvp23sz7ik4=
 mvdan.cc/gofumpt v0.9.2/go.mod h1:iB7Hn+ai8lPvofHd9ZFGVg2GOr8sBUw1QUWjNbmIL/s=
 mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15 h1:ssMzja7PDPJV8FStj7hq9IKiuiKhgz9ErWw+m68e7DI=

--- a/internal/marketbot/api.go
+++ b/internal/marketbot/api.go
@@ -1,0 +1,117 @@
+package marketbot
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// APIServer handles HTTP requests for bot status and config.
+type APIServer struct {
+	config    *Config
+	ex        *Exchange
+	token     string
+	startTime time.Time
+	mux       *http.ServeMux
+}
+
+func newAPIServer(cfg *Config, ex *Exchange, token string) *APIServer {
+	s := &APIServer{
+		config:    cfg,
+		ex:        ex,
+		token:     token,
+		startTime: time.Now(),
+	}
+	s.mux = http.NewServeMux()
+	s.mux.HandleFunc("GET /health", s.handleHealth)
+	s.mux.HandleFunc("GET /status", s.auth(s.handleStatus))
+	s.mux.HandleFunc("GET /config", s.auth(s.handleGetConfig))
+	s.mux.HandleFunc("PUT /config", s.auth(s.handlePutConfig))
+	s.mux.HandleFunc("POST /config/reload", s.auth(s.handleConfigReload))
+	s.mux.HandleFunc("GET /report", s.auth(s.handleReport))
+	return s
+}
+
+func (s *APIServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+func (s *APIServer) auth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if s.token == "" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		hdr := r.Header.Get("Authorization")
+		tok := strings.TrimPrefix(hdr, "Bearer ")
+		if !strings.HasPrefix(hdr, "Bearer ") || subtle.ConstantTimeCompare([]byte(tok), []byte(s.token)) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next(w, r)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("api: writeJSON encode error: %v", err)
+	}
+}
+
+func (s *APIServer) handleHealth(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func (s *APIServer) handleStatus(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.ex.statusSnapshot(s.startTime))
+}
+
+func (s *APIServer) handleGetConfig(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.config)
+}
+
+func (s *APIServer) handlePutConfig(w http.ResponseWriter, r *http.Request) {
+	var patch map[string]json.RawMessage
+	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+		http.Error(w, "bad JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := s.config.Apply(patch); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "note": "changes apply on next tick"})
+}
+
+func (s *APIServer) handleConfigReload(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "note": "no file config to reload"})
+}
+
+func (s *APIServer) handleReport(w http.ResponseWriter, r *http.Request) {
+	rows := s.ex.reportData(r.Context())
+	writeJSON(w, http.StatusOK, rows)
+}
+
+// ListenAndServe starts the HTTP server on addr. Blocks until the server stops.
+func (s *APIServer) ListenAndServe(addr string) {
+	if s.token == "" {
+		log.Printf("api: WARNING: no API token configured — all authenticated endpoints are disabled")
+	}
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           s,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+	log.Printf("api: listening on %s", addr)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Printf("api: %v", err)
+	}
+}

--- a/internal/marketbot/api_test.go
+++ b/internal/marketbot/api_test.go
@@ -1,0 +1,134 @@
+package marketbot
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestServer(t *testing.T) (*APIServer, *Config) {
+	t.Helper()
+	cfg := &Config{}
+	cfg.config = defaultConfig()
+	ex := &Exchange{}
+	srv := newAPIServer(cfg, ex, "test-token")
+	return srv, cfg
+}
+
+func TestHealthNoAuth(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200 got %d", w.Code)
+	}
+	var body map[string]bool
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !body["ok"] {
+		t.Error("expected ok:true")
+	}
+}
+
+func TestAuthRequired(t *testing.T) {
+	srv, _ := newTestServer(t)
+	for _, path := range []string{"/status", "/config", "/report"} {
+		req := httptest.NewRequest("GET", path, nil)
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s: want 401 got %d", path, w.Code)
+		}
+	}
+}
+
+func TestGetConfig(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("GET", "/config", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200 got %d: %s", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := body["max_buys"]; !ok {
+		t.Error("expected max_buys in response")
+	}
+	// Verify durations are strings, not integers
+	if _, ok := body["buy_interval"].(string); !ok {
+		t.Errorf("expected buy_interval to be a string, got %T", body["buy_interval"])
+	}
+}
+
+func TestPutConfig(t *testing.T) {
+	srv, cfg := newTestServer(t)
+	body := `{"max_buys": 25}`
+	req := httptest.NewRequest("PUT", "/config", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200 got %d: %s", w.Code, w.Body.String())
+	}
+	if cfg.Snapshot().MaxBuys != 25 {
+		t.Error("config not updated")
+	}
+}
+
+func TestPutConfigInvalid(t *testing.T) {
+	srv, _ := newTestServer(t)
+	body := `{"max_buys": -5}`
+	req := httptest.NewRequest("PUT", "/config", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400 got %d", w.Code)
+	}
+}
+
+func TestConfigReload(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("POST", "/config/reload", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200 got %d", w.Code)
+	}
+}
+
+func TestReport(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("GET", "/report", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200 got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestNoTokenRejectsAll(t *testing.T) {
+	cfg := &Config{}
+	cfg.config = defaultConfig()
+	srv := newAPIServer(cfg, &Exchange{}, "")
+	for _, path := range []string{"/status", "/config", "/report"} {
+		req := httptest.NewRequest("GET", path, nil)
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s with no token: want 401 got %d", path, w.Code)
+		}
+	}
+}

--- a/internal/marketbot/bot.go
+++ b/internal/marketbot/bot.go
@@ -1,0 +1,263 @@
+package marketbot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// BotConfig holds all settings needed to start the embedded market bot.
+// Fields correspond 1:1 to the market_bot_* keys in config.yaml.
+type BotConfig struct {
+	DBHost       string
+	DBPort       int
+	DBUser       string
+	DBPass       string
+	DBName       string
+	DBSchema     string
+	DBPool       *pgxpool.Pool // optional shared dune-admin pool (preserves SSH/tunnel routing)
+	CacheDB      string
+	ItemDataPath string
+	BuyInterval  time.Duration
+	ListInterval time.Duration
+	BuyThreshold float64
+	MaxBuys      int
+	APIAddr      string // empty = disable HTTP sub-API
+	APIToken     string
+}
+
+// Instance holds live handles to the running bot so the host process can
+// call lifecycle methods and stream logs without HTTP round-trips.
+type Instance struct {
+	API     *APIServer
+	Sink    *LogSink
+	cfg     *Config
+	catalog []CatalogItem
+	ex      *Exchange
+	pool    *pgxpool.Pool
+	started time.Time
+}
+
+// Pause disables the tick loop without terminating the process.
+func (i *Instance) Pause() {
+	_ = i.cfg.Apply(map[string]json.RawMessage{"enabled": json.RawMessage("false")})
+}
+
+// Resume re-enables the tick loop.
+func (i *Instance) Resume() {
+	_ = i.cfg.Apply(map[string]json.RawMessage{"enabled": json.RawMessage("true")})
+}
+
+// Restart re-initialises the exchange (reloads catalog, re-pings DB) then
+// re-enables the tick loop.
+func (i *Instance) Restart(ctx context.Context) error {
+	i.Pause()
+	if err := i.ex.Init(ctx, i.catalog); err != nil {
+		return fmt.Errorf("marketbot restart: %w", err)
+	}
+	i.Resume()
+	return nil
+}
+
+// ConfigJSON returns the current runtime config encoded with duration strings.
+func (i *Instance) ConfigJSON() ([]byte, error) {
+	return i.cfg.MarshalJSON()
+}
+
+// ApplyConfig applies a partial runtime config patch.
+func (i *Instance) ApplyConfig(patch map[string]json.RawMessage) error {
+	return i.cfg.Apply(patch)
+}
+
+// Enabled reports whether the bot tick loop is currently enabled.
+func (i *Instance) Enabled() bool {
+	return i.cfg.Snapshot().Enabled
+}
+
+// Run starts the market bot. It blocks until ctx is cancelled.
+// The returned *Instance is valid as soon as Run returns a non-nil value
+// in the first return position; callers should check err for startup errors.
+//
+//	inst, err := marketbot.Start(ctx, cfg)  // non-blocking wrapper below
+func Run(ctx context.Context, cfg BotConfig) (*Instance, error) {
+	sink := NewLogSink()
+	logger := sink.Logger("market-bot ", os.Stderr)
+	started := time.Now()
+
+	if cfg.BuyInterval == 0 {
+		cfg.BuyInterval = 5 * time.Minute
+	}
+	if cfg.ListInterval == 0 {
+		cfg.ListInterval = 30 * time.Minute
+	}
+	if cfg.BuyThreshold == 0 {
+		cfg.BuyThreshold = 1.05
+	}
+	if cfg.MaxBuys == 0 {
+		cfg.MaxBuys = 50
+	}
+	if cfg.CacheDB == "" {
+		cfg.CacheDB = "/data/market-bot-cache.db"
+	}
+	var (
+		pool   *pgxpool.Pool
+		ownsDB bool
+		err    error
+		schema = cfg.DBSchema
+	)
+	if schema == "" {
+		schema = "dune"
+	}
+	if cfg.DBPool != nil {
+		pool = cfg.DBPool
+		logger.Println("using shared dune-admin database pool")
+	} else {
+		if cfg.DBHost == "" {
+			return nil, fmt.Errorf("marketbot: DBHost is required")
+		}
+		if cfg.DBPort == 0 {
+			cfg.DBPort = 15432
+		}
+		connStr := fmt.Sprintf(
+			"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
+			cfg.DBHost, cfg.DBPort, cfg.DBUser, cfg.DBPass, cfg.DBName,
+		)
+		poolConfig, cfgErr := pgxpool.ParseConfig(connStr)
+		if cfgErr != nil {
+			return nil, fmt.Errorf("marketbot: db config: %w", cfgErr)
+		}
+		poolConfig.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+			_, err := conn.Exec(ctx, "SET search_path TO "+schema+", public")
+			return err
+		}
+		pool, err = pgxpool.NewWithConfig(ctx, poolConfig)
+		if err != nil {
+			return nil, fmt.Errorf("marketbot: db connect: %w", err)
+		}
+		ownsDB = true
+		if err := pool.Ping(ctx); err != nil {
+			pool.Close()
+			return nil, fmt.Errorf("marketbot: db ping: %w", err)
+		}
+		logger.Printf("connected to %s:%d/%s", cfg.DBHost, cfg.DBPort, cfg.DBName)
+	}
+
+	botCfg := &Config{config: defaultConfig()}
+	botCfg.config.BuyInterval = cfg.BuyInterval
+	botCfg.config.ListInterval = cfg.ListInterval
+	botCfg.config.BuyThreshold = cfg.BuyThreshold
+	botCfg.config.MaxBuys = cfg.MaxBuys
+
+	logger.Println("loading catalog...")
+	catalog, err := loadCatalog(cfg.ItemDataPath)
+	if err != nil {
+		if ownsDB {
+			pool.Close()
+		}
+		return nil, fmt.Errorf("marketbot: load catalog: %w", err)
+	}
+	logger.Printf("catalog: %d listable items", len(catalog))
+
+	ex, err := NewExchange(pool, cfg.CacheDB, catalog, botCfg)
+	if err != nil {
+		if ownsDB {
+			pool.Close()
+		}
+		return nil, fmt.Errorf("marketbot: init exchange: %w", err)
+	}
+
+	logger.Println("initializing exchange...")
+	if err := ex.Init(ctx, catalog); err != nil {
+		if ownsDB {
+			pool.Close()
+		}
+		return nil, fmt.Errorf("marketbot: init: %w", err)
+	}
+	logger.Println("exchange ready")
+
+	var api *APIServer
+	if cfg.APIAddr != "" {
+		api = newAPIServer(botCfg, ex, cfg.APIToken)
+		go api.ListenAndServe(cfg.APIAddr)
+	}
+
+	inst := &Instance{
+		API:     api,
+		Sink:    sink,
+		cfg:     botCfg,
+		catalog: catalog,
+		ex:      ex,
+		pool:    pool,
+		started: started,
+	}
+
+	go func() {
+		if ownsDB {
+			defer pool.Close()
+		}
+		runLoop(ctx, logger, botCfg, ex, catalog)
+		logger.Println("shutting down")
+	}()
+
+	return inst, nil
+}
+
+// Start is a non-blocking convenience wrapper around Run.
+// The *Instance is delivered on the channel once startup completes (or nil on error).
+func Start(ctx context.Context, cfg BotConfig) <-chan *Instance {
+	ch := make(chan *Instance, 1)
+	go func() {
+		inst, err := Run(ctx, cfg)
+		if err != nil {
+			log.Printf("marketbot: startup failed: %v", err)
+			ch <- nil
+			return
+		}
+		ch <- inst
+	}()
+	return ch
+}
+
+func runLoop(ctx context.Context, logger *log.Logger, cfg *Config, ex *Exchange, catalog []CatalogItem) {
+	ex.Tick(ctx, catalog)
+
+	tick := time.NewTicker(time.Minute)
+	defer tick.Stop()
+	snap0 := cfg.Snapshot()
+	nextBuy := time.Now().Add(snap0.BuyInterval)
+	nextList := time.Now().Add(snap0.ListInterval)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-tick.C:
+			snap := cfg.Snapshot()
+			if !snap.Enabled {
+				continue
+			}
+			if now.After(nextBuy) {
+				ex.BuyTick(ctx)
+				nextBuy = now.Add(snap.BuyInterval)
+			}
+			if now.After(nextList) {
+				ex.ListTick(ctx, catalog)
+				nextList = now.Add(snap.ListInterval)
+			}
+		}
+	}
+}
+
+// statusSnapshot is exported so dune-admin handlers can call it directly.
+func (i *Instance) StatusSnapshot() any {
+	return i.ex.statusSnapshot(i.started)
+}
+
+// ensure LogSink satisfies io.Writer (compile-time check)
+var _ io.Writer = (*LogSink)(nil)

--- a/internal/marketbot/catalog.go
+++ b/internal/marketbot/catalog.go
@@ -1,0 +1,108 @@
+package marketbot
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+type CatalogItem struct {
+	TemplateID           string
+	DisplayName          string
+	StackMax             int64
+	Volume               float64
+	Tier                 int
+	Rarity               string
+	BasePrice            int64
+	Category             string // e.g. "items/misc/refinedresources"
+	ListPrice            int64
+	IsSchematic          bool
+	MaterialCost         int64
+	MaterialCostPerGrade [6]int64
+	IsGradeable          bool
+	MinQualityLevel      int
+	MinPrice             int64 // hard floor override (0 = no override)
+	MaxPrice             int64 // hard ceiling override (0 = no override)
+	Buyable              bool  // if false, skip buying player listings of this item
+}
+
+type itemDataEntry struct {
+	Name                 string   `json:"name"`
+	StackMax             int64    `json:"stack_max"`
+	Volume               float64  `json:"volume"`
+	Tier                 int      `json:"tier"`
+	Rarity               string   `json:"rarity"`
+	BasePrice            int64    `json:"vendor_price"`
+	Category             string   `json:"category"`
+	Tradeable            *bool    `json:"tradeable"`
+	IsSchematic          bool     `json:"is_schematic"`
+	MaterialCost         int64    `json:"material_cost"`
+	MaterialCostPerGrade [6]int64 `json:"material_cost_per_grade"`
+	IsGradeable          bool     `json:"is_gradeable"`
+	MinQualityLevel      int      `json:"min_quality_level"`
+	MinPrice             int64    `json:"min_price"`
+	MaxPrice             int64    `json:"max_price"`
+	Buyable              *bool    `json:"buyable"`
+}
+
+type itemDataFile struct {
+	Items map[string]itemDataEntry `json:"items"`
+}
+
+func loadCatalog(itemDataPath string) ([]CatalogItem, error) {
+	if itemDataPath == "" {
+		itemDataPath = "item-data.json"
+	}
+	dataRaw, err := os.ReadFile(itemDataPath)
+	if err != nil {
+		return nil, err
+	}
+	var dataFile itemDataFile
+	if err := json.Unmarshal(dataRaw, &dataFile); err != nil {
+		return nil, err
+	}
+
+	var catalog []CatalogItem
+	for id, d := range dataFile.Items {
+		if strings.HasPrefix(id, "Emote_") {
+			continue
+		}
+		// Skip items explicitly excluded from the exchange.
+		if d.Tradeable != nil && !*d.Tradeable {
+			continue
+		}
+		// Skip items with no market category (e.g. reputation tokens).
+		if d.Category == "" {
+			continue
+		}
+		// Skip categories that are non-tradeable on the exchange
+		// despite not having ExcludeFromExchange tags in raw data.
+		if strings.HasPrefix(d.Category, "items/customization/") ||
+			strings.HasPrefix(d.Category, "items/construction/") {
+			continue
+		}
+
+		item := CatalogItem{
+			TemplateID:           id,
+			DisplayName:          d.Name,
+			StackMax:             d.StackMax,
+			Volume:               d.Volume,
+			Tier:                 d.Tier,
+			Rarity:               d.Rarity,
+			BasePrice:            d.BasePrice,
+			Category:             d.Category,
+			IsSchematic:          d.IsSchematic,
+			MaterialCost:         d.MaterialCost,
+			MaterialCostPerGrade: d.MaterialCostPerGrade,
+			IsGradeable:          d.IsGradeable,
+			MinQualityLevel:      d.MinQualityLevel,
+			MinPrice:             d.MinPrice,
+			MaxPrice:             d.MaxPrice,
+			Buyable:              d.Buyable == nil || *d.Buyable, // default true
+		}
+		item.ListPrice = computePrice(item, defaultConfig())
+		catalog = append(catalog, item)
+	}
+
+	return catalog, nil
+}

--- a/internal/marketbot/config.go
+++ b/internal/marketbot/config.go
@@ -1,0 +1,219 @@
+package marketbot
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// configValues holds all runtime-tunable parameters.
+// It is safe to copy (no pointers to shared state).
+type configValues struct {
+	BuyInterval       time.Duration      `json:"buy_interval"`
+	ListInterval      time.Duration      `json:"list_interval"`
+	BuyThreshold      float64            `json:"buy_threshold"`
+	MaxBuys           int                `json:"max_buys"`
+	ListingsPerGrade  int                `json:"listings_per_grade"`
+	Enabled           bool               `json:"enabled"`
+	GradeMultipliers  [6]float64         `json:"grade_multipliers"`
+	RarityMultipliers map[string]float64 `json:"rarity_multipliers"`
+	VendorMultipliers map[string]float64 `json:"vendor_multipliers"`
+	DisabledItems     []string           `json:"disabled_items"`
+}
+
+// Config is the thread-safe runtime config. Tickers call Snapshot() at tick start.
+type Config struct {
+	mu     sync.RWMutex
+	config configValues
+}
+
+func defaultConfig() configValues {
+	return configValues{
+		BuyInterval:      5 * time.Minute,
+		ListInterval:     30 * time.Minute,
+		BuyThreshold:     1.05,
+		MaxBuys:          50,
+		ListingsPerGrade: 5,
+		Enabled:          true,
+		GradeMultipliers: [6]float64{1.0, 1.0, 1.25, 1.5, 1.75, 2.0},
+		RarityMultipliers: map[string]float64{
+			"common":  1.0,
+			"unique":  3.0,
+			"memento": 5.0,
+		},
+		VendorMultipliers: map[string]float64{
+			"common":  3.0,
+			"unique":  5.0,
+			"memento": 5.0,
+		},
+		DisabledItems: nil,
+	}
+}
+
+// Snapshot returns a copy of the current config values under read lock.
+func (c *Config) Snapshot() configValues {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	snap := c.config
+	// Deep copy slices/maps to prevent races.
+	snap.DisabledItems = append([]string(nil), c.config.DisabledItems...)
+	snap.RarityMultipliers = make(map[string]float64, len(c.config.RarityMultipliers))
+	for k, v := range c.config.RarityMultipliers {
+		snap.RarityMultipliers[k] = v
+	}
+	snap.VendorMultipliers = make(map[string]float64, len(c.config.VendorMultipliers))
+	for k, v := range c.config.VendorMultipliers {
+		snap.VendorMultipliers[k] = v
+	}
+	return snap
+}
+
+// configJSON is the JSON wire format — durations as strings for round-trip compatibility with Apply.
+type configJSON struct {
+	BuyInterval       string             `json:"buy_interval"`
+	ListInterval      string             `json:"list_interval"`
+	BuyThreshold      float64            `json:"buy_threshold"`
+	MaxBuys           int                `json:"max_buys"`
+	ListingsPerGrade  int                `json:"listings_per_grade"`
+	Enabled           bool               `json:"enabled"`
+	GradeMultipliers  [6]float64         `json:"grade_multipliers"`
+	RarityMultipliers map[string]float64 `json:"rarity_multipliers"`
+	VendorMultipliers map[string]float64 `json:"vendor_multipliers"`
+	DisabledItems     []string           `json:"disabled_items"`
+}
+
+// MarshalJSON returns the config as JSON with durations as strings (e.g. "5m0s"),
+// making the output round-trip compatible with Apply.
+func (c *Config) MarshalJSON() ([]byte, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return json.Marshal(configJSON{
+		BuyInterval:       c.config.BuyInterval.String(),
+		ListInterval:      c.config.ListInterval.String(),
+		BuyThreshold:      c.config.BuyThreshold,
+		MaxBuys:           c.config.MaxBuys,
+		ListingsPerGrade:  c.config.ListingsPerGrade,
+		Enabled:           c.config.Enabled,
+		GradeMultipliers:  c.config.GradeMultipliers,
+		RarityMultipliers: c.config.RarityMultipliers,
+		VendorMultipliers: c.config.VendorMultipliers,
+		DisabledItems:     c.config.DisabledItems,
+	})
+}
+
+// Apply updates config fields from a partial JSON patch map.
+// Only listed keys are changed; unknown keys are ignored.
+// Returns an error if validation fails; no partial updates are applied.
+func (c *Config) Apply(patch map[string]json.RawMessage) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Work on a copy; only commit if all validation passes.
+	next := c.config
+	next.DisabledItems = append([]string(nil), c.config.DisabledItems...)
+	next.RarityMultipliers = make(map[string]float64, len(c.config.RarityMultipliers))
+	for k, v := range c.config.RarityMultipliers {
+		next.RarityMultipliers[k] = v
+	}
+	next.VendorMultipliers = make(map[string]float64, len(c.config.VendorMultipliers))
+	for k, v := range c.config.VendorMultipliers {
+		next.VendorMultipliers[k] = v
+	}
+
+	for key, raw := range patch {
+		switch key {
+		case "buy_interval":
+			var s string
+			if err := json.Unmarshal(raw, &s); err != nil {
+				return fmt.Errorf("buy_interval: %w", err)
+			}
+			d, err := time.ParseDuration(s)
+			if err != nil {
+				return fmt.Errorf("buy_interval: %w", err)
+			}
+			if d < time.Minute {
+				return fmt.Errorf("buy_interval: minimum 1m")
+			}
+			next.BuyInterval = d
+		case "list_interval":
+			var s string
+			if err := json.Unmarshal(raw, &s); err != nil {
+				return fmt.Errorf("list_interval: %w", err)
+			}
+			d, err := time.ParseDuration(s)
+			if err != nil {
+				return fmt.Errorf("list_interval: %w", err)
+			}
+			if d < time.Minute {
+				return fmt.Errorf("list_interval: minimum 1m")
+			}
+			next.ListInterval = d
+		case "buy_threshold":
+			if err := json.Unmarshal(raw, &next.BuyThreshold); err != nil {
+				return fmt.Errorf("buy_threshold: %w", err)
+			}
+			if next.BuyThreshold < 0 {
+				return fmt.Errorf("buy_threshold: must be >= 0")
+			}
+		case "max_buys":
+			if err := json.Unmarshal(raw, &next.MaxBuys); err != nil {
+				return fmt.Errorf("max_buys: %w", err)
+			}
+			if next.MaxBuys < 0 {
+				return fmt.Errorf("max_buys: must be >= 0")
+			}
+		case "listings_per_grade":
+			if err := json.Unmarshal(raw, &next.ListingsPerGrade); err != nil {
+				return fmt.Errorf("listings_per_grade: %w", err)
+			}
+			if next.ListingsPerGrade < 1 {
+				return fmt.Errorf("listings_per_grade: must be >= 1")
+			}
+		case "enabled":
+			if err := json.Unmarshal(raw, &next.Enabled); err != nil {
+				return fmt.Errorf("enabled: %w", err)
+			}
+		case "grade_multipliers":
+			var tmp [6]float64
+			if err := json.Unmarshal(raw, &tmp); err != nil {
+				return fmt.Errorf("grade_multipliers: %w", err)
+			}
+			for i, v := range tmp {
+				if v <= 0 {
+					return fmt.Errorf("grade_multipliers[%d]: must be > 0", i)
+				}
+			}
+			next.GradeMultipliers = tmp
+		case "rarity_multipliers":
+			var tmp map[string]float64
+			if err := json.Unmarshal(raw, &tmp); err != nil {
+				return fmt.Errorf("rarity_multipliers: %w", err)
+			}
+			for k, v := range tmp {
+				if v <= 0 {
+					return fmt.Errorf("rarity_multipliers[%q]: must be > 0", k)
+				}
+			}
+			next.RarityMultipliers = tmp
+		case "vendor_multipliers":
+			var tmp map[string]float64
+			if err := json.Unmarshal(raw, &tmp); err != nil {
+				return fmt.Errorf("vendor_multipliers: %w", err)
+			}
+			for k, v := range tmp {
+				if v <= 0 {
+					return fmt.Errorf("vendor_multipliers[%q]: must be > 0", k)
+				}
+			}
+			next.VendorMultipliers = tmp
+		case "disabled_items":
+			if err := json.Unmarshal(raw, &next.DisabledItems); err != nil {
+				return fmt.Errorf("disabled_items: %w", err)
+			}
+		}
+	}
+
+	c.config = next
+	return nil
+}

--- a/internal/marketbot/config_test.go
+++ b/internal/marketbot/config_test.go
@@ -1,0 +1,126 @@
+// config_test.go
+package marketbot
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestConfigDefaults(t *testing.T) {
+	cfg := defaultConfig()
+	if cfg.ListInterval != 30*time.Minute {
+		t.Errorf("ListInterval want 30m got %v", cfg.ListInterval)
+	}
+	if cfg.BuyInterval != 5*time.Minute {
+		t.Errorf("BuyInterval want 5m got %v", cfg.BuyInterval)
+	}
+	if cfg.ListingsPerGrade != 5 {
+		t.Errorf("ListingsPerGrade want 5 got %d", cfg.ListingsPerGrade)
+	}
+	if cfg.BuyThreshold != 1.05 {
+		t.Errorf("BuyThreshold want 1.05 got %f", cfg.BuyThreshold)
+	}
+	if cfg.MaxBuys != 50 {
+		t.Errorf("MaxBuys want 50 got %d", cfg.MaxBuys)
+	}
+	if !cfg.Enabled {
+		t.Error("Enabled should default to true")
+	}
+	want := [6]float64{1.0, 1.0, 1.25, 1.5, 1.75, 2.0}
+	if cfg.GradeMultipliers != want {
+		t.Errorf("GradeMultipliers want %v got %v", want, cfg.GradeMultipliers)
+	}
+}
+
+func TestConfigSnapshot(t *testing.T) {
+	c := &Config{}
+	c.config = defaultConfig()
+	snap := c.Snapshot()
+	snap.MaxBuys = 999
+	if c.config.MaxBuys == 999 {
+		t.Error("Snapshot should be a copy, not a reference")
+	}
+
+	// Test map isolation
+	snap2 := c.Snapshot()
+	snap2.RarityMultipliers["common"] = 99.0
+	if c.Snapshot().RarityMultipliers["common"] == 99.0 {
+		t.Error("Snapshot RarityMultipliers should be an independent copy")
+	}
+
+	// Test slice isolation
+	snap3 := c.Snapshot()
+	snap3.DisabledItems = append(snap3.DisabledItems, "extra")
+	if len(c.Snapshot().DisabledItems) != 0 {
+		t.Error("Snapshot DisabledItems should be an independent copy")
+	}
+}
+
+func TestConfigUpdate(t *testing.T) {
+	c := &Config{}
+	c.config = defaultConfig()
+
+	patch := map[string]json.RawMessage{}
+	b, _ := json.Marshal(25)
+	patch["max_buys"] = b
+	if err := c.Apply(patch); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if c.Snapshot().MaxBuys != 25 {
+		t.Error("MaxBuys not updated")
+	}
+}
+
+func TestConfigValidation(t *testing.T) {
+	c := &Config{}
+	c.config = defaultConfig()
+
+	patch := map[string]json.RawMessage{}
+	b, _ := json.Marshal(-1)
+	patch["max_buys"] = b
+	if err := c.Apply(patch); err == nil {
+		t.Error("expected error for negative MaxBuys")
+	}
+}
+
+func TestConfigMultiplierValidation(t *testing.T) {
+	c := &Config{}
+	c.config = defaultConfig()
+
+	// Zero grade multiplier should be rejected
+	patch := map[string]json.RawMessage{}
+	b, _ := json.Marshal([6]float64{1.0, 0.0, 1.25, 1.5, 1.75, 2.0})
+	patch["grade_multipliers"] = b
+	if err := c.Apply(patch); err == nil {
+		t.Error("expected error for zero grade multiplier")
+	}
+
+	// Negative rarity multiplier should be rejected
+	patch2 := map[string]json.RawMessage{}
+	b2, _ := json.Marshal(map[string]float64{"common": -1.0})
+	patch2["rarity_multipliers"] = b2
+	if err := c.Apply(patch2); err == nil {
+		t.Error("expected error for negative rarity multiplier")
+	}
+}
+
+func TestConfigValidationAtomicity(t *testing.T) {
+	c := &Config{}
+	c.config = defaultConfig()
+
+	patch := map[string]json.RawMessage{}
+	validVal, _ := json.Marshal(25)
+	patch["max_buys"] = validVal
+	invalidVal, _ := json.Marshal(-1)
+	patch["buy_threshold"] = invalidVal // invalid: negative
+
+	err := c.Apply(patch)
+	if err == nil {
+		t.Error("expected error for invalid buy_threshold")
+	}
+	// max_buys should NOT have been updated (atomicity)
+	if c.Snapshot().MaxBuys != 50 {
+		t.Errorf("Apply should be atomic: MaxBuys should still be 50, got %d", c.Snapshot().MaxBuys)
+	}
+}

--- a/internal/marketbot/exchange.go
+++ b/internal/marketbot/exchange.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -94,6 +95,7 @@ type Exchange struct {
 	ownerID       int64 // actor ID of the market bot (Revy)
 	exchangeID    int64
 	accessPointID int64
+	mapMu         sync.RWMutex // protects prices and catalogMap
 	prices        map[string]int64
 	marketPrices  map[string]marketPrice // real market prices from dune_exchange_get_item_price_stats
 	categories    map[string]categoryEntry
@@ -231,16 +233,17 @@ func (e *Exchange) Init(ctx context.Context, catalog []CatalogItem) error {
 		return fmt.Errorf("bot user: %w", err)
 	}
 
-	// Seed list prices.
+	newCatalog := make(map[string]CatalogItem, len(catalog))
+	for _, item := range catalog {
+		newCatalog[item.TemplateID] = item
+	}
+
+	e.mapMu.Lock()
 	for _, item := range catalog {
 		e.prices[item.TemplateID] = item.ListPrice
 	}
-
-	// Build catalog map for buyable checks.
-	e.catalogMap = make(map[string]CatalogItem, len(catalog))
-	for _, item := range catalog {
-		e.catalogMap[item.TemplateID] = item
-	}
+	e.catalogMap = newCatalog
+	e.mapMu.Unlock()
 
 	// Start position counter after existing items.
 	_ = e.db.QueryRow(ctx,
@@ -833,7 +836,9 @@ func (e *Exchange) updatePrices(ctx context.Context, catalog []CatalogItem, snap
 			}
 		}
 
+		e.mapMu.Lock()
 		e.prices[tmpl] = adjusted
+		e.mapMu.Unlock()
 	}
 }
 

--- a/internal/marketbot/exchange.go
+++ b/internal/marketbot/exchange.go
@@ -1,0 +1,902 @@
+package marketbot
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "modernc.org/sqlite"
+)
+
+const orderExpirySecs = int64(24 * 3600)
+
+// statusSnap is returned by GET /status.
+type statusSnap struct {
+	Uptime       string `json:"uptime"`
+	LastBuyTick  string `json:"last_buy_tick"`
+	LastListTick string `json:"last_list_tick"`
+	ListingCount int64  `json:"listing_count"`
+	Balance      int64  `json:"balance"`
+	ErrorCount   int64  `json:"error_count"`
+}
+
+func (e *Exchange) statusSnapshot(start time.Time) statusSnap {
+	lastBuy := "never"
+	if ns := e.lastBuyNano.Load(); ns > 0 {
+		lastBuy = time.Unix(0, ns).UTC().Format(time.RFC3339)
+	}
+	lastList := "never"
+	if ns := e.lastListNano.Load(); ns > 0 {
+		lastList = time.Unix(0, ns).UTC().Format(time.RFC3339)
+	}
+	return statusSnap{
+		Uptime:       time.Since(start).Round(time.Second).String(),
+		LastBuyTick:  lastBuy,
+		LastListTick: lastList,
+		ListingCount: e.listingCount.Load(),
+		Balance:      e.solariBalance.Load(),
+		ErrorCount:   e.errCount.Load(),
+	}
+}
+
+// gradeKey groups listings by template + quality grade for per-grade quota tracking.
+type gradeKey struct {
+	tmpl  string
+	grade int64
+}
+
+// applicableGrades returns which quality levels to list an item at.
+// Items whose schematic drops from overland testing stations (ecolabs) are gradeable 0–5
+// (or from MinQualityLevel–5 for augments that only drop at higher grades).
+// Stackables and items without an ecolab schematic get grade 0 only.
+func applicableGrades(item CatalogItem) []int64 {
+	if item.StackMax > 1 || !item.IsGradeable {
+		return []int64{0}
+	}
+	min := item.MinQualityLevel
+	if min < 0 || min > 5 {
+		min = 0
+	}
+	grades := make([]int64, 0, 6-min)
+	for g := min; g <= 5; g++ {
+		grades = append(grades, int64(g))
+	}
+	return grades
+}
+
+type categoryEntry struct {
+	mask  int32
+	depth int16
+}
+
+type listingInfo struct {
+	orderID   int64
+	itemID    int64
+	stackSize int64
+	price     int64
+	grade     int64
+}
+
+type Exchange struct {
+	db            *pgxpool.Pool
+	cache         *sql.DB // local SQLite category cache
+	cfg           *Config
+	segIdx        [4][]string
+	botInvID      int64
+	ownerID       int64 // actor ID of the market bot (Revy)
+	exchangeID    int64
+	accessPointID int64
+	prices        map[string]int64
+	marketPrices  map[string]marketPrice // real market prices from dune_exchange_get_item_price_stats
+	categories    map[string]categoryEntry
+	catalogMap    map[string]CatalogItem // template_id → catalog entry (for buyable check)
+	gameEpochUnix int64                  // unix timestamp of the game server's time epoch; 0 = unknown
+	nextPos       int64                  // position_index counter for item inserts
+
+	// atomic counters — updated by BuyTick/ListTick, read by statusSnapshot.
+	lastBuyNano   atomic.Int64 // UnixNano of last buy tick; 0 = never
+	lastListNano  atomic.Int64 // UnixNano of last list tick; 0 = never
+	listingCount  atomic.Int64 // current bot listing count
+	errCount      atomic.Int64 // cumulative errors since process start
+	solariBalance atomic.Int64 // Solari balance as of last list tick
+}
+
+// marketPrice holds real market stats from dune_exchange_get_item_price_stats.
+type marketPrice struct {
+	minimum int64
+	average int64
+}
+
+func ensureCachePath(cachePath string) (string, error) {
+	if strings.TrimSpace(cachePath) == "" {
+		return "", fmt.Errorf("cache path is empty")
+	}
+	cleanPath := filepath.Clean(cachePath)
+	dir := filepath.Dir(cleanPath)
+	if dir == "." || dir == "" {
+		return cleanPath, nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create cache directory %s: %w", dir, err)
+	}
+	return cleanPath, nil
+}
+
+func NewExchange(db *pgxpool.Pool, cachePath string, catalog []CatalogItem, cfg *Config) (*Exchange, error) {
+	cachePath, err := ensureCachePath(cachePath)
+	if err != nil {
+		return nil, fmt.Errorf("prepare category cache path: %w", err)
+	}
+	cache, err := sql.Open("sqlite", cachePath)
+	if err != nil {
+		return nil, fmt.Errorf("open category cache %s: %w", cachePath, err)
+	}
+	if _, err := cache.Exec(`
+		CREATE TABLE IF NOT EXISTS categories (
+			template_id    TEXT     PRIMARY KEY,
+			category_mask  INTEGER  NOT NULL,
+			category_depth INTEGER  NOT NULL
+		)`); err != nil {
+		_ = cache.Close()
+		return nil, fmt.Errorf("init category cache: %w", err)
+	}
+	if _, err := cache.Exec(`
+		CREATE TABLE IF NOT EXISTS metadata (
+			key   TEXT    PRIMARY KEY,
+			value INTEGER NOT NULL
+		)`); err != nil {
+		_ = cache.Close()
+		return nil, fmt.Errorf("init metadata cache: %w", err)
+	}
+
+	ex := &Exchange{
+		db:         db,
+		cache:      cache,
+		cfg:        cfg,
+		segIdx:     buildSegmentIndex(catalog),
+		prices:     make(map[string]int64),
+		categories: make(map[string]categoryEntry),
+	}
+	if err := cache.QueryRow(`SELECT value FROM metadata WHERE key = 'game_epoch_unix'`).Scan(&ex.gameEpochUnix); err == nil {
+		log.Printf("loaded game epoch from cache: unix %d (game time now: %d)", ex.gameEpochUnix, ex.gameNow())
+	}
+	return ex, nil
+}
+
+func (e *Exchange) learnGameEpoch(ctx context.Context) {
+	var ref int64
+	err := e.db.QueryRow(ctx, `
+		SELECT expiration_time FROM dune.dune_exchange_orders
+		WHERE is_npc_order = FALSE
+		  AND expiration_time IS NOT NULL
+		  AND expiration_time < 1000000000
+		ORDER BY expiration_time DESC LIMIT 1`).Scan(&ref)
+	if err != nil || ref == 0 {
+		return
+	}
+	gameNow := ref - int64(24*3600)
+	epoch := time.Now().Unix() - gameNow
+	if e.gameEpochUnix == epoch {
+		return
+	}
+	e.gameEpochUnix = epoch
+	_, _ = e.cache.Exec(`INSERT INTO metadata (key, value) VALUES ('game_epoch_unix', ?)
+		ON CONFLICT (key) DO UPDATE SET value = excluded.value`, epoch)
+	log.Printf("game epoch learned: unix %d (current game time: %d)", epoch, gameNow)
+}
+
+func (e *Exchange) gameNow() int64 {
+	if e.gameEpochUnix == 0 {
+		return 0
+	}
+	return time.Now().Unix() - e.gameEpochUnix
+}
+
+func (e *Exchange) Init(ctx context.Context, catalog []CatalogItem) error {
+	err := e.db.QueryRow(ctx,
+		`SELECT exchange_id FROM dune.dune_exchange_orders WHERE is_npc_order = FALSE LIMIT 1`).Scan(&e.exchangeID)
+	if err != nil {
+		// No player orders yet — fall back to first non-Global exchange
+		if err2 := e.db.QueryRow(ctx,
+			`SELECT id FROM dune.dune_exchanges WHERE exchange_name != 'Global' ORDER BY id LIMIT 1`).Scan(&e.exchangeID); err2 != nil {
+			return fmt.Errorf("detect exchange id: %w", err2)
+		}
+	}
+	log.Printf("exchange id: %d", e.exchangeID)
+
+	if err := e.db.QueryRow(ctx,
+		`SELECT DISTINCT access_point_id FROM dune.dune_exchange_orders WHERE exchange_id = $1 LIMIT 1`,
+		e.exchangeID).Scan(&e.accessPointID); err != nil {
+		e.accessPointID = 1
+		log.Printf("access point: no existing orders, defaulting to 1")
+	} else {
+		log.Printf("access point id: %d", e.accessPointID)
+	}
+
+	if err := e.db.QueryRow(ctx,
+		`SELECT dune.get_exchange_inventory_id($1)`, e.exchangeID).Scan(&e.botInvID); err != nil {
+		return fmt.Errorf("exchange inventory: %w", err)
+	}
+	log.Printf("exchange inventory id: %d", e.botInvID)
+
+	if err := e.initBotUser(ctx); err != nil {
+		return fmt.Errorf("bot user: %w", err)
+	}
+
+	// Seed list prices.
+	for _, item := range catalog {
+		e.prices[item.TemplateID] = item.ListPrice
+	}
+
+	// Build catalog map for buyable checks.
+	e.catalogMap = make(map[string]CatalogItem, len(catalog))
+	for _, item := range catalog {
+		e.catalogMap[item.TemplateID] = item
+	}
+
+	// Start position counter after existing items.
+	_ = e.db.QueryRow(ctx,
+		`SELECT COALESCE(MAX(position_index), -1) + 1 FROM dune.items WHERE inventory_id = $1`,
+		e.botInvID).Scan(&e.nextPos)
+
+	e.learnGameEpoch(ctx)
+	e.refreshCategoryCache(ctx)
+
+	if err := e.poisonCategoryHash(ctx); err != nil {
+		log.Printf("warn: category hash poison: %v", err)
+	}
+	return nil
+}
+
+func (e *Exchange) initBotUser(ctx context.Context) error {
+	err := e.db.QueryRow(ctx,
+		`SELECT id FROM dune.actors WHERE class = 'Revy' LIMIT 1`).Scan(&e.ownerID)
+	if err == pgx.ErrNoRows {
+		// Use a valid world partition so the bot actor satisfies the actors FK.
+		var partitionID int64
+		partitionArg := any(nil)
+		partitionErr := e.db.QueryRow(ctx,
+			`SELECT partition_id FROM dune.world_partition ORDER BY partition_id LIMIT 1`).Scan(&partitionID)
+		if partitionErr == nil {
+			partitionArg = partitionID
+		} else if partitionErr != pgx.ErrNoRows {
+			return fmt.Errorf("bot actor partition: %w", partitionErr)
+		}
+		err = e.db.QueryRow(ctx,
+			`INSERT INTO dune.actors (class, serial, gas_attributes, properties, dimension_index, partition_id)
+			 VALUES ('Revy', 0, '{}', '{}', 0, $1) RETURNING id`, partitionArg).Scan(&e.ownerID)
+	}
+	if err != nil {
+		return fmt.Errorf("bot actor: %w", err)
+	}
+	log.Printf("bot actor id: %d (Revy)", e.ownerID)
+
+	var userID int64
+	if err := e.db.QueryRow(ctx,
+		`SELECT dune.dune_exchange_get_user_id($1)`, e.ownerID).Scan(&userID); err != nil {
+		return err
+	}
+
+	// Check current balance before seeding — dune_exchange_modify_user_solari_balance
+	// adds a delta, not sets an absolute. Only seed if below a reasonable floor.
+	const seedFloor int64 = 1_000_000_000_000  // 1T
+	const seedAmount int64 = 9_000_000_000_000 // 9T
+	var currentBalance int64
+	_ = e.db.QueryRow(ctx,
+		`SELECT dune.dune_exchange_retrieve_solari_balance($1)`, e.ownerID).Scan(&currentBalance)
+	if currentBalance < seedFloor {
+		_, err = e.db.Exec(ctx,
+			`SELECT dune.dune_exchange_modify_user_solari_balance($1, $2)`,
+			e.ownerID, seedAmount-currentBalance) // top up to 9T
+		if err != nil {
+			return err
+		}
+		log.Printf("seeded bot balance: %d → %d", currentBalance, seedAmount)
+	} else {
+		log.Printf("bot balance OK: %d (floor %d)", currentBalance, seedFloor)
+	}
+	return nil
+}
+
+func (e *Exchange) poisonCategoryHash(ctx context.Context) error {
+	_, err := e.db.Exec(ctx,
+		`INSERT INTO dune.dune_exchange_categories_hash (id, hash) VALUES (1, 0)
+		 ON CONFLICT (id) DO UPDATE SET hash = 0`)
+	return err
+}
+
+func (e *Exchange) refreshCategoryCache(ctx context.Context) {
+	rows, err := e.cache.Query(
+		`SELECT template_id, category_mask, category_depth FROM categories`)
+	if err != nil {
+		log.Printf("warn: load category cache: %v", err)
+	} else {
+		for rows.Next() {
+			var tmpl string
+			var mask int32
+			var depth int16
+			if err := rows.Scan(&tmpl, &mask, &depth); err != nil {
+				continue
+			}
+			e.categories[strings.ToLower(tmpl)] = categoryEntry{mask: mask, depth: depth}
+		}
+		_ = rows.Close()
+	}
+
+	liveRows, err := e.db.Query(ctx, `
+		SELECT DISTINCT template_id, category_mask, category_depth
+		FROM dune.dune_exchange_orders
+		WHERE category_mask != 0`)
+	if err != nil {
+		log.Printf("warn: live category scan: %v", err)
+		return
+	}
+	defer liveRows.Close()
+
+	type entry struct {
+		tmpl  string
+		mask  int32
+		depth int16
+	}
+	var toWrite []entry
+	for liveRows.Next() {
+		var tmpl string
+		var mask int32
+		var depth int16
+		if err := liveRows.Scan(&tmpl, &mask, &depth); err != nil {
+			continue
+		}
+		key := strings.ToLower(tmpl)
+		if _, known := e.categories[key]; !known {
+			e.categories[key] = categoryEntry{mask: mask, depth: depth}
+			toWrite = append(toWrite, entry{tmpl, mask, depth})
+		}
+	}
+
+	for _, en := range toWrite {
+		if _, err := e.cache.Exec(`
+			INSERT INTO categories (template_id, category_mask, category_depth)
+			VALUES (?, ?, ?)
+			ON CONFLICT (template_id) DO UPDATE
+			  SET category_mask  = excluded.category_mask,
+			      category_depth = excluded.category_depth`,
+			en.tmpl, en.mask, en.depth); err != nil {
+			log.Printf("warn: persist category %s: %v", en.tmpl, err)
+		}
+	}
+
+	if len(toWrite) > 0 {
+		log.Printf("category cache: +%d new (total %d)", len(toWrite), len(e.categories))
+	}
+}
+
+func (e *Exchange) categoryFor(item CatalogItem) (mask int32, depth int16) {
+	if item.IsSchematic && item.Category != "" {
+		if m, d, ok := UniqueSchematicsMask(item.Category); ok {
+			return m, d
+		}
+		// Schematic whose category has no unique-schematics section — fall through.
+		return CategoryMask(item.Category, e.segIdx)
+	}
+	// Catalog items always use a freshly computed mask so stale cache values
+	// can never poison category filters.
+	if item.Category != "" {
+		return CategoryMask(item.Category, e.segIdx)
+	}
+	if c, ok := e.categories[strings.ToLower(item.TemplateID)]; ok {
+		return c.mask, c.depth
+	}
+	return 0, 0
+}
+
+func (e *Exchange) buyPlayerListings(ctx context.Context, orderExpiry int64, snap configValues) {
+	if snap.BuyThreshold <= 0 {
+		return
+	}
+	if orderExpiry <= 0 {
+		orderExpiry = 999_999_999
+	}
+
+	// Use actual current stack_size from items so partial fills pay the right amount.
+	// quality_level is needed to compare the player's grade-adjusted price against the
+	// bot's grade-adjusted reference price rather than the raw base price.
+	rows, err := e.db.Query(ctx, `
+		SELECT o.id, o.template_id, o.item_price, o.item_id, o.owner_id,
+		       COALESCE(i.stack_size, s.initial_stack_size) AS actual_stack,
+		       COALESCE(o.quality_level, 0) AS quality_level
+		FROM dune.dune_exchange_orders o
+		JOIN dune.dune_exchange_sell_orders s ON s.order_id = o.id
+		LEFT JOIN dune.items i ON i.id = o.item_id
+		WHERE o.is_npc_order = FALSE AND o.exchange_id = $1
+		LIMIT $2`, e.exchangeID, snap.MaxBuys*10)
+	if err != nil {
+		log.Printf("buy: query: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	purchased, skippedPrice, skippedUnknown, errs := 0, 0, 0, 0
+
+	for rows.Next() {
+		if purchased >= snap.MaxBuys {
+			break
+		}
+
+		var orderID, price, itemID, sellerActorID, stackSize, grade int64
+		var tmpl string
+		if err := rows.Scan(&orderID, &tmpl, &price, &itemID, &sellerActorID, &stackSize, &grade); err != nil {
+			errs++
+			continue
+		}
+
+		botPrice, known := e.prices[tmpl]
+		if !known || botPrice <= 0 {
+			skippedUnknown++
+			continue
+		}
+
+		// Skip items the operator has marked as non-buyable.
+		if item, ok := e.catalogMap[tmpl]; ok && !item.Buyable {
+			skippedUnknown++
+			continue
+		}
+
+		refPrice := gradedPrice(botPrice, grade, snap.GradeMultipliers)
+		if price > int64(float64(refPrice)*snap.BuyThreshold) {
+			log.Printf("buy: skip %s price=%d ref=%d(grade%d) threshold=%.2f", tmpl, price, refPrice, grade, snap.BuyThreshold)
+			skippedPrice++
+			continue
+		}
+
+		totalCost := price * stackSize
+
+		tx, err := e.db.Begin(ctx)
+		if err != nil {
+			errs++
+			continue
+		}
+
+		// Create a payment log entry for the seller (item_id omitted → NULL).
+		// completion_type=4 + item_id=NULL is what the game engine uses for the
+		// seller side of a fulfilled sale, causing the client to show "Take Solari"
+		// in the Completed tab and fire the "X SOLARIS CLAIMED" toast on collection.
+		var logOrderID int64
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO dune.dune_exchange_orders
+			  (exchange_id, access_point_id, owner_id, template_id, expiration_time,
+			   durability_cur, durability_max, item_price, category_mask, category_depth, is_npc_order)
+			VALUES ($1,$2,$3,$4,$5,1.0,1.0,$6,0,0,FALSE) RETURNING id`,
+			e.exchangeID, e.accessPointID, sellerActorID, tmpl, orderExpiry, price,
+		).Scan(&logOrderID); err != nil {
+			log.Printf("buy: log order for %s: %v", tmpl, err)
+			_ = tx.Rollback(ctx)
+			errs++
+			continue
+		}
+
+		ok := true
+		for _, q := range []struct {
+			sql  string
+			args []any
+		}{
+			// Fulfilled-order record: source_order_id=NULL (original listing will be
+			// deleted), original_order_id kept for telemetry linkage (no FK constraint).
+			{`INSERT INTO dune.dune_exchange_fulfilled_orders
+			    (order_id, source_order_id, completion_type, stack_size, original_order_id)
+			    VALUES ($1, NULL, 4, $2, $3)`, []any{logOrderID, stackSize, orderID}},
+			// Debit bot's exchange balance for the purchase.
+			{`UPDATE dune.dune_exchange_users
+			    SET solari_balance = solari_balance - $1
+			    WHERE owner_id = $2`, []any{totalCost, e.ownerID}},
+			// Remove the original sell listing.
+			{`DELETE FROM dune.dune_exchange_sell_orders WHERE order_id = $1`, []any{orderID}},
+			{`DELETE FROM dune.dune_exchange_orders WHERE id = $1`, []any{orderID}},
+		} {
+			if _, err := tx.Exec(ctx, q.sql, q.args...); err != nil {
+				log.Printf("buy: %s: %v", tmpl, err)
+				ok = false
+				break
+			}
+		}
+		if ok && itemID > 0 {
+			if _, err := tx.Exec(ctx, `DELETE FROM dune.items WHERE id = $1`, itemID); err != nil {
+				log.Printf("buy: delete item %d: %v", itemID, err)
+				ok = false
+			}
+		}
+		if !ok {
+			_ = tx.Rollback(ctx)
+			errs++
+			continue
+		}
+		if err := tx.Commit(ctx); err != nil {
+			errs++
+			continue
+		}
+		purchased++
+	}
+
+	if errs > 0 {
+		e.errCount.Add(int64(errs))
+	}
+	if purchased+errs+skippedPrice+skippedUnknown > 0 {
+		log.Printf("buy: %d purchased, %d skipped-price, %d skipped-unknown, %d errors",
+			purchased, skippedPrice, skippedUnknown, errs)
+	}
+}
+
+// pendingListing holds the data needed to batch-insert a new bot listing.
+type pendingListing struct {
+	item      CatalogItem
+	basePrice int64
+	stackMax  int64
+	expiry    int64
+	grade     int64
+}
+
+// createListingsBatch inserts up to batchSize listings per transaction.
+// Returns (created, errors).
+func (e *Exchange) createListingsBatch(ctx context.Context, listings []pendingListing, snap configValues) (int, int) {
+	const batchSize = 100
+	created, errs := 0, 0
+	for i := 0; i < len(listings); i += batchSize {
+		end := i + batchSize
+		if end > len(listings) {
+			end = len(listings)
+		}
+		batch := listings[i:end]
+
+		tx, err := e.db.Begin(ctx)
+		if err != nil {
+			errs += len(batch)
+			continue
+		}
+		ok := true
+		for _, pl := range batch {
+			catMask, catDepth := e.categoryFor(pl.item)
+			qualityLevel := pl.grade
+			listPrice := gradeFloor(pl.item, pl.grade, snap)
+			if pl.item.MaterialCost <= 0 {
+				listPrice = gradedPrice(pl.basePrice, pl.grade, snap.GradeMultipliers)
+			}
+			var itemID int64
+			if err := tx.QueryRow(ctx, `
+				INSERT INTO dune.items (inventory_id, stack_size, position_index, template_id, quality_level, stats)
+				VALUES ($1, $2, $3, $4, $5, '{}') RETURNING id`,
+				e.botInvID, pl.stackMax, e.nextPos, pl.item.TemplateID, qualityLevel).Scan(&itemID); err != nil {
+				log.Printf("batch insert item %s grade %d: %v", pl.item.TemplateID, pl.grade, err)
+				ok = false
+				errs++
+				break
+			}
+			e.nextPos++
+			var orderID int64
+			if err := tx.QueryRow(ctx, `
+				INSERT INTO dune.dune_exchange_orders
+				  (exchange_id, access_point_id, owner_id, is_npc_order, expiration_time,
+				   template_id, durability_cur, durability_max, category_mask, category_depth,
+				   item_price, quality_level, item_id)
+				VALUES ($1,$2,$3,TRUE,$4,$5,$6,$7,$8,$9,$10,$11,$12) RETURNING id`,
+				e.exchangeID, e.accessPointID, e.ownerID, pl.expiry,
+				pl.item.TemplateID, float32(1.0), float32(1.0),
+				catMask, catDepth, listPrice, qualityLevel, itemID).Scan(&orderID); err != nil {
+				log.Printf("batch insert order %s grade %d: %v", pl.item.TemplateID, pl.grade, err)
+				ok = false
+				errs++
+				break
+			}
+			if _, err := tx.Exec(ctx, `
+				INSERT INTO dune.dune_exchange_sell_orders (order_id, initial_stack_size, wear_normalized_price)
+				VALUES ($1, $2, $3)`,
+				orderID, pl.stackMax, listPrice); err != nil {
+				log.Printf("batch insert sell order %s grade %d: %v", pl.item.TemplateID, pl.grade, err)
+				ok = false
+				errs++
+				break
+			}
+			created++
+		}
+		if ok {
+			_ = tx.Commit(ctx)
+		} else {
+			_ = tx.Rollback(ctx)
+		}
+	}
+	return created, errs
+}
+
+// BuyTick runs the buy-side operations: learn game epoch and purchase player listings.
+func (e *Exchange) BuyTick(ctx context.Context) {
+	e.learnGameEpoch(ctx)
+
+	snap := e.cfg.Snapshot()
+
+	gameNow := e.gameNow()
+	var orderExpiry int64
+	if gameNow > 0 {
+		orderExpiry = gameNow + orderExpirySecs
+	} else {
+		orderExpiry = 999_999_999
+	}
+
+	e.buyPlayerListings(ctx, orderExpiry, snap)
+	e.lastBuyNano.Store(time.Now().UnixNano())
+}
+
+// ListTick runs the listing/pruning operations: refresh caches, update prices,
+// prune stale listings, top up depleted stacks, and create new listings.
+func (e *Exchange) ListTick(ctx context.Context, catalog []CatalogItem) {
+	snap := e.cfg.Snapshot()
+
+	e.learnGameEpoch(ctx)
+	e.refreshCategoryCache(ctx)
+	e.fetchMarketPrices(ctx, catalog) // fetch real market prices via proc
+	e.updatePrices(ctx, catalog, snap)
+	e.expireAndPurgeOrders(ctx) // use server procs for expiration
+
+	gameNow := e.gameNow()
+	var orderExpiry int64
+	if gameNow > 0 {
+		orderExpiry = gameNow + orderExpirySecs
+	} else {
+		orderExpiry = 999_999_999
+	}
+
+	// Load all current bot listings grouped by (template, grade).
+	rows, err := e.db.Query(ctx, `
+		SELECT o.id, o.template_id, o.item_id, o.item_price, i.stack_size, o.quality_level
+		FROM dune.dune_exchange_orders o
+		JOIN dune.items i ON i.id = o.item_id
+		WHERE o.owner_id = $1 AND o.is_npc_order = TRUE`, e.ownerID)
+	if err != nil {
+		log.Printf("load listings: %v", err)
+		return
+	}
+	current := make(map[gradeKey][]listingInfo)
+	for rows.Next() {
+		var orderID, itemID, price, stack, grade int64
+		var tmpl string
+		if err := rows.Scan(&orderID, &tmpl, &itemID, &price, &stack, &grade); err != nil {
+			continue
+		}
+		k := gradeKey{tmpl, grade}
+		current[k] = append(current[k], listingInfo{orderID, itemID, stack, price, grade})
+	}
+	rows.Close()
+
+	// Slices accumulated across the full catalog loop, flushed in bulk at the end.
+	var staleOrderIDs, staleItemIDs []int64
+	type topUp struct{ itemID, stackMax int64 }
+	var topUps []topUp
+	var pending []pendingListing
+
+	created, topped, pruned, errs := 0, 0, 0, 0
+
+	for _, item := range catalog {
+		stackMax := item.StackMax
+		if stackMax <= 0 {
+			stackMax = 1
+		}
+		basePrice := e.prices[item.TemplateID]
+		if basePrice <= 0 {
+			basePrice = item.ListPrice
+		}
+		if basePrice <= 0 {
+			continue
+		}
+
+		for _, grade := range applicableGrades(item) {
+			price := gradeFloor(item, grade, snap)
+			if item.MaterialCost <= 0 {
+				price = gradedPrice(basePrice, grade, snap.GradeMultipliers)
+			}
+			key := gradeKey{item.TemplateID, grade}
+			listings := current[key]
+
+			// Collect stale listings (wrong price) for bulk delete.
+			var valid []listingInfo
+			for _, l := range listings {
+				if l.price != price {
+					staleOrderIDs = append(staleOrderIDs, l.orderID)
+					staleItemIDs = append(staleItemIDs, l.itemID)
+					pruned++
+				} else {
+					valid = append(valid, l)
+				}
+			}
+
+			// Collect depleted stacks for bulk update.
+			for _, l := range valid {
+				if l.stackSize < stackMax {
+					topUps = append(topUps, topUp{l.itemID, stackMax})
+					topped++
+				}
+			}
+
+			// Accumulate listings to create to reach the configured quota per grade.
+			for i := len(valid); i < snap.ListingsPerGrade; i++ {
+				pending = append(pending, pendingListing{
+					item:      item,
+					basePrice: basePrice,
+					stackMax:  stackMax,
+					expiry:    orderExpiry,
+					grade:     grade,
+				})
+			}
+		}
+	}
+
+	// Bulk delete stale orders and their items.
+	if len(staleOrderIDs) > 0 {
+		_, _ = e.db.Exec(ctx, `DELETE FROM dune.dune_exchange_orders WHERE id = ANY($1)`, staleOrderIDs)
+		_, _ = e.db.Exec(ctx, `DELETE FROM dune.items WHERE id = ANY($1)`, staleItemIDs)
+	}
+
+	// Bulk update depleted stacks.
+	if len(topUps) > 0 {
+		ids := make([]int64, len(topUps))
+		sizes := make([]int64, len(topUps))
+		for i, t := range topUps {
+			ids[i] = t.itemID
+			sizes[i] = t.stackMax
+		}
+		_, _ = e.db.Exec(ctx, `
+			UPDATE dune.items SET stack_size = u.s
+			FROM unnest($1::bigint[], $2::bigint[]) AS u(id, s)
+			WHERE dune.items.id = u.id`, ids, sizes)
+	}
+
+	// Batch insert new listings.
+	if len(pending) > 0 {
+		c, e2 := e.createListingsBatch(ctx, pending, snap)
+		created += c
+		errs += e2
+	}
+
+	log.Printf("list-tick: %d created, %d topped up, %d pruned, %d errors", created, topped, pruned, errs)
+
+	e.lastListNano.Store(time.Now().UnixNano())
+	if errs > 0 {
+		e.errCount.Add(int64(errs))
+	}
+
+	// Refresh balance and listing count for /status endpoint.
+	var balance, count int64
+	_ = e.db.QueryRow(ctx, `SELECT dune.dune_exchange_retrieve_solari_balance($1)`, e.ownerID).Scan(&balance)
+	_ = e.db.QueryRow(ctx, `SELECT COUNT(*) FROM dune.dune_exchange_orders WHERE owner_id = $1 AND is_npc_order = TRUE`, e.ownerID).Scan(&count)
+	e.solariBalance.Store(balance)
+	e.listingCount.Store(count)
+}
+
+// Tick runs both BuyTick and ListTick. Used for the initial run on startup.
+func (e *Exchange) Tick(ctx context.Context, catalog []CatalogItem) {
+	e.BuyTick(ctx)
+	e.ListTick(ctx, catalog)
+}
+
+func (e *Exchange) updatePrices(ctx context.Context, catalog []CatalogItem, snap configValues) {
+	catalogMap := make(map[string]CatalogItem, len(catalog))
+	for _, item := range catalog {
+		catalogMap[item.TemplateID] = item
+	}
+
+	rows, err := e.db.Query(ctx, `
+		SELECT o.template_id,
+		       COALESCE(SUM(f.stack_size), 0)         AS sold,
+		       COALESCE(MAX(s.initial_stack_size), 0) AS listed
+		FROM dune.dune_exchange_orders o
+		JOIN dune.dune_exchange_sell_orders s ON s.order_id = o.id
+		LEFT JOIN dune.dune_exchange_fulfilled_orders f ON f.order_id = o.id
+		WHERE o.owner_id = $1 AND o.is_npc_order = TRUE
+		GROUP BY o.template_id`, e.ownerID)
+	if err != nil {
+		log.Printf("price stats: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var tmpl string
+		var sold, listed int64
+		if err := rows.Scan(&tmpl, &sold, &listed); err != nil {
+			continue
+		}
+		item, ok := catalogMap[tmpl]
+		if !ok {
+			continue
+		}
+		current := e.prices[tmpl]
+		if current <= 0 {
+			current = item.ListPrice
+		}
+		var frac float64
+		if listed > 0 {
+			frac = float64(sold) / float64(listed)
+		}
+		adjusted := adjustPrice(item, current, frac, snap)
+
+		// Factor in real market prices: if players are undercutting us significantly,
+		// consider lowering our price toward the market minimum.
+		if mp, ok := e.marketPrices[tmpl]; ok && mp.minimum > 0 {
+			// If market min is below our adjusted price by >10%, move toward it.
+			if mp.minimum < int64(float64(adjusted)*0.9) {
+				// Don't go below our floor, but trend toward market.
+				adjusted = (adjusted + mp.minimum) / 2
+			}
+		}
+
+		e.prices[tmpl] = adjusted
+	}
+}
+
+// fetchMarketPrices uses dune_exchange_get_item_price_stats to get real market
+// prices (minimum and weighted average) across ALL active listings, not just bot's.
+func (e *Exchange) fetchMarketPrices(ctx context.Context, catalog []CatalogItem) {
+	if len(catalog) == 0 {
+		return
+	}
+
+	// Collect all template IDs.
+	templateIDs := make([]string, 0, len(catalog))
+	for _, item := range catalog {
+		templateIDs = append(templateIDs, item.TemplateID)
+	}
+
+	rows, err := e.db.Query(ctx,
+		`SELECT * FROM dune.dune_exchange_get_item_price_stats($1)`, templateIDs)
+	if err != nil {
+		log.Printf("market price stats: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	if e.marketPrices == nil {
+		e.marketPrices = make(map[string]marketPrice)
+	}
+
+	count := 0
+	for rows.Next() {
+		var tmpl string
+		var minPrice, avgPrice int64
+		if err := rows.Scan(&tmpl, &minPrice, &avgPrice); err != nil {
+			continue
+		}
+		e.marketPrices[tmpl] = marketPrice{minimum: minPrice, average: avgPrice}
+		count++
+	}
+	log.Printf("market prices: fetched %d items from real market", count)
+}
+
+// expireAndPurgeOrders uses server procs to expire and purge old orders.
+func (e *Exchange) expireAndPurgeOrders(ctx context.Context) {
+	now := e.gameNow()
+	if now <= 0 {
+		return // game epoch not learned yet
+	}
+
+	// Expire old sell orders. completion_type=2 = expired.
+	// purge_time = now + 7 days (when fulfilled orders get deleted).
+	purgeTime := now + 7*24*3600
+	_, err := e.db.Exec(ctx,
+		`SELECT * FROM dune.dune_exchange_expire_orders($1, $2, $3, 2)`,
+		e.exchangeID, now, purgeTime)
+	if err != nil {
+		log.Printf("expire orders: %v", err)
+	}
+
+	// Purge completed/expired orders past their purge time.
+	_, err = e.db.Exec(ctx,
+		`SELECT * FROM dune.dune_exchange_purge_completed_orders($1, $2)`,
+		e.exchangeID, now)
+	if err != nil {
+		log.Printf("purge orders: %v", err)
+	}
+}

--- a/internal/marketbot/exchange_test.go
+++ b/internal/marketbot/exchange_test.go
@@ -1,0 +1,29 @@
+package marketbot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureCachePathCreatesParentDirectories(t *testing.T) {
+	root := t.TempDir()
+	cachePath := filepath.Join(root, "nested", "cache", "market-bot.db")
+
+	resolved, err := ensureCachePath(cachePath)
+	if err != nil {
+		t.Fatalf("ensureCachePath returned error: %v", err)
+	}
+	if resolved != cachePath {
+		t.Fatalf("ensureCachePath returned %q, want %q", resolved, cachePath)
+	}
+	if _, err := os.Stat(filepath.Dir(cachePath)); err != nil {
+		t.Fatalf("expected cache directory to exist: %v", err)
+	}
+}
+
+func TestEnsureCachePathRejectsEmptyPath(t *testing.T) {
+	if _, err := ensureCachePath("   "); err == nil {
+		t.Fatalf("ensureCachePath should reject empty path")
+	}
+}

--- a/internal/marketbot/logsink.go
+++ b/internal/marketbot/logsink.go
@@ -1,0 +1,91 @@
+package marketbot
+
+import (
+	"io"
+	"log"
+	"sync"
+)
+
+const ringCapacity = 1000
+
+// LogSink is a bounded ring buffer that captures log lines from the embedded
+// bot and fan-outs to active WebSocket subscribers. It implements io.Writer so
+// it can be passed to log.New as the output destination.
+type LogSink struct {
+	mu   sync.Mutex
+	ring []string
+	pos  int // next write position (wraps)
+	full bool
+
+	subsMu sync.RWMutex
+	subs   map[chan string]struct{}
+}
+
+// NewLogSink returns an initialised LogSink.
+func NewLogSink() *LogSink {
+	return &LogSink{
+		ring: make([]string, ringCapacity),
+		subs: make(map[chan string]struct{}),
+	}
+}
+
+// Write implements io.Writer; each call is treated as one log line.
+func (s *LogSink) Write(p []byte) (int, error) {
+	line := string(p)
+	s.mu.Lock()
+	s.ring[s.pos] = line
+	s.pos = (s.pos + 1) % ringCapacity
+	if s.pos == 0 {
+		s.full = true
+	}
+	s.mu.Unlock()
+
+	s.subsMu.RLock()
+	for ch := range s.subs {
+		select {
+		case ch <- line:
+		default: // slow subscriber — drop rather than block
+		}
+	}
+	s.subsMu.RUnlock()
+	return len(p), nil
+}
+
+// Subscribe returns a buffered channel that will receive new log lines.
+// The caller must call Unsubscribe when done.
+func (s *LogSink) Subscribe() chan string {
+	ch := make(chan string, 256)
+	// Replay existing ring contents in order.
+	s.mu.Lock()
+	var history []string
+	if s.full {
+		history = append(s.ring[s.pos:], s.ring[:s.pos]...)
+	} else {
+		history = s.ring[:s.pos]
+	}
+	s.mu.Unlock()
+
+	s.subsMu.Lock()
+	s.subs[ch] = struct{}{}
+	s.subsMu.Unlock()
+
+	go func() {
+		for _, line := range history {
+			ch <- line
+		}
+	}()
+	return ch
+}
+
+// Unsubscribe removes a channel previously returned by Subscribe.
+func (s *LogSink) Unsubscribe(ch chan string) {
+	s.subsMu.Lock()
+	delete(s.subs, ch)
+	s.subsMu.Unlock()
+}
+
+// Logger returns a *log.Logger that writes to this sink as well as w.
+// Pass io.Discard to suppress the secondary output.
+func (s *LogSink) Logger(prefix string, w io.Writer) *log.Logger {
+	return log.New(io.MultiWriter(s, w), prefix, log.Ldate|log.Ltime|log.Lmsgprefix)
+}

--- a/internal/marketbot/logsink.go
+++ b/internal/marketbot/logsink.go
@@ -71,7 +71,10 @@ func (s *LogSink) Subscribe() chan string {
 
 	go func() {
 		for _, line := range history {
-			ch <- line
+			select {
+			case ch <- line:
+			default:
+			}
 		}
 	}()
 	return ch

--- a/internal/marketbot/pricing.go
+++ b/internal/marketbot/pricing.go
@@ -1,0 +1,534 @@
+package marketbot
+
+import (
+	"math"
+	"sort"
+	"strings"
+)
+
+// buildSegmentIndex collects every unique path segment at each depth level
+// across the full catalog, returning a sorted slice per level used by CategoryMask.
+func buildSegmentIndex(catalog []CatalogItem) [4][]string {
+	sets := [4]map[string]struct{}{}
+	for i := range sets {
+		sets[i] = make(map[string]struct{})
+	}
+	for _, item := range catalog {
+		if item.Category == "" {
+			continue
+		}
+		parts := strings.Split(item.Category, "/")
+		for i, p := range parts {
+			if i < 4 {
+				sets[i][p] = struct{}{}
+			}
+		}
+	}
+	var idx [4][]string
+	for i, s := range sets {
+		for k := range s {
+			idx[i] = append(idx[i], k)
+		}
+		sort.Strings(idx[i])
+	}
+	return idx
+}
+
+// Category encoding: depth1 in bits 24-31 (MSB), depth2 in bits 16-23,
+// depth3 in bits 8-15, depth0 (root "items") always 0 in bits 0-7.
+// Code = 0-indexed position in the game UI list, confirmed from live player orders
+// and in-game category screenshots.
+//
+// Depth-1 UI tab order: GARMENTS(0) WEAPONS(1) VEHICLES(2) UTILITY(3) AUGMENTATIONS(4) MISC(5)
+var knownCodes = [4]map[string]byte{
+	0: {},
+	1: {
+		"garment":  0,
+		"weapons":  1,
+		"vehicles": 2,
+		"utility":  3,
+		"augment":  4,
+		"misc":     5,
+	},
+	2: {
+		// GARMENTS: LIGHT ARMOR(0) HEAVY ARMOR(1) STILLSUITS(2) UTILITY(3) SOCIAL(4)
+		"lightarmor":       0,
+		"heavyarmor":       1,
+		"stillsuits":       2,
+		"utilitywearables": 3,
+		"socialwearables":  4,
+		// WEAPONS: MELEE(0) individual-type codes (depth-2), AMMUNITION(2)
+		// Ranged weapon item types — codes confirmed from UniqueSchematicsMask ordering
+		// (same positional order used for both item depth-2 and schematic depth-3).
+		"pistol":          2,
+		"heavypistol":     3,
+		"heavyrifle":      4,
+		"smg":             5,
+		"spitdart":        6,
+		"shotgun":         7,
+		"battlerifle":     8,
+		"heavyshotgun":    9,
+		"missilelauncher": 10,
+		"flamethrower":    11,
+		"fireballer":      12,
+		"lasgun":          13,
+		"ammunition":      14,
+		// VEHICLES: ONE MAN(0) FOUR MAN/buggy(1) LIGHT ORNITHOPTER(2) MEDIUM ORNITHOPTER(3) CARRY-ALL/transport(4) SANDCRAWLER(5)
+		"sandbike":             0,
+		"buggy":                1,
+		"lightornithopter":     2,
+		"mediumornithopter":    3,
+		"transportornithopter": 4,
+		"sandcrawler":          5,
+		// UTILITY: BUILDING TOOLS(0) DEPLOYABLES(1) HYDRATION TOOLS(2) GATHERING TOOLS(3) CARTOGRAPHY TOOLS(4) UTILITY TOOLS(5) CONSUMABLES(6)
+		"buildingtools":    0,
+		"hydrationtools":   2,
+		"gatheringtools":   3,
+		"cartographytools": 4,
+		"utilitytools":     5,
+		"consumables":      6,
+		// AUGMENTATIONS: GARMENT/armor(0) MELEE(1) RANGED(2) GENERIC/misc(3)
+		"armor":  0,
+		"melee":  1,
+		"ranged": 2,
+		"misc":   3,
+		// MISC: FUEL(0) REFINED RESOURCES(1) COMPONENTS(2) RAW RESOURCES(3)
+		"fuel":             0,
+		"refinedresources": 1,
+		"components":       2,
+		"rawresources":     3,
+	},
+	3: {
+		// GATHERING TOOLS: CUTTERAY(0) COMPACTOR(1) — confirmed from player orders
+		"cutteray":  0,
+		"compactor": 1,
+	},
+}
+
+// depth3Parent resolves depth-3 codes using (parent-depth2, segment) context.
+// All codes read from in-game UI screenshots (position = code, 0-indexed).
+var depth3Parent = map[[2]string]byte{
+	// GARMENTS > LIGHT ARMOR: HEAD(0) CHEST(1) LEGS(2) HANDS(3) FEET(4)
+	{"lightarmor", "head"}: 0, {"lightarmor", "chest"}: 1, {"lightarmor", "legs"}: 2,
+	{"lightarmor", "hands"}: 3, {"lightarmor", "feet"}: 4,
+	// GARMENTS > HEAVY ARMOR: HEAD(0) CHEST(1) LEGS(2) HANDS(3) FEET(4)
+	{"heavyarmor", "head"}: 0, {"heavyarmor", "chest"}: 1, {"heavyarmor", "legs"}: 2,
+	{"heavyarmor", "hands"}: 3, {"heavyarmor", "feet"}: 4,
+	// GARMENTS > STILLSUITS: HEAD(0) CHEST(1) HANDS(2) FEET(3)
+	{"stillsuits", "head"}: 0, {"stillsuits", "chest"}: 1,
+	{"stillsuits", "hands"}: 2, {"stillsuits", "feet"}: 3,
+	// GARMENTS > SOCIAL: CHEST(0) LEGS(1) HANDS(2) FEET(3)
+	{"socialwearables", "chest"}: 0, {"socialwearables", "legs"}: 1,
+	{"socialwearables", "hands"}: 2, {"socialwearables", "feet"}: 3,
+
+	// VEHICLES > ONE MAN GROUNDCAR: CHASSIS(0) HULL(1) ENGINE(2) PSU(3) LOCOMOTION(4) UTILITY(5)
+	{"sandbike", "chassis"}: 0, {"sandbike", "hull"}: 1, {"sandbike", "engine"}: 2,
+	{"sandbike", "psu"}: 3, {"sandbike", "locomotion"}: 4, {"sandbike", "utility"}: 5,
+	// VEHICLES > FOUR MAN GROUNDCAR: CHASSIS(0) HULL(1) REAR HULL(2) ENGINE(3) PSU(4) LOCOMOTION(5) TURRET(6) UTILITY(7)
+	{"buggy", "chassis"}: 0, {"buggy", "hull"}: 1, {"buggy", "rear"}: 2,
+	{"buggy", "engine"}: 3, {"buggy", "psu"}: 4, {"buggy", "locomotion"}: 5,
+	{"buggy", "turret"}: 6, {"buggy", "utility"}: 7,
+	// VEHICLES > LIGHT ORNITHOPTER: CHASSIS(0) COCKPIT(1) HULL(2) ENGINE(3) PSU(4) WING/locomotion(5) UTILITY(6)
+	{"lightornithopter", "chassis"}: 0, {"lightornithopter", "cockpit"}: 1,
+	{"lightornithopter", "hull"}: 2, {"lightornithopter", "engine"}: 3,
+	{"lightornithopter", "psu"}: 4, {"lightornithopter", "locomotion"}: 5,
+	{"lightornithopter", "utility"}: 6,
+	// VEHICLES > MEDIUM ORNITHOPTER: CHASSIS(0) CABIN(1) COCKPIT(2) TAIL(3) ENGINE(4) PSU(5) WING/locomotion(6) UTILITY(7)
+	{"mediumornithopter", "chassis"}: 0, {"mediumornithopter", "cabin"}: 1,
+	{"mediumornithopter", "cockpit"}: 2, {"mediumornithopter", "tail"}: 3,
+	{"mediumornithopter", "engine"}: 4, {"mediumornithopter", "psu"}: 5,
+	{"mediumornithopter", "locomotion"}: 6, {"mediumornithopter", "utility"}: 7,
+	// VEHICLES > CARRY-ALL: CHASSIS(0) HULL(1) ENGINE(2) PSU(3) WING/locomotion(4) UTILITY(5)
+	{"transportornithopter", "chassis"}: 0, {"transportornithopter", "hull"}: 1,
+	{"transportornithopter", "engine"}: 2, {"transportornithopter", "psu"}: 3,
+	{"transportornithopter", "locomotion"}: 4, {"transportornithopter", "utility"}: 5,
+	// VEHICLES > SANDCRAWLER: CHASSIS(0) CABIN(1) ENGINE(2) PSU(3) LOCOMOTION(4) UTILITY(5)
+	{"sandcrawler", "chassis"}: 0, {"sandcrawler", "cabin"}: 1, {"sandcrawler", "engine"}: 2,
+	{"sandcrawler", "psu"}: 3, {"sandcrawler", "locomotion"}: 4, {"sandcrawler", "utility"}: 5,
+
+	// UTILITY > HYDRATION TOOLS: WATER TOOL(0) BLOOD TOOL(1)
+	{"hydrationtools", "watertools"}: 0, {"hydrationtools", "bloodtools"}: 1,
+	// UTILITY > UTILITY TOOLS: POWER PACK(0) SUSPENSOR BELT(1) SHIELD(2) UTILITY(3)
+	{"utilitytools", "powerpack"}: 0, {"utilitytools", "suspensor"}: 1,
+	{"utilitytools", "utility"}: 3,
+	// UTILITY > CONSUMABLES: HEALKIT(0) SPICE(1) UTILITY(2)
+	{"consumables", "utility"}: 2,
+}
+
+// weaponPathRemap corrects the structural mismatch where item-data.json has melee
+// weapon sub-types at depth-2 (items/weapons/shortblades) but the game puts them at
+// depth-3 under melee (items/weapons/melee/shortblades).
+// Maps depth-2 segment → (d2_code, d3_code).
+var weaponPathRemap = map[string][2]byte{
+	"shortblades": {0, 0}, // MELEE WEAPONS(0) > SHORT BLADES(0)
+	"longblades":  {0, 1}, // MELEE WEAPONS(0) > LONG BLADES(1)
+}
+
+// uniqueSchematicsD2 is the depth-2 code for UNIQUE SCHEMATICS under each
+// depth-1 category. Confirmed from in-game UI screenshots (0-indexed position).
+//
+//	GARMENTS:      LIGHT ARMOR(0) HEAVY ARMOR(1) STILLSUITS(2) UTILITY(3) SOCIAL(4) → UNIQUE SCHEMATICS(5)
+//	WEAPONS:       MELEE(0) RANGED(1) AMMUNITION(2) → UNIQUE SCHEMATICS(3)
+//	VEHICLES:      ONE MAN(0) FOUR MAN(1) LIGHT ORNITHOPTER(2) MEDIUM ORNITHOPTER(3) CARRY-ALL(4) SANDCRAWLER(5) → UNIQUE SCHEMATICS(6)
+//	UTILITY:       BUILDING TOOLS(0) DEPLOYABLES(1) HYDRATION(2) GATHERING(3) CARTOGRAPHY(4) UTILITY TOOLS(5) CONSUMABLES(6) → UNIQUE SCHEMATICS(7)
+//	AUGMENTATIONS: GARMENT(0) MELEE(1) RANGED(2) GENERIC(3) → UNIQUE SCHEMATICS(4)
+var uniqueSchematicsD2 = map[string]byte{
+	"garment":  5,
+	"weapons":  3,
+	"vehicles": 6,
+	"utility":  7,
+	"augment":  4,
+}
+
+// uniqueSchematicsD3 maps the last segment of an item's category path to its
+// depth-3 position within the UNIQUE SCHEMATICS subcategory.
+// Confirmed from in-game UI screenshots.
+var uniqueSchematicsD3 = map[string]byte{
+	// GARMENTS/UNIQUE SCHEMATICS
+	"lightarmor":       0,
+	"heavyarmor":       1,
+	"stillsuits":       2,
+	"utilitywearables": 3,
+	"socialwearables":  4,
+
+	// WEAPONS/UNIQUE SCHEMATICS (confirmed from screenshots — previous mapping was wrong)
+	"shortblades":     0,
+	"longblades":      1,
+	"pistol":          2,  // MAULA PISTOL (Light.Pistol)
+	"heavypistol":     3,  // KARPOV 38 (Heavy.Pistol)
+	"heavyrifle":      4,  // GRDA 44 (Heavy.Rifle / LMG)
+	"smg":             5,  // DISRUPTOR M11
+	"spitdart":        6,  // JABAL SPITDART
+	"shotgun":         7,  // RAFIQ SNUBNOSE (Light.Shotgun)
+	"battlerifle":     8,  // DRILLSHOT FK7 (Light.Rifle.BattleRifle)
+	"heavyshotgun":    9,  // VULCAN GAU-92 (Heavy.Shotgun)
+	"missilelauncher": 10, // MISSILE LAUNCHER
+	"flamethrower":    11, // FLAMETHROWER
+	"fireballer":      12, // PYROCKET (Exotic.Fireballer)
+	"lasgun":          13, // LASGUN
+
+	// VEHICLES/UNIQUE SCHEMATICS
+	"sandbike":             0,
+	"buggy":                1,
+	"lightornithopter":     2,
+	"mediumornithopter":    3,
+	"transportornithopter": 4,
+	"sandcrawler":          5,
+
+	// UTILITY/UNIQUE SCHEMATICS
+	"deployables":      0,
+	"watertools":       1,
+	"bloodtools":       2,
+	"cutteray":         3,
+	"staticcompactor":  4,
+	"cartographytools": 5,
+	"shield":           6,
+	"suspensor":        7,
+	"powerpack":        8,
+
+	// AUGMENTATIONS/UNIQUE SCHEMATICS
+	"armor":  0,
+	"melee":  1,
+	"ranged": 2,
+	"misc":   3,
+}
+
+// UniqueSchematicsMask computes the category mask for Unique/Memento items,
+// routing them into the UNIQUE SCHEMATICS subcategory instead of their standard
+// type category. Returns ok=false if this category doesn't have a known UNIQUE
+// SCHEMATICS section (vehicles, augments, misc — those stay in standard categories).
+func UniqueSchematicsMask(category string) (mask int32, depth int16, ok bool) {
+	parts := strings.Split(category, "/")
+	if len(parts) < 3 {
+		return 0, 0, false
+	}
+	d1seg := parts[1]
+	d2code, hasUS := uniqueSchematicsD2[d1seg]
+	if !hasUS {
+		return 0, 0, false
+	}
+	d1code := knownCodes[1][d1seg]
+
+	// The item's standard depth-2 (or depth-3 for nested paths) becomes depth-3
+	// within UNIQUE SCHEMATICS.
+	d3seg := parts[2]
+	d3code, hasD3 := uniqueSchematicsD3[d3seg]
+	if !hasD3 && len(parts) >= 4 {
+		d3seg = parts[3] // e.g. items/weapons/sidearms/pistol → "pistol"
+		d3code, hasD3 = uniqueSchematicsD3[d3seg]
+	}
+	if !hasD3 {
+		// Unknown sub-type: don't reroute — fall back to standard category.
+		return 0, 0, false
+	}
+
+	mask = int32(d1code)<<24 | int32(d2code)<<16 | int32(d3code)<<8
+	return mask, 3, true
+}
+
+// CategoryMask computes category_mask and category_depth from an item's category path.
+// Uses confirmed codes from player orders; falls back to alphabetical for unknowns.
+func CategoryMask(category string, idx [4][]string) (mask int32, depth int16) {
+	if category == "" {
+		return 0, 0
+	}
+	parts := strings.Split(category, "/")
+	n := len(parts)
+	if n > 4 {
+		n = 4
+	}
+	depth = int16(n - 1)
+	if depth < 0 {
+		depth = 0
+	}
+
+	// Melee weapons: item-data.json has items/weapons/shortblades (depth-2) but
+	// the game uses items/weapons/melee/shortblades (depth-3). Remap the mask.
+	if n >= 3 && parts[1] == "weapons" {
+		if remap, ok := weaponPathRemap[parts[2]]; ok {
+			depth = 3
+			mask = int32(knownCodes[1]["weapons"])<<24 | int32(remap[0])<<16 | int32(remap[1])<<8
+			return mask, depth
+		}
+	}
+
+	for i := 1; i < n; i++ { // skip i=0 (root "items", always 0)
+		seg := parts[i]
+		code := byte(0)
+		found := false
+		// depth-3: check parent context first to resolve same-name conflicts
+		if i == 3 && len(parts) >= 3 {
+			if c, ok := depth3Parent[[2]string{parts[2], seg}]; ok {
+				code, found = c, true
+			}
+		}
+		if !found {
+			if c, ok := knownCodes[i][seg]; ok {
+				code, found = c, true
+			}
+		}
+		if !found {
+			for j, s := range idx[i] {
+				if s == seg {
+					code = byte(j + 1)
+					break
+				}
+			}
+		}
+		// Bit layout: depth1→bits24-31, depth2→bits16-23, depth3→bits8-15 (confirmed)
+		mask |= int32(code) << uint((4-i)*8)
+	}
+	return mask, depth
+}
+
+// computePrice returns the base listing price for an item.
+// When vendor_price is available (nearly all items), market price = vendor_price * multiplier.
+// The multiplier accounts for rarity and convenience over NPC vendors.
+// Falls back to tier+stack-based pricing for the few items without a vendor price.
+func computePrice(item CatalogItem, snap configValues) int64 {
+	return roundPrice(basePrice(item, snap))
+}
+
+// minMeaningfulVendorPrice is the threshold below which vendor_price is treated as a
+// placeholder (the game uses 1–2 for "can't be sold to vendor") and tier-based pricing
+// is used instead.
+const minMeaningfulVendorPrice = 10
+
+// basePrice returns the unrounded base price, shared by computePrice and adjustPrice.
+func basePrice(item CatalogItem, snap configValues) int64 {
+	// Unique/memento equipment with a known crafting cost: price as
+	// schematic_equivalent + material_cost * 0.75.
+	if item.MaterialCost > 0 && item.StackMax <= 1 && !item.IsSchematic &&
+		(strings.ToLower(item.Rarity) == "unique" || strings.ToLower(item.Rarity) == "memento") {
+		schemPrice := float64(schematicEquipmentPrice(item.Tier)) * rarityMult(item.Rarity, snap.RarityMultipliers)
+		return int64(math.Round(schemPrice + float64(materialCostForGrade(item, 0))*0.75))
+	}
+	if item.BasePrice >= minMeaningfulVendorPrice {
+		mult := vendorMult(item.Rarity, snap.VendorMultipliers)
+		return int64(math.Round(float64(item.BasePrice) * mult))
+	}
+	// Fallback for items without a vendor price.
+	mult := rarityMult(item.Rarity, snap.RarityMultipliers)
+	if item.StackMax <= 1 {
+		base := equipmentPrice(item.Tier)
+		if item.IsSchematic {
+			base = schematicEquipmentPrice(item.Tier)
+		}
+		return int64(math.Round(float64(base) * mult))
+	}
+	p := int64(math.Round(float64(materialUnitPrice(item.Tier)) * mult))
+	if p < 1 {
+		p = 1
+	}
+	return p
+}
+
+// vendorMult returns the market price multiplier for the NPC vendor base price.
+// Looks up rarity (case-insensitive) in the provided multiplier map; defaults to 1.0.
+func vendorMult(rarity string, mult map[string]float64) float64 {
+	lower := strings.ToLower(rarity)
+	for k, v := range mult {
+		if strings.ToLower(k) == lower {
+			return v
+		}
+	}
+	return 1.0
+}
+
+// equipmentPrice is the per-item price for non-stackable physical gear (StackMax=1).
+func equipmentPrice(tier int) int64 {
+	switch tier {
+	case 1:
+		return 2_000
+	case 2:
+		return 8_000
+	case 3:
+		return 30_000
+	case 4:
+		return 100_000
+	case 5:
+		return 300_000
+	case 6:
+		return 750_000
+	default: // T0 social/cosmetic gear
+		return 500
+	}
+}
+
+// schematicEquipmentPrice is the base listing price for a unique schematic.
+// Calibrated to be competitive with (but below) Landsraad vendor prices which
+// range from ~42,500–215,000 for T6 unique schematics.
+func schematicEquipmentPrice(tier int) int64 {
+	switch tier {
+	case 1:
+		return 500
+	case 2:
+		return 1_500
+	case 3:
+		return 4_000
+	case 4:
+		return 12_000
+	case 5:
+		return 30_000
+	case 6:
+		return 75_000
+	default:
+		return 500
+	}
+}
+
+// materialUnitPrice is the per-unit price for stackable crafting materials.
+// Full-stack values: T1≈10k, T2≈40k, T3≈100k, T4≈300k, T5≈750k, T6≈2M
+func materialUnitPrice(tier int) int64 {
+	switch tier {
+	case 1:
+		return 20
+	case 2:
+		return 80
+	case 3:
+		return 200
+	case 4:
+		return 600
+	case 5:
+		return 1_500
+	case 6:
+		return 4_000
+	default: // T0 raw materials
+		return 5
+	}
+}
+
+func rarityMult(rarity string, mult map[string]float64) float64 {
+	lower := strings.ToLower(rarity)
+	for k, v := range mult {
+		if strings.ToLower(k) == lower {
+			return v
+		}
+	}
+	return 1.0
+}
+
+func adjustPrice(item CatalogItem, currentPrice int64, soldFraction float64, snap configValues) int64 {
+	floor := roundPrice(basePrice(item, snap))
+	ceiling := floor * 5
+
+	// Hard per-item overrides from item-data.json take precedence.
+	if item.MinPrice > 0 && floor < item.MinPrice {
+		floor = item.MinPrice
+	}
+	if item.MaxPrice > 0 && ceiling > item.MaxPrice {
+		ceiling = item.MaxPrice
+	}
+
+	var next int64
+	switch {
+	case soldFraction > 0.5:
+		next = int64(math.Round(float64(currentPrice) * 1.10))
+	case soldFraction == 0:
+		next = int64(math.Round(float64(currentPrice) * 0.95))
+	default:
+		next = currentPrice
+	}
+
+	next = roundPrice(next)
+	if next < floor {
+		next = floor
+	}
+	if next > ceiling {
+		next = ceiling
+	}
+	return next
+}
+
+// gradePriceMult returns the price multiplier for quality grades 0–5 from the config array.
+func gradePriceMult(grade int64, mults [6]float64) float64 {
+	if grade < 0 || grade > 5 {
+		return 1.0
+	}
+	return mults[grade]
+}
+
+// gradedPrice returns the grade-adjusted listing price, rounded to a clean step.
+func gradedPrice(basePrice int64, grade int64, mults [6]float64) int64 {
+	return roundPrice(int64(math.Round(float64(basePrice) * gradePriceMult(grade, mults))))
+}
+
+// materialCostForGrade returns the recipe material cost for a specific grade.
+// Falls back to MaterialCost (grade-5 / last tier) when per-grade data is absent.
+func materialCostForGrade(item CatalogItem, grade int64) int64 {
+	if grade >= 0 && grade <= 5 && item.MaterialCostPerGrade[grade] > 0 {
+		return item.MaterialCostPerGrade[grade]
+	}
+	return item.MaterialCost
+}
+
+// gradeFloor returns the listing price floor for item at the given grade.
+// For unique/memento equipment with crafting recipes, each grade's price is derived
+// from that grade's actual material cost rather than a flat multiplier.
+func gradeFloor(item CatalogItem, grade int64, snap configValues) int64 {
+	if item.MaterialCost > 0 && item.StackMax <= 1 && !item.IsSchematic &&
+		(strings.ToLower(item.Rarity) == "unique" || strings.ToLower(item.Rarity) == "memento") {
+		mc := materialCostForGrade(item, grade)
+		schemPrice := float64(schematicEquipmentPrice(item.Tier)) * rarityMult(item.Rarity, snap.RarityMultipliers)
+		return roundPrice(int64(math.Round(schemPrice + float64(mc)*0.75)))
+	}
+	return gradedPrice(roundPrice(basePrice(item, snap)), grade, snap.GradeMultipliers)
+}
+
+// roundPrice rounds to a magnitude-appropriate step so prices look clean.
+func roundPrice(v int64) int64 {
+	var step int64
+	switch {
+	case v >= 1_000_000:
+		step = 100_000
+	case v >= 100_000:
+		step = 10_000
+	case v >= 10_000:
+		step = 1_000
+	case v >= 1_000:
+		step = 100
+	default:
+		step = 10
+	}
+	return int64(math.Round(float64(v)/float64(step))) * step
+}

--- a/internal/marketbot/pricing_test.go
+++ b/internal/marketbot/pricing_test.go
@@ -1,0 +1,137 @@
+package marketbot
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestUniqueSchematicsMask(t *testing.T) {
+	cases := []struct {
+		category string
+		wantMask int32
+	}{
+		// GARMENTS(0) → UNIQUE SCHEMATICS(5) → lightarmor(0)/heavyarmor(1)/stillsuits(2)/social(4)
+		{"items/garment/lightarmor/chest", 0x00050000},
+		{"items/garment/heavyarmor/head", 0x00050100},
+		{"items/garment/stillsuits/hands", 0x00050200},
+		{"items/garment/socialwearables/chest", 0x00050400},
+		// WEAPONS(1) → UNIQUE SCHEMATICS(3) — confirmed D3 codes from in-game screenshots
+		{"items/weapons/shortblades", 0x01030000},
+		{"items/weapons/longblades", 0x01030100},
+		{"items/weapons/pistol", 0x01030200},      // Maula Pistol (Light.Pistol)
+		{"items/weapons/heavypistol", 0x01030300}, // Karpov 38 (Heavy.Pistol)
+		{"items/weapons/heavyrifle", 0x01030400},  // GRDA 44 (Heavy.Rifle)
+		{"items/weapons/smg", 0x01030500},         // Disruptor M11
+		{"items/weapons/spitdart", 0x01030600},    // Jabal Spitdart
+		{"items/weapons/shotgun", 0x01030700},     // Rafiq Snubnose (Light.Shotgun)
+		{"items/weapons/battlerifle", 0x01030800}, // Drillshot FK7 (was wrongly 3 in old code)
+		{"items/weapons/heavyshotgun", 0x01030900},
+		{"items/weapons/missilelauncher", 0x01030A00},
+		{"items/weapons/flamethrower", 0x01030B00},
+		{"items/weapons/fireballer", 0x01030C00}, // Pyrocket
+		{"items/weapons/lasgun", 0x01030D00},
+		// VEHICLES(2) → UNIQUE SCHEMATICS(6)
+		{"items/vehicles/sandbike", 0x02060000},
+		{"items/vehicles/buggy", 0x02060100},
+		{"items/vehicles/lightornithopter", 0x02060200},
+		{"items/vehicles/mediumornithopter", 0x02060300},
+		{"items/vehicles/transportornithopter", 0x02060400},
+		{"items/vehicles/sandcrawler", 0x02060500},
+		// UTILITY(3) → UNIQUE SCHEMATICS(7)
+		{"items/utility/deployables", 0x03070000},
+		{"items/utility/watertools", 0x03070100},
+		{"items/utility/cutteray", 0x03070300},
+		{"items/utility/suspensor", 0x03070700},
+		{"items/utility/powerpack", 0x03070800},
+		// AUGMENTATIONS(4) → UNIQUE SCHEMATICS(4)
+		{"items/augment/armor", 0x04040000},
+		{"items/augment/melee", 0x04040100},
+		{"items/augment/ranged", 0x04040200},
+		{"items/augment/misc", 0x04040300},
+	}
+
+	for _, tc := range cases {
+		mask, depth, ok := UniqueSchematicsMask(tc.category)
+		if !ok {
+			t.Errorf("%-50s: got ok=false, want mask=0x%08X", tc.category, uint32(tc.wantMask))
+			continue
+		}
+		if mask != tc.wantMask {
+			t.Errorf("%-50s: got=0x%08X depth=%d want=0x%08X", tc.category, uint32(mask), depth, uint32(tc.wantMask))
+		} else {
+			fmt.Printf("OK %-50s 0x%08X depth=%d\n", tc.category, uint32(mask), depth)
+		}
+	}
+
+	// Only MISC has no UNIQUE SCHEMATICS section
+	for _, cat := range []string{"items/misc/components", "items/misc/rawresources"} {
+		if _, _, ok := UniqueSchematicsMask(cat); ok {
+			t.Errorf("%s: expected ok=false (no unique schematics remapping)", cat)
+		}
+	}
+}
+
+func TestCategoryMask(t *testing.T) {
+	cases := []struct {
+		category string
+		wantD1   byte
+		wantD2   byte
+		wantD3   byte
+		wantMask int32
+	}{
+		// Weapons: shortblades/longblades remapped to items/weapons/melee/*
+		{"items/weapons/shortblades", 1, 0, 0, 0x01000000},
+		{"items/weapons/longblades", 1, 0, 1, 0x01000100},
+		// Ranged weapon item types (depth-2 codes, same order as UniqueSchematicsMask d3)
+		{"items/weapons/pistol", 1, 2, 0, 0x01020000},
+		{"items/weapons/heavypistol", 1, 3, 0, 0x01030000},
+		{"items/weapons/heavyrifle", 1, 4, 0, 0x01040000},
+		{"items/weapons/smg", 1, 5, 0, 0x01050000},
+		{"items/weapons/spitdart", 1, 6, 0, 0x01060000},
+		{"items/weapons/shotgun", 1, 7, 0, 0x01070000},
+		{"items/weapons/battlerifle", 1, 8, 0, 0x01080000},
+		{"items/weapons/heavyshotgun", 1, 9, 0, 0x01090000},
+		{"items/weapons/missilelauncher", 1, 10, 0, 0x010A0000},
+		{"items/weapons/flamethrower", 1, 11, 0, 0x010B0000},
+		{"items/weapons/fireballer", 1, 12, 0, 0x010C0000},
+		{"items/weapons/lasgun", 1, 13, 0, 0x010D0000},
+		{"items/weapons/ammunition", 1, 14, 0, 0x010E0000},
+		// AUGMENTATIONS item types including GENERIC/misc
+		{"items/augment/armor", 4, 0, 0, 0x04000000},
+		{"items/augment/melee", 4, 1, 0, 0x04010000},
+		{"items/augment/ranged", 4, 2, 0, 0x04020000},
+		{"items/augment/misc", 4, 3, 0, 0x04030000},
+		// MISC
+		{"items/misc/refinedresources", 5, 1, 0, 0x05010000},
+		{"items/misc/components", 5, 2, 0, 0x05020000},
+		{"items/misc/rawresources", 5, 3, 0, 0x05030000},
+		// GARMENTS
+		{"items/garment/lightarmor/chest", 0, 0, 1, 0x00000100},
+		{"items/garment/heavyarmor/head", 0, 1, 0, 0x00010000},
+		// VEHICLES
+		{"items/vehicles/mediumornithopter/chassis", 2, 3, 0, 0x02030000},
+		// UTILITY
+		{"items/utility/consumables", 3, 6, 0, 0x03060000},
+		{"items/utility/gatheringtools/cutteray", 3, 3, 0, 0x03030000},
+	}
+
+	catalog := make([]CatalogItem, len(cases))
+	for i, tc := range cases {
+		catalog[i] = CatalogItem{Category: tc.category}
+	}
+	idx := buildSegmentIndex(catalog)
+
+	for _, tc := range cases {
+		mask, _ := CategoryMask(tc.category, idx)
+		d1 := byte((mask >> 24) & 0xFF)
+		d2 := byte((mask >> 16) & 0xFF)
+		d3 := byte((mask >> 8) & 0xFF)
+		d0 := byte(mask & 0xFF)
+		if mask != tc.wantMask {
+			t.Errorf("%-50s got=0x%08X want=0x%08X [d1=%d d2=%d d3=%d d0=%d]",
+				tc.category, uint32(mask), uint32(tc.wantMask), d1, d2, d3, d0)
+		} else {
+			fmt.Printf("OK %-50s 0x%08X\n", tc.category, uint32(mask))
+		}
+	}
+}

--- a/internal/marketbot/report.go
+++ b/internal/marketbot/report.go
@@ -10,6 +10,8 @@ func (e *Exchange) reportData(ctx context.Context) []reportRow {
 	if e.db == nil {
 		return nil
 	}
+	e.mapMu.RLock()
+	defer e.mapMu.RUnlock()
 	rows, err := e.db.Query(ctx, `
 		SELECT o.template_id,
 		       COALESCE(SUM(f.stack_size), 0)          AS sold,

--- a/internal/marketbot/report.go
+++ b/internal/marketbot/report.go
@@ -1,0 +1,68 @@
+package marketbot
+
+import (
+	"context"
+	"sort"
+)
+
+// reportData returns per-item sales rows for the API /report endpoint.
+func (e *Exchange) reportData(ctx context.Context) []reportRow {
+	if e.db == nil {
+		return nil
+	}
+	rows, err := e.db.Query(ctx, `
+		SELECT o.template_id,
+		       COALESCE(SUM(f.stack_size), 0)          AS sold,
+		       COALESCE(MAX(s.initial_stack_size), 0)  AS listed
+		FROM dune.dune_exchange_orders o
+		JOIN dune.dune_exchange_sell_orders s ON s.order_id = o.id
+		LEFT JOIN dune.dune_exchange_fulfilled_orders f ON f.order_id = o.id
+		WHERE o.owner_id = $1 AND o.is_npc_order = TRUE
+		GROUP BY o.template_id
+		ORDER BY o.template_id`, e.ownerID)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var report []reportRow
+	for rows.Next() {
+		var tmpl string
+		var sold, listed int64
+		if err := rows.Scan(&tmpl, &sold, &listed); err != nil {
+			continue
+		}
+		var sellPct float64
+		if listed > 0 {
+			sellPct = float64(sold) / float64(listed) * 100
+		}
+		item := e.catalogMap[tmpl]
+		report = append(report, reportRow{
+			Template: tmpl,
+			Sold:     sold,
+			Listed:   listed,
+			SellPct:  sellPct,
+			Price:    e.prices[tmpl],
+			MinPrice: item.MinPrice,
+			MaxPrice: item.MaxPrice,
+			Buyable:  item.Buyable,
+		})
+	}
+
+	sort.Slice(report, func(i, j int) bool {
+		return report[i].Template < report[j].Template
+	})
+
+	return report
+}
+
+type reportRow struct {
+	Template string  `json:"template"`
+	Sold     int64   `json:"sold"`
+	Listed   int64   `json:"listed"`
+	SellPct  float64 `json:"sell_pct"`
+	Price    int64   `json:"price"`
+	MinPrice int64   `json:"min_price"`
+	MaxPrice int64   `json:"max_price"`
+	Buyable  bool    `json:"buyable"`
+}

--- a/listen.ps1
+++ b/listen.ps1
@@ -1,0 +1,11 @@
+[CmdletBinding()]
+param(
+  [string]$Namespace = "dune-admin",
+  [int]$LocalPort = 8080,
+  [int]$RemotePort = 8080
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Opening API port-forward at http://127.0.0.1:$LocalPort ..."
+kubectl -n $Namespace port-forward svc/dune-admin "$LocalPort`:$RemotePort"

--- a/listen.sh
+++ b/listen.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+NAMESPACE="${NAMESPACE:-dune-admin}"
+LOCAL_PORT="${LOCAL_PORT:-8080}"
+REMOTE_PORT="${REMOTE_PORT:-8080}"
+
+usage() {
+  cat <<'EOF'
+Usage: ./listen.sh [options]
+
+Options:
+  --namespace <ns>         Kubernetes namespace (default: dune-admin)
+  --local-port <port>      Local listen port (default: 8080)
+  --remote-port <port>     Service target port (default: 8080)
+  -h, --help               Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --local-port) LOCAL_PORT="$2"; shift 2 ;;
+    --remote-port) REMOTE_PORT="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+echo "Opening API port-forward at http://127.0.0.1:${LOCAL_PORT} ..."
+kubectl -n "$NAMESPACE" port-forward svc/dune-admin "${LOCAL_PORT}:${REMOTE_PORT}"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -241,7 +241,7 @@ function AppCore({ isSignedIn }: { isSignedIn: boolean }) {
             <ServerSettingsTab />
           </Tabs.Panel>
           <Tabs.Panel id="market" className="flex-1 overflow-hidden flex flex-col p-4 min-h-0">
-            <MarketTab isSignedIn={isSignedIn} />
+            <MarketTab />
           </Tabs.Panel>
         </Tabs>
       </div>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -18,11 +18,12 @@ function getApiBase(): string {
   // users to set localStorage('dune_admin_backend') to their SSH tunnel.
   const isCdnDeploy = !!(import.meta.env.VITE_CDN_BASE_URL as string | undefined)
 
-  // Single-binary deploys (AMP, local Go): SPA and API are same-origin.
-  // Anything that isn't the Vite dev server gets the auto-detected origin.
-  const devHosts = new Set(['localhost', '127.0.0.1', '::1', '[::1]'])
-  if (!isCdnDeploy && typeof window !== 'undefined' && !devHosts.has(window.location.hostname)) {
-    return window.location.origin + '/api/v1'
+  // Single-binary deploys (AMP, local Go, k8s port-forward): SPA and API are
+  // same-origin unless we're on the Vite dev server.
+  if (!isCdnDeploy && typeof window !== 'undefined') {
+    if (window.location.port !== '5173') {
+      return window.location.origin + '/api/v1'
+    }
   }
   return 'http://localhost:8080/api/v1'
 }
@@ -222,7 +223,9 @@ export type CatalogItem = {
   display_name: string
 }
 export type BotStatus = {
-  running: boolean      // injected by dune-admin proxy (true = bot responded)
+  running: boolean
+  mode?: 'embedded'
+  enabled?: boolean
   uptime: string
   last_list_tick: string | null
   last_buy_tick: string | null
@@ -234,16 +237,40 @@ export type BotStatus = {
   error?: string        // set when running=false
 }
 export type BotConfig = {
-  list_tick_interval: string
-  buy_tick_interval: string
+  list_interval: string
+  buy_interval: string
   rarity_multipliers: Record<string, number>
   vendor_multipliers?: Record<string, number>
   grade_multipliers: number[]
   buy_threshold: number
-  max_buys_per_tick: number
+  max_buys: number
   listings_per_grade: number
   disabled_items: string[]
   enabled: boolean
+}
+
+function normalizeBotConfig(raw: unknown): BotConfig {
+  const src = (raw && typeof raw === 'object') ? (raw as Record<string, unknown>) : {}
+  return {
+    list_interval: typeof src.list_interval === 'string'
+      ? src.list_interval
+      : (typeof src.list_tick_interval === 'string' ? src.list_tick_interval : '30m0s'),
+    buy_interval: typeof src.buy_interval === 'string'
+      ? src.buy_interval
+      : (typeof src.buy_tick_interval === 'string' ? src.buy_tick_interval : '5m0s'),
+    rarity_multipliers: (src.rarity_multipliers as Record<string, number> | undefined) ?? {},
+    vendor_multipliers: (src.vendor_multipliers as Record<string, number> | undefined) ?? {},
+    grade_multipliers: Array.isArray(src.grade_multipliers)
+      ? (src.grade_multipliers as number[])
+      : [],
+    buy_threshold: typeof src.buy_threshold === 'number' ? src.buy_threshold : 1.05,
+    max_buys: typeof src.max_buys === 'number'
+      ? src.max_buys
+      : (typeof src.max_buys_per_tick === 'number' ? src.max_buys_per_tick : 50),
+    listings_per_grade: typeof src.listings_per_grade === 'number' ? src.listings_per_grade : 5,
+    disabled_items: Array.isArray(src.disabled_items) ? (src.disabled_items as string[]) : [],
+    enabled: typeof src.enabled === 'boolean' ? src.enabled : true,
+  }
 }
 
 export type ProgressionPreset = {
@@ -519,8 +546,8 @@ export const api = {
 
   marketBot: {
     status: () => req<BotStatus>('GET', '/market-bot/status'),
-    config: () => req<BotConfig>('GET', '/market-bot/config'),
-    saveConfig: (cfg: BotConfig) => req<BotConfig>('PUT', '/market-bot/config', cfg),
+    config: async () => normalizeBotConfig(await req<unknown>('GET', '/market-bot/config')),
+    saveConfig: async (cfg: BotConfig) => normalizeBotConfig(await req<unknown>('PUT', '/market-bot/config', cfg)),
     lifecycle: (cmd: 'start' | 'stop' | 'restart') => req<{ output: string }>('POST', '/market-bot/exec', { cmd }),
     logsReady: () => req<{ ready: boolean; reason?: string; namespace?: string; name?: string }>('GET', '/market-bot/logs-ready'),
   },

--- a/web/src/tabs/MarketTab/bot/BotActions.tsx
+++ b/web/src/tabs/MarketTab/bot/BotActions.tsx
@@ -16,10 +16,12 @@ export default function BotActions({ status, onRefresh }: Props) {
     setBusy(cmd)
     try {
       const res = await api.marketBot.lifecycle(cmd)
-      toast.success(`Bot ${cmd}: ${res.output || 'ok'}`)
+      const actionLabel = cmd === 'start' ? 'resume' : cmd === 'stop' ? 'pause' : 'reinitialize'
+      toast.success(`Bot ${actionLabel}: ${res.output || 'ok'}`)
       setTimeout(onRefresh, 1500)
     } catch (e: unknown) {
-      toast.danger(`Failed to ${cmd} bot: ${e instanceof Error ? e.message : String(e)}`)
+      const actionLabel = cmd === 'start' ? 'resume' : cmd === 'stop' ? 'pause' : 'reinitialize'
+      toast.danger(`Failed to ${actionLabel} bot: ${e instanceof Error ? e.message : String(e)}`)
     } finally {
       setBusy(null)
     }
@@ -36,7 +38,7 @@ export default function BotActions({ status, onRefresh }: Props) {
         onPress={() => run('start')}
       >
         {busy === 'start' ? <Spinner size="sm" color="current" /> : <Icon name="play" />}
-        Start
+        Resume
       </Button>
       <Button
         size="sm"
@@ -45,7 +47,7 @@ export default function BotActions({ status, onRefresh }: Props) {
         onPress={() => run('stop')}
       >
         {busy === 'stop' ? <Spinner size="sm" color="current" /> : <Icon name="square" />}
-        Stop
+        Pause
       </Button>
       <Button
         size="sm"
@@ -54,7 +56,7 @@ export default function BotActions({ status, onRefresh }: Props) {
         onPress={() => run('restart')}
       >
         {busy === 'restart' ? <Spinner size="sm" color="current" /> : <Icon name="refresh-cw" />}
-        Restart
+        Reinitialize
       </Button>
     </div>
   )

--- a/web/src/tabs/MarketTab/bot/BotConfigEditor.tsx
+++ b/web/src/tabs/MarketTab/bot/BotConfigEditor.tsx
@@ -54,15 +54,15 @@ export default function BotConfigEditor({ config, onSaved }: Props) {
           <Field label="List tick interval" hint="e.g. 30m, 1h">
             <input
               className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-foreground w-full"
-              value={draft.list_tick_interval}
-              onChange={e => set('list_tick_interval', e.target.value)}
+              value={draft.list_interval}
+              onChange={e => set('list_interval', e.target.value)}
             />
           </Field>
           <Field label="Buy tick interval" hint="e.g. 5m">
             <input
               className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-foreground w-full"
-              value={draft.buy_tick_interval}
-              onChange={e => set('buy_tick_interval', e.target.value)}
+              value={draft.buy_interval}
+              onChange={e => set('buy_interval', e.target.value)}
             />
           </Field>
         </div>
@@ -74,8 +74,8 @@ export default function BotConfigEditor({ config, onSaved }: Props) {
             <input
               className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-foreground w-full"
               type="number"
-              value={draft.max_buys_per_tick}
-              onChange={e => set('max_buys_per_tick', Number(e.target.value))}
+              value={draft.max_buys}
+              onChange={e => set('max_buys', Number(e.target.value))}
             />
           </Field>
           <Field label="Listings per grade">

--- a/web/src/tabs/MarketTab/bot/BotStatusCard.tsx
+++ b/web/src/tabs/MarketTab/bot/BotStatusCard.tsx
@@ -12,16 +12,19 @@ function fmtBalance(n: number | undefined): string {
 }
 
 export default function BotStatusCard({ status }: { status: BotStatus }) {
+  const statusLabel = status.running ? '● Running' : '⏸ Paused'
+  const statusColor = status.running ? 'success' : 'warning'
+
   return (
     <div className="flex flex-wrap gap-4 items-start">
       <div className="flex flex-col gap-1 min-w-[120px]">
         <span className="text-xs text-muted uppercase tracking-wider">Status</span>
         <Chip
           size="sm"
-          color={status.running ? 'success' : 'default'}
+          color={statusColor}
           variant="soft"
         >
-          {status.running ? '● Running' : '○ Stopped'}
+          {statusLabel}
         </Chip>
       </div>
 

--- a/web/src/tabs/MarketTab/index.tsx
+++ b/web/src/tabs/MarketTab/index.tsx
@@ -13,11 +13,7 @@ import BotControlPanel from './bot/BotControlPanel'
 
 const DEFAULT_FILTERS: MarketFilters = { search: '', category: '', owner: '' }
 
-type Props = {
-  isSignedIn?: boolean
-}
-
-export default function MarketTab({ isSignedIn = false }: Props) {
+export default function MarketTab() {
   const [items, setItems] = useState<MarketItem[]>([])
   const [categories, setCategories] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
@@ -61,11 +57,9 @@ export default function MarketTab({ isSignedIn = false }: Props) {
   return (
     <div className="flex flex-col h-full gap-3 min-h-0">
       <PageHeader title="Market Board" subtitle="Browse active exchange listings from bot and player sellers.">
-        {isSignedIn && (
-          <Button size="sm" variant="ghost" onPress={() => setBotOpen(true)}>
-            <Icon name="bot" /> Bot Control
-          </Button>
-        )}
+        <Button size="sm" variant="ghost" onPress={() => setBotOpen(true)}>
+          <Icon name="bot" /> Bot Control
+        </Button>
         <ViewToggle view={view} onChange={setView} />
         <Button size="sm" variant="ghost" onPress={load} isDisabled={loading}>
           {loading ? <Spinner size="sm" color="current" /> : <><Icon name="refresh-cw" /> Refresh</>}
@@ -98,9 +92,7 @@ export default function MarketTab({ isSignedIn = false }: Props) {
         <ItemDetail item={selected} onClose={() => setSelected(null)} />
       </div>
 
-      {isSignedIn && (
-        <BotControlPanel open={botOpen} onClose={() => setBotOpen(false)} />
-      )}
+      <BotControlPanel open={botOpen} onClose={() => setBotOpen(false)} />
     </div>
   )
 }


### PR DESCRIPTION
- embed market-bot as an internal library with API, config, pricing, exchange and reporting modules
- wire backend runtime lifecycle, status/config/exec/log endpoints, and UI controls for embedded operation
- add cross-control-plane runtime improvements for local/kubectl/docker/amp flows
- harden battlegroup backup/restore and server-settings handling across host and k8s pod filesystem paths
- improve default INI discovery in deployed environments and preserve layered settings behavior
- introduce render-k8s + deploy scripts, API-first deploy checks, and dedicated listen.sh/listen.ps1 port-forward helpers
- update docs, setup guides, plans, ADRs, and dependency manifests to match phase-2 architecture