### PR TITLE
[REFACTOR] Phase 4 — Resolve cyclomatic complexity across 32 functions (issues #18–#51)

### DIFF
--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-cmdApplyProgressionPreset      progression_presets.go:92:1         19   https://github.com/Icehunter/dune-admin/issues/43
 connectAll                     connection.go:40:1                  18   https://github.com/Icehunter/dune-admin/issues/44
 cmdRepairItem                  db.go:3265:1                        18   https://github.com/Icehunter/dune-admin/issues/45
 listGameProcesses              control_amp.go:104:1                17   https://github.com/Icehunter/dune-admin/issues/46

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-handleExportBase               handlers_bases.go:82:1              53   https://github.com/Icehunter/dune-admin/issues/19
 cmdReverseContracts            db.go:1695:1                        51   https://github.com/Icehunter/dune-admin/issues/20
 cmdRepairPlayerGear            db.go:3336:1                        46   https://github.com/Icehunter/dune-admin/issues/21
 handleGetServerSettings        handlers_server_settings.go:410:1   41   https://github.com/Icehunter/dune-admin/issues/22

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-stripKeysFromContent           handlers_server_settings.go:756:1   17   https://github.com/Icehunter/dune-admin/issues/48
 handleSaveConfig               handlers_config.go:31:1             16   https://github.com/Icehunter/dune-admin/issues/49
 cmdSampleTable                 db.go:1277:1                        16   https://github.com/Icehunter/dune-admin/issues/50
 cmdGrantAllKeystones           db.go:3015:1                        16   https://github.com/Icehunter/dune-admin/issues/51

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-cmdProgressionUnlock           db.go:2314:1                        32   https://github.com/Icehunter/dune-admin/issues/29
 cmdReverseProgressionUnlock    db.go:2457:1                        32   https://github.com/Icehunter/dune-admin/issues/30
 main                           main.go:420:1                       30   https://github.com/Icehunter/dune-admin/issues/31
 handleUpdateServerSettings     handlers_server_settings.go:862:1   26   https://github.com/Icehunter/dune-admin/issues/33

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-parseINILines                  handlers_server_settings.go:198:1   24   https://github.com/Icehunter/dune-admin/issues/37
 cmdRepairVehicle               db.go:3440:1                        24   https://github.com/Icehunter/dune-admin/issues/39
 stripEmptySections             handlers_server_settings.go:703:1   22   https://github.com/Icehunter/dune-admin/issues/40
 handleGiveItems                handlers_players.go:230:1           22   https://github.com/Icehunter/dune-admin/issues/41

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-cmdGiveItem                    db.go:262:1                         109  https://github.com/Icehunter/dune-admin/issues/18
 handleExportBase               handlers_bases.go:82:1              53   https://github.com/Icehunter/dune-admin/issues/19
 cmdReverseContracts            db.go:1695:1                        51   https://github.com/Icehunter/dune-admin/issues/20
 cmdRepairPlayerGear            db.go:3336:1                        46   https://github.com/Icehunter/dune-admin/issues/21

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-discoverDefaultINI             handlers_server_settings.go:339:1   26   https://github.com/Icehunter/dune-admin/issues/34
 cmdSetStarterClass             db.go:1866:1                        25   https://github.com/Icehunter/dune-admin/issues/35
 runKubectlSetup                setup.go:99:1                       25   https://github.com/Icehunter/dune-admin/issues/36
 parseINILines                  handlers_server_settings.go:198:1   24   https://github.com/Icehunter/dune-admin/issues/37

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-stripEmptySections             handlers_server_settings.go:703:1   22   https://github.com/Icehunter/dune-admin/issues/40
 handleGiveItems                handlers_players.go:230:1           22   https://github.com/Icehunter/dune-admin/issues/41
 fetchBlueprintData             handlers_blueprints.go:148:1        22   https://github.com/Icehunter/dune-admin/issues/42
 cmdApplyProgressionPreset      progression_presets.go:92:1         19   https://github.com/Icehunter/dune-admin/issues/43

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-cmdAwardCharXP                 db.go:2723:1                        33   https://github.com/Icehunter/dune-admin/issues/28
 cmdProgressionUnlock           db.go:2314:1                        32   https://github.com/Icehunter/dune-admin/issues/29
 cmdReverseProgressionUnlock    db.go:2457:1                        32   https://github.com/Icehunter/dune-admin/issues/30
 main                           main.go:420:1                       30   https://github.com/Icehunter/dune-admin/issues/31

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-listGameProcesses              control_amp.go:104:1                17   https://github.com/Icehunter/dune-admin/issues/46
 cmdRunSQL                      db.go:219:1                         17   https://github.com/Icehunter/dune-admin/issues/47
 stripKeysFromContent           handlers_server_settings.go:756:1   17   https://github.com/Icehunter/dune-admin/issues/48
 handleSaveConfig               handlers_config.go:31:1             16   https://github.com/Icehunter/dune-admin/issues/49

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-cmdSetStarterClass             db.go:1866:1                        25   https://github.com/Icehunter/dune-admin/issues/35
 runKubectlSetup                setup.go:99:1                       25   https://github.com/Icehunter/dune-admin/issues/36
 parseINILines                  handlers_server_settings.go:198:1   24   https://github.com/Icehunter/dune-admin/issues/37
 cmdRepairVehicle               db.go:3440:1                        24   https://github.com/Icehunter/dune-admin/issues/39

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-cmdRepairVehicle               db.go:3440:1                        24   https://github.com/Icehunter/dune-admin/issues/39
 stripEmptySections             handlers_server_settings.go:703:1   22   https://github.com/Icehunter/dune-admin/issues/40
 handleGiveItems                handlers_players.go:230:1           22   https://github.com/Icehunter/dune-admin/issues/41
 fetchBlueprintData             handlers_blueprints.go:148:1        22   https://github.com/Icehunter/dune-admin/issues/42

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-cmdRunSQL                      db.go:219:1                         17   https://github.com/Icehunter/dune-admin/issues/47
 stripKeysFromContent           handlers_server_settings.go:756:1   17   https://github.com/Icehunter/dune-admin/issues/48
 handleSaveConfig               handlers_config.go:31:1             16   https://github.com/Icehunter/dune-admin/issues/49
 cmdSampleTable                 db.go:1277:1                        16   https://github.com/Icehunter/dune-admin/issues/50

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-cmdReverseContracts            db.go:1695:1                        51   https://github.com/Icehunter/dune-admin/issues/20
 cmdRepairPlayerGear            db.go:3336:1                        46   https://github.com/Icehunter/dune-admin/issues/21
 handleGetServerSettings        handlers_server_settings.go:410:1   41   https://github.com/Icehunter/dune-admin/issues/22
 importBlueprintData            handlers_blueprints.go:274:1        41   https://github.com/Icehunter/dune-admin/issues/23

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-cmdRepairPlayerGear            db.go:3336:1                        46   https://github.com/Icehunter/dune-admin/issues/21
 handleGetServerSettings        handlers_server_settings.go:410:1   41   https://github.com/Icehunter/dune-admin/issues/22
 importBlueprintData            handlers_blueprints.go:274:1        41   https://github.com/Icehunter/dune-admin/issues/23
 cmdCompleteContracts           db.go:1618:1                        38   https://github.com/Icehunter/dune-admin/issues/24

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-handleBGBackupUpload           handlers_battlegroup.go:203:1       37   https://github.com/Icehunter/dune-admin/issues/25
 checkInventoryCapacity         db.go:476:1                         37   https://github.com/Icehunter/dune-admin/issues/26
 handleMarketItems              handlers_market.go:12:1             34   https://github.com/Icehunter/dune-admin/issues/27
 cmdAwardCharXP                 db.go:2723:1                        33   https://github.com/Icehunter/dune-admin/issues/28

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-handleGiveItems                handlers_players.go:230:1           22   https://github.com/Icehunter/dune-admin/issues/41
 fetchBlueprintData             handlers_blueprints.go:148:1        22   https://github.com/Icehunter/dune-admin/issues/42
 cmdApplyProgressionPreset      progression_presets.go:92:1         19   https://github.com/Icehunter/dune-admin/issues/43
 connectAll                     connection.go:40:1                  18   https://github.com/Icehunter/dune-admin/issues/44

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-main                           main.go:420:1                       30   https://github.com/Icehunter/dune-admin/issues/31
 handleUpdateServerSettings     handlers_server_settings.go:862:1   26   https://github.com/Icehunter/dune-admin/issues/33
 discoverDefaultINI             handlers_server_settings.go:339:1   26   https://github.com/Icehunter/dune-admin/issues/34
 cmdSetStarterClass             db.go:1866:1                        25   https://github.com/Icehunter/dune-admin/issues/35

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-cmdReverseProgressionUnlock    db.go:2457:1                        32   https://github.com/Icehunter/dune-admin/issues/30
 main                           main.go:420:1                       30   https://github.com/Icehunter/dune-admin/issues/31
 handleUpdateServerSettings     handlers_server_settings.go:862:1   26   https://github.com/Icehunter/dune-admin/issues/33
 discoverDefaultINI             handlers_server_settings.go:339:1   26   https://github.com/Icehunter/dune-admin/issues/34

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,4 +1,3 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-cmdGrantAllKeystones           db.go:3015:1                        16   https://github.com/Icehunter/dune-admin/issues/51

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-runKubectlSetup                setup.go:99:1                       25   https://github.com/Icehunter/dune-admin/issues/36
 parseINILines                  handlers_server_settings.go:198:1   24   https://github.com/Icehunter/dune-admin/issues/37
 cmdRepairVehicle               db.go:3440:1                        24   https://github.com/Icehunter/dune-admin/issues/39
 stripEmptySections             handlers_server_settings.go:703:1   22   https://github.com/Icehunter/dune-admin/issues/40

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,6 +1,5 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-handleSaveConfig               handlers_config.go:31:1             16   https://github.com/Icehunter/dune-admin/issues/49
 cmdSampleTable                 db.go:1277:1                        16   https://github.com/Icehunter/dune-admin/issues/50
 cmdGrantAllKeystones           db.go:3015:1                        16   https://github.com/Icehunter/dune-admin/issues/51

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-cmdCompleteContracts           db.go:1618:1                        38   https://github.com/Icehunter/dune-admin/issues/24
 handleBGBackupUpload           handlers_battlegroup.go:203:1       37   https://github.com/Icehunter/dune-admin/issues/25
 checkInventoryCapacity         db.go:476:1                         37   https://github.com/Icehunter/dune-admin/issues/26
 handleMarketItems              handlers_market.go:12:1             34   https://github.com/Icehunter/dune-admin/issues/27

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-fetchBlueprintData             handlers_blueprints.go:148:1        22   https://github.com/Icehunter/dune-admin/issues/42
 cmdApplyProgressionPreset      progression_presets.go:92:1         19   https://github.com/Icehunter/dune-admin/issues/43
 connectAll                     connection.go:40:1                  18   https://github.com/Icehunter/dune-admin/issues/44
 cmdRepairItem                  db.go:3265:1                        18   https://github.com/Icehunter/dune-admin/issues/45

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-handleUpdateServerSettings     handlers_server_settings.go:862:1   26   https://github.com/Icehunter/dune-admin/issues/33
 discoverDefaultINI             handlers_server_settings.go:339:1   26   https://github.com/Icehunter/dune-admin/issues/34
 cmdSetStarterClass             db.go:1866:1                        25   https://github.com/Icehunter/dune-admin/issues/35
 runKubectlSetup                setup.go:99:1                       25   https://github.com/Icehunter/dune-admin/issues/36

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-connectAll                     connection.go:40:1                  18   https://github.com/Icehunter/dune-admin/issues/44
 cmdRepairItem                  db.go:3265:1                        18   https://github.com/Icehunter/dune-admin/issues/45
 listGameProcesses              control_amp.go:104:1                17   https://github.com/Icehunter/dune-admin/issues/46
 cmdRunSQL                      db.go:219:1                         17   https://github.com/Icehunter/dune-admin/issues/47

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-cmdRepairItem                  db.go:3265:1                        18   https://github.com/Icehunter/dune-admin/issues/45
 listGameProcesses              control_amp.go:104:1                17   https://github.com/Icehunter/dune-admin/issues/46
 cmdRunSQL                      db.go:219:1                         17   https://github.com/Icehunter/dune-admin/issues/47
 stripKeysFromContent           handlers_server_settings.go:756:1   17   https://github.com/Icehunter/dune-admin/issues/48

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-handleGetServerSettings        handlers_server_settings.go:410:1   41   https://github.com/Icehunter/dune-admin/issues/22
 importBlueprintData            handlers_blueprints.go:274:1        41   https://github.com/Icehunter/dune-admin/issues/23
 cmdCompleteContracts           db.go:1618:1                        38   https://github.com/Icehunter/dune-admin/issues/24
 handleBGBackupUpload           handlers_battlegroup.go:203:1       37   https://github.com/Icehunter/dune-admin/issues/25

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-checkInventoryCapacity         db.go:476:1                         37   https://github.com/Icehunter/dune-admin/issues/26
 handleMarketItems              handlers_market.go:12:1             34   https://github.com/Icehunter/dune-admin/issues/27
 cmdAwardCharXP                 db.go:2723:1                        33   https://github.com/Icehunter/dune-admin/issues/28
 cmdProgressionUnlock           db.go:2314:1                        32   https://github.com/Icehunter/dune-admin/issues/29

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,5 +1,4 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-cmdSampleTable                 db.go:1277:1                        16   https://github.com/Icehunter/dune-admin/issues/50
 cmdGrantAllKeystones           db.go:3015:1                        16   https://github.com/Icehunter/dune-admin/issues/51

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-handleMarketItems              handlers_market.go:12:1             34   https://github.com/Icehunter/dune-admin/issues/27
 cmdAwardCharXP                 db.go:2723:1                        33   https://github.com/Icehunter/dune-admin/issues/28
 cmdProgressionUnlock           db.go:2314:1                        32   https://github.com/Icehunter/dune-admin/issues/29
 cmdReverseProgressionUnlock    db.go:2457:1                        32   https://github.com/Icehunter/dune-admin/issues/30

--- a/.gocognit-ignore
+++ b/.gocognit-ignore
@@ -1,7 +1,6 @@
 # Functions excluded from the gocognit complexity gate.
 # Each entry has a GitHub issue tracking the refactor work.
 # Format: FuncName  file:line  score  issue-url
-importBlueprintData            handlers_blueprints.go:274:1        41   https://github.com/Icehunter/dune-admin/issues/23
 cmdCompleteContracts           db.go:1618:1                        38   https://github.com/Icehunter/dune-admin/issues/24
 handleBGBackupUpload           handlers_battlegroup.go:203:1       37   https://github.com/Icehunter/dune-admin/issues/25
 checkInventoryCapacity         db.go:476:1                         37   https://github.com/Icehunter/dune-admin/issues/26

--- a/cmd/dune-admin/connection_test.go
+++ b/cmd/dune-admin/connection_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+func TestResolveControl(t *testing.T) {
+	origControlPlane := controlPlane
+	origSSHHost := sshHost
+	t.Cleanup(func() {
+		controlPlane = origControlPlane
+		sshHost = origSSHHost
+	})
+
+	controlPlane = "amp"
+	sshHost = ""
+	if got := resolveControl(); got != "amp" {
+		t.Fatalf("expected explicit control plane to win, got %q", got)
+	}
+
+	controlPlane = ""
+	sshHost = "vm.example:22"
+	if got := resolveControl(); got != "kubectl" {
+		t.Fatalf("expected ssh host to default control to kubectl, got %q", got)
+	}
+
+	controlPlane = ""
+	sshHost = ""
+	if got := resolveControl(); got != "local" {
+		t.Fatalf("expected local default without ssh/control flags, got %q", got)
+	}
+}

--- a/cmd/dune-admin/control_amp.go
+++ b/cmd/dune-admin/control_amp.go
@@ -99,6 +99,40 @@ type ampGameProcess struct {
 	partition int
 }
 
+func parseAMPMapName(argsFields []string) string {
+	for i, field := range argsFields {
+		if field == "DuneSandbox" && i+1 < len(argsFields) {
+			return argsFields[i+1]
+		}
+	}
+	return ""
+}
+
+func parseAMPArgInt(re *regexp.Regexp, args string) int {
+	m := re.FindStringSubmatch(args)
+	if len(m) <= 1 {
+		return 0
+	}
+	value, _ := strconv.Atoi(m[1])
+	return value
+}
+
+func parseAMPGameProcess(line string) (ampGameProcess, bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return ampGameProcess{}, false
+	}
+	pid, _ := strconv.Atoi(fields[0])
+	argsFields := fields[1:]
+	args := strings.Join(argsFields, " ")
+	return ampGameProcess{
+		pid:       pid,
+		mapName:   parseAMPMapName(argsFields),
+		port:      parseAMPArgInt(ampPortRe, args),
+		partition: parseAMPArgInt(ampPartRe, args),
+	}, true
+}
+
 func (c *ampControl) listGameProcesses(exec Executor) ([]ampGameProcess, error) {
 	out, err := exec.Exec(`ps -eo pid,args --no-headers 2>/dev/null | grep 'DuneSandboxServer-Linux-Shipping' | grep -v grep`)
 	if err != nil && strings.TrimSpace(out) == "" {
@@ -106,31 +140,14 @@ func (c *ampControl) listGameProcesses(exec Executor) ([]ampGameProcess, error) 
 	}
 	var procs []ampGameProcess
 	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		if line == "" {
+		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
+		proc, ok := parseAMPGameProcess(line)
+		if !ok {
 			continue
 		}
-		pid, _ := strconv.Atoi(fields[0])
-		args := strings.Join(fields[1:], " ")
-		mapName := ""
-		for i, p := range fields[1:] {
-			if p == "DuneSandbox" && i+1 < len(fields[1:]) {
-				mapName = fields[1+i+1]
-				break
-			}
-		}
-		port := 0
-		if m := ampPortRe.FindStringSubmatch(args); len(m) > 1 {
-			port, _ = strconv.Atoi(m[1])
-		}
-		partition := 0
-		if m := ampPartRe.FindStringSubmatch(args); len(m) > 1 {
-			partition, _ = strconv.Atoi(m[1])
-		}
-		procs = append(procs, ampGameProcess{pid: pid, mapName: mapName, port: port, partition: partition})
+		procs = append(procs, proc)
 	}
 	return procs, nil
 }

--- a/cmd/dune-admin/control_amp_test.go
+++ b/cmd/dune-admin/control_amp_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"net"
+	"testing"
+)
+
+type fakeAMPExecutor struct {
+	out string
+	err error
+	cmd string
+}
+
+func (f *fakeAMPExecutor) Exec(cmd string) (string, error) {
+	f.cmd = cmd
+	return f.out, f.err
+}
+func (f *fakeAMPExecutor) Stream(string) (<-chan string, func(), error) {
+	return nil, func() {}, nil
+}
+func (f *fakeAMPExecutor) PipeToWriter(string, io.Writer) error { return nil }
+func (f *fakeAMPExecutor) WriteFile(string, io.Reader) error    { return nil }
+func (f *fakeAMPExecutor) Dial(string, string) (net.Conn, error) {
+	return nil, nil
+}
+func (f *fakeAMPExecutor) Close()       {}
+func (f *fakeAMPExecutor) Type() string { return "local" }
+
+func TestParseAMPGameProcess(t *testing.T) {
+	t.Parallel()
+
+	line := "123 /srv/DuneSandboxServer-Linux-Shipping DuneSandbox HaggaBasinS -Port=7777 -PartitionIndex=3"
+	got, ok := parseAMPGameProcess(line)
+	if !ok {
+		t.Fatalf("expected line to parse")
+	}
+	if got.pid != 123 || got.mapName != "HaggaBasinS" || got.port != 7777 || got.partition != 3 {
+		t.Fatalf("unexpected parsed process: %+v", got)
+	}
+
+	if _, ok := parseAMPGameProcess("garbage"); ok {
+		t.Fatalf("expected malformed line to be rejected")
+	}
+}
+
+func TestListGameProcesses(t *testing.T) {
+	t.Parallel()
+
+	ctrl := &ampControl{}
+	exec := &fakeAMPExecutor{
+		out: "100 one DuneSandbox MapA -Port=7001 -PartitionIndex=1\nbad\n200 two DuneSandbox MapB -Port=7002",
+	}
+	procs, err := ctrl.listGameProcesses(exec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(procs) != 2 {
+		t.Fatalf("expected 2 parsed processes, got %d", len(procs))
+	}
+	if procs[0].pid != 100 || procs[0].mapName != "MapA" || procs[0].port != 7001 || procs[0].partition != 1 {
+		t.Fatalf("unexpected first process: %+v", procs[0])
+	}
+	if procs[1].pid != 200 || procs[1].mapName != "MapB" || procs[1].port != 7002 || procs[1].partition != 0 {
+		t.Fatalf("unexpected second process: %+v", procs[1])
+	}
+	if exec.cmd == "" {
+		t.Fatalf("expected process listing command to be executed")
+	}
+}
+
+func TestListGameProcesses_EmptyOnExecErrorWithoutOutput(t *testing.T) {
+	t.Parallel()
+
+	ctrl := &ampControl{}
+	exec := &fakeAMPExecutor{err: errors.New("ps failed")}
+	procs, err := ctrl.listGameProcesses(exec)
+	if err != nil {
+		t.Fatalf("expected no error when exec fails without output, got %v", err)
+	}
+	if len(procs) != 0 {
+		t.Fatalf("expected empty process list, got %+v", procs)
+	}
+}

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -3830,55 +3830,82 @@ func cmdRepairPlayerGear(playerID int64) Cmd {
 	}
 }
 
-func cmdRepairVehicle(playerID, vehicleID int64) Cmd {
-	return func() Msg {
-		if globalDB == nil {
-			return msgRepairVehicle{err: fmt.Errorf("not connected")}
-		}
-		if playerID == 0 {
-			return msgRepairVehicle{err: fmt.Errorf("player ID required")}
-		}
-		ctx := context.Background()
-		if err := checkPlayerOffline(ctx, playerID); err != nil {
-			return msgRepairVehicle{err: err}
-		}
+func validateRepairVehicleInput(playerID int64) error {
+	if globalDB == nil {
+		return fmt.Errorf("not connected")
+	}
+	if playerID == 0 {
+		return fmt.Errorf("player ID required")
+	}
+	return nil
+}
 
-		rows, err := globalDB.Query(ctx, `
+type vehicleModule struct {
+	id         int64
+	templateID string
+}
+
+func loadVehicleModules(ctx context.Context, vehicleID int64) ([]vehicleModule, error) {
+	rows, err := globalDB.Query(ctx, `
 			SELECT id, template_id
 			FROM dune.vehicle_modules
 			WHERE vehicle_id = $1::bigint`, vehicleID)
-		if err != nil {
-			return msgRepairVehicle{err: fmt.Errorf("scan modules: %w", err)}
-		}
-		defer rows.Close()
+	if err != nil {
+		return nil, fmt.Errorf("scan modules: %w", err)
+	}
+	defer rows.Close()
 
-		type moduleRow struct {
-			id         int64
-			templateID string
+	var modules []vehicleModule
+	for rows.Next() {
+		var module vehicleModule
+		if err := rows.Scan(&module.id, &module.templateID); err != nil {
+			return nil, fmt.Errorf("scan module: %w", err)
 		}
-		var modules []moduleRow
-		for rows.Next() {
-			var m moduleRow
-			if err := rows.Scan(&m.id, &m.templateID); err != nil {
-				return msgRepairVehicle{err: fmt.Errorf("scan module: %w", err)}
-			}
-			modules = append(modules, m)
-		}
-		if err := rows.Err(); err != nil {
-			return msgRepairVehicle{err: err}
-		}
+		modules = append(modules, module)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return modules, nil
+}
 
-		total := len(modules)
-		repaired := 0
-		skipped := 0
-		for _, m := range modules {
-			target, ok := itemMaxDurability(m.templateID)
-			if !ok || target <= 0 {
-				skipped++
-				continue
-			}
-			// Both fields must be written — Current-only is clamped to surviving Decayed on reload.
-			_, err := globalDB.Exec(ctx, `
+type vehicleRepairSummary struct {
+	repaired int
+	skipped  int
+	total    int
+	err      error
+}
+
+func vehicleRepairTarget(templateID string) (float64, bool) {
+	target, ok := itemMaxDurability(templateID)
+	if !ok || target <= 0 {
+		return 0, false
+	}
+	return target, true
+}
+
+func runVehicleModuleRepairs(
+	modules []vehicleModule,
+	update func(module vehicleModule, target float64) error,
+) vehicleRepairSummary {
+	summary := vehicleRepairSummary{total: len(modules)}
+	for _, module := range modules {
+		target, ok := vehicleRepairTarget(module.templateID)
+		if !ok {
+			summary.skipped++
+			continue
+		}
+		if err := update(module, target); err != nil {
+			summary.err = fmt.Errorf("repair module %d: %w", module.id, err)
+			return summary
+		}
+		summary.repaired++
+	}
+	return summary
+}
+
+func updateVehicleModuleDurability(ctx context.Context, moduleID int64, target float64) error {
+	_, err := globalDB.Exec(ctx, `
 				UPDATE dune.vehicle_modules
 				SET stats = jsonb_set(
 					jsonb_set(stats,
@@ -3886,13 +3913,30 @@ func cmdRepairVehicle(playerID, vehicleID int64) Cmd {
 						to_jsonb($2::float8), true),
 					'{FVehicleModuleDurabilityStats,1,DecayedMaxDurability}',
 					to_jsonb($2::float8), true)
-				WHERE id = $1::bigint`, m.id, target)
-			if err != nil {
-				return msgRepairVehicle{repaired: repaired, skipped: skipped, total: total, err: fmt.Errorf("repair module %d: %w", m.id, err)}
-			}
-			repaired++
+				WHERE id = $1::bigint`, moduleID, target)
+	return err
+}
+
+func cmdRepairVehicle(playerID, vehicleID int64) Cmd {
+	return func() Msg {
+		if err := validateRepairVehicleInput(playerID); err != nil {
+			return msgRepairVehicle{err: err}
 		}
-		return msgRepairVehicle{repaired: repaired, skipped: skipped, total: total}
+		ctx := context.Background()
+		if err := checkPlayerOffline(ctx, playerID); err != nil {
+			return msgRepairVehicle{err: err}
+		}
+
+		modules, err := loadVehicleModules(ctx, vehicleID)
+		if err != nil {
+			return msgRepairVehicle{err: err}
+		}
+
+		summary := runVehicleModuleRepairs(modules, func(module vehicleModule, target float64) error {
+			// Both fields must be written — Current-only is clamped to surviving Decayed on reload.
+			return updateVehicleModuleDurability(ctx, module.id, target)
+		})
+		return msgRepairVehicle(summary)
 	}
 }
 

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -3398,37 +3398,25 @@ func keystoneSPBonus(ids []int16) int64 {
 	return total
 }
 
-func cmdGrantAllKeystones(playerID int64) Cmd {
-	return func() Msg {
-		if globalDB == nil {
-			return msgMutate{err: fmt.Errorf("not connected")}
-		}
-		ctx := context.Background()
-
-		if err := checkPlayerOffline(ctx, playerID); err != nil {
-			return msgMutate{err: err}
-		}
-
-		var err error
-		_, err = globalDB.Exec(ctx, `
+func insertAllPurchasedKeystones(ctx context.Context, playerID int64) error {
+	_, err := globalDB.Exec(ctx, `
 			INSERT INTO dune.purchased_specialization_keystones (player_id, keystone_id)
 			SELECT $1::bigint, generate_series(1, 205)
 			ON CONFLICT DO NOTHING`, playerID)
-		if err != nil {
-			return msgMutate{err: err}
-		}
+	return err
+}
 
-		// Compute the SP bonus all 205 purchased keystones should give.
-		allIDs := make([]int16, 205)
-		for i := range allIDs {
-			allIDs[i] = int16(i + 1)
-		}
-		keystoneBonus := keystoneSPBonus(allIDs)
+func allKeystoneIDs() []int16 {
+	ids := make([]int16, 205)
+	for i := range ids {
+		ids[i] = int16(i + 1)
+	}
+	return ids
+}
 
-		// Read XP, current TotalSkillPoints, and SP spent in non-starter modules.
-		// Uses pawn actor id (purchased_specialization_keystones uses controller id).
-		var xp, currentTotal, spentSP int64
-		err = globalDB.QueryRow(ctx, `
+func readLevelComponentSkillState(ctx context.Context, playerID int64) (int64, int64, int64, error) {
+	var xp, currentTotal, spentSP int64
+	err := globalDB.QueryRow(ctx, `
 			SELECT
 				(fe.components->'FLevelComponent'->1->>'TotalXPEarned')::bigint,
 				(fe.components->'FLevelComponent'->1->>'TotalSkillPoints')::bigint,
@@ -3445,25 +3433,26 @@ func cmdGrantAllKeystones(playerID int64) Cmd {
 				SELECT player_pawn_id FROM dune.player_state
 				WHERE player_controller_id = $1 LIMIT 1
 			  )`, playerID).Scan(&xp, &currentTotal, &spentSP)
-		if err != nil {
-			return msgMutate{err: fmt.Errorf("read FLevelComponent: %w", err)}
-		}
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("read FLevelComponent: %w", err)
+	}
+	return xp, currentTotal, spentSP, nil
+}
 
-		level := int64(xpToLevel(xp))
-		expectedTotal := level + keystoneBonus
-		// UnspentSkillPoints = total - non-starter spent - 1 (starter job always occupies 1 SP).
-		expectedUnspent := expectedTotal - spentSP - 1
-		if expectedUnspent < 0 {
-			expectedUnspent = 0
-		}
+func grantAllKeystoneTargets(xp, spentSP int64) (int64, int64, int64) {
+	keystoneBonus := keystoneSPBonus(allKeystoneIDs())
+	level := int64(xpToLevel(xp))
+	expectedTotal := level + keystoneBonus
+	// UnspentSkillPoints = total - non-starter spent - 1 (starter job always occupies 1 SP).
+	expectedUnspent := expectedTotal - spentSP - 1
+	if expectedUnspent < 0 {
+		expectedUnspent = 0
+	}
+	return expectedTotal, expectedUnspent, keystoneBonus
+}
 
-		if currentTotal >= expectedTotal {
-			return msgMutate{ok: fmt.Sprintf(
-				"Granted all keystones to player %d — SP already correct (%d total, %d unspent)",
-				playerID, currentTotal, expectedUnspent)}
-		}
-
-		_, err = globalDB.Exec(ctx, `
+func updateLevelComponentSkillPoints(ctx context.Context, playerID, expectedTotal, expectedUnspent int64) error {
+	_, err := globalDB.Exec(ctx, `
 			UPDATE dune.fgl_entities
 			SET components = jsonb_set(jsonb_set(
 				components,
@@ -3479,8 +3468,44 @@ func cmdGrantAllKeystones(playerID int64) Cmd {
 					WHERE player_controller_id = $1 LIMIT 1
 				  )
 			)`, playerID, expectedTotal, expectedUnspent)
+	if err != nil {
+		return fmt.Errorf("update skill points: %w", err)
+	}
+	return nil
+}
+
+func cmdGrantAllKeystones(playerID int64) Cmd {
+	return func() Msg {
+		if globalDB == nil {
+			return msgMutate{err: fmt.Errorf("not connected")}
+		}
+		ctx := context.Background()
+
+		if err := checkPlayerOffline(ctx, playerID); err != nil {
+			return msgMutate{err: err}
+		}
+
+		if err := insertAllPurchasedKeystones(ctx, playerID); err != nil {
+			return msgMutate{err: err}
+		}
+
+		// Read XP, current TotalSkillPoints, and SP spent in non-starter modules.
+		// Uses pawn actor id (purchased_specialization_keystones uses controller id).
+		xp, currentTotal, spentSP, err := readLevelComponentSkillState(ctx, playerID)
 		if err != nil {
-			return msgMutate{err: fmt.Errorf("update skill points: %w", err)}
+			return msgMutate{err: err}
+		}
+
+		expectedTotal, expectedUnspent, keystoneBonus := grantAllKeystoneTargets(xp, spentSP)
+
+		if currentTotal >= expectedTotal {
+			return msgMutate{ok: fmt.Sprintf(
+				"Granted all keystones to player %d — SP already correct (%d total, %d unspent)",
+				playerID, currentTotal, expectedUnspent)}
+		}
+
+		if err := updateLevelComponentSkillPoints(ctx, playerID, expectedTotal, expectedUnspent); err != nil {
+			return msgMutate{err: err}
 		}
 
 		return msgMutate{ok: fmt.Sprintf(

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -3607,33 +3607,24 @@ func cmdGetPlayerVehicles(controllerID int64) Cmd {
 	}
 }
 
-func cmdRepairItem(itemID int64) Cmd {
-	return func() Msg {
-		if globalDB == nil {
-			return msgMutate{err: fmt.Errorf("not connected")}
-		}
-		ctx := context.Background()
-
-		// Derive owning player from item → inventory → actor (pawn) so we can gate Offline.
-		var pawnID int64
-		err := globalDB.QueryRow(ctx, `
+func lookupRepairItemOwner(ctx context.Context, itemID int64) (int64, error) {
+	var pawnID int64
+	err := globalDB.QueryRow(ctx, `
 			SELECT inv.actor_id
 			FROM dune.items i
 			JOIN dune.inventories inv ON inv.id = i.inventory_id
 			WHERE i.id = $1::bigint`, itemID).Scan(&pawnID)
-		if errors.Is(err, pgx.ErrNoRows) {
-			return msgMutate{err: fmt.Errorf("item %d not found", itemID)}
-		}
-		if err != nil {
-			return msgMutate{err: fmt.Errorf("look up item owner: %w", err)}
-		}
-		if err := checkPlayerOffline(ctx, pawnID); err != nil {
-			return msgMutate{err: err}
-		}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, fmt.Errorf("item %d not found", itemID)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("look up item owner: %w", err)
+	}
+	return pawnID, nil
+}
 
-		// Write both fields: Current-only gets clamped to surviving Decayed on reload.
-		// Fallback target = 100.0 covers the 0-100 gear scale when MaxDurability is absent.
-		res, err := globalDB.Exec(ctx, `
+func repairItemDurability(ctx context.Context, itemID int64) (int64, error) {
+	res, err := globalDB.Exec(ctx, `
 			UPDATE dune.items i
 			SET stats = jsonb_set(
 				jsonb_set(i.stats,
@@ -3655,23 +3646,64 @@ func cmdRepairItem(itemID int64) Cmd {
 				abs(COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0) - t.val) > 0.01
 				OR abs(COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0) - t.val) > 0.01
 			  )`, itemID)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected(), nil
+}
+
+func itemHasDurabilityStats(ctx context.Context, itemID int64) (bool, error) {
+	var hasDurability bool
+	if err := globalDB.QueryRow(ctx, `
+				SELECT stats ? 'FItemStackAndDurabilityStats'
+				FROM dune.items WHERE id = $1::bigint`, itemID).Scan(&hasDurability); err != nil {
+		return false, fmt.Errorf("check item: %w", err)
+	}
+	return hasDurability, nil
+}
+
+func repairItemNoChangeMessage(itemID int64, hasDurability bool) msgMutate {
+	if !hasDurability {
+		return msgMutate{err: fmt.Errorf("item %d has no durability field", itemID)}
+	}
+	return msgMutate{ok: fmt.Sprintf("Item %d already at full durability", itemID)}
+}
+
+func repairItemSuccessMessage(itemID int64) msgMutate {
+	return msgMutate{ok: fmt.Sprintf("Repaired item %d — relog to see in-game", itemID)}
+}
+
+func cmdRepairItem(itemID int64) Cmd {
+	return func() Msg {
+		if globalDB == nil {
+			return msgMutate{err: fmt.Errorf("not connected")}
+		}
+		ctx := context.Background()
+
+		// Derive owning player from item → inventory → actor (pawn) so we can gate Offline.
+		pawnID, err := lookupRepairItemOwner(ctx, itemID)
+		if err != nil {
+			return msgMutate{err: err}
+		}
+		if err := checkPlayerOffline(ctx, pawnID); err != nil {
+			return msgMutate{err: err}
+		}
+
+		// Write both fields: Current-only gets clamped to surviving Decayed on reload.
+		// Fallback target = 100.0 covers the 0-100 gear scale when MaxDurability is absent.
+		rowsAffected, err := repairItemDurability(ctx, itemID)
 		if err != nil {
 			return msgMutate{err: fmt.Errorf("repair item: %w", err)}
 		}
-		if res.RowsAffected() == 0 {
+		if rowsAffected == 0 {
 			// Item exists (owner lookup succeeded). Either no durability field, or already at ceiling.
-			var hasDur bool
-			if err := globalDB.QueryRow(ctx, `
-				SELECT stats ? 'FItemStackAndDurabilityStats'
-				FROM dune.items WHERE id = $1::bigint`, itemID).Scan(&hasDur); err != nil {
-				return msgMutate{err: fmt.Errorf("check item: %w", err)}
+			hasDurability, err := itemHasDurabilityStats(ctx, itemID)
+			if err != nil {
+				return msgMutate{err: err}
 			}
-			if !hasDur {
-				return msgMutate{err: fmt.Errorf("item %d has no durability field", itemID)}
-			}
-			return msgMutate{ok: fmt.Sprintf("Item %d already at full durability", itemID)}
+			return repairItemNoChangeMessage(itemID, hasDurability)
 		}
-		return msgMutate{ok: fmt.Sprintf("Repaired item %d — relog to see in-game", itemID)}
+		return repairItemSuccessMessage(itemID)
 	}
 }
 

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -1776,6 +1776,118 @@ func cmdCompleteContracts(accountID int64, contractIDs []string) Cmd {
 	}
 }
 
+func validateContractMutationInput(accountID int64, contractIDs []string) error {
+	if accountID == 0 {
+		return fmt.Errorf("account ID required")
+	}
+	if len(contractIDs) == 0 {
+		return fmt.Errorf("at least one contract required")
+	}
+	return nil
+}
+
+type contractRemovalSet struct {
+	resolvedNames []string
+	removeTags    []string
+	removeSkills  []string
+}
+
+func buildContractRemovalSet(contractIDs []string) (contractRemovalSet, error) {
+	seenTag := map[string]bool{}
+	seenSkill := map[string]bool{}
+	set := contractRemovalSet{
+		resolvedNames: make([]string, 0, len(contractIDs)),
+		removeTags:    make([]string, 0, len(contractIDs)),
+		removeSkills:  make([]string, 0, len(contractIDs)),
+	}
+
+	for _, id := range contractIDs {
+		name, tags, err := resolveContractTags(id)
+		if err != nil {
+			return contractRemovalSet{}, err
+		}
+		set.resolvedNames = append(set.resolvedNames, name)
+		for _, tag := range tags {
+			if seenTag[tag] {
+				continue
+			}
+			seenTag[tag] = true
+			set.removeTags = append(set.removeTags, tag)
+		}
+		for _, skill := range tagsData.ContractSkillGrants[name] {
+			if seenSkill[skill] {
+				continue
+			}
+			seenSkill[skill] = true
+			set.removeSkills = append(set.removeSkills, skill)
+		}
+	}
+
+	return set, nil
+}
+
+func removeContractTags(ctx context.Context, accountID int64, removeTags []string) error {
+	if len(removeTags) == 0 {
+		return nil
+	}
+	if _, err := globalDB.Exec(ctx,
+		`SELECT dune.update_player_tags($1, '{}'::text[], $2::text[])`,
+		accountID, removeTags); err != nil {
+		return fmt.Errorf("remove tags: %w", err)
+	}
+	return nil
+}
+
+func loadContractPawnID(ctx context.Context, accountID int64) int64 {
+	var pawnID int64
+	_ = globalDB.QueryRow(ctx,
+		`SELECT player_pawn_id FROM dune.player_state WHERE account_id = $1 LIMIT 1`,
+		accountID).Scan(&pawnID)
+	return pawnID
+}
+
+func stripContractSkillBlocks(ctx context.Context, pawnID int64, removeSkills []string) (int, error) {
+	if pawnID == 0 || len(removeSkills) == 0 {
+		return 0, nil
+	}
+
+	stripped := 0
+	for _, skill := range removeSkills {
+		key := fmt.Sprintf(`(TagName="%s")`, skill)
+		tag, err := globalDB.Exec(ctx, `
+			UPDATE dune.fgl_entities fe
+			SET components = jsonb_set(
+				fe.components,
+				ARRAY['FLevelComponent','1','ModuleData'],
+				(fe.components->'FLevelComponent'->1->'ModuleData') - $2::text)
+			WHERE fe.entity_id = (
+				SELECT entity_id FROM dune.actor_fgl_entities
+				WHERE actor_id = $1 AND slot_name = 'DuneCharacter'
+			)
+			AND COALESCE(
+				(fe.components->'FLevelComponent'->1->'ModuleData'->$2->>'SkillPointsSpent')::int,
+				0
+			) <= 1`,
+			pawnID, key)
+		if err != nil {
+			return 0, fmt.Errorf("strip %s: %w", skill, err)
+		}
+		if tag.RowsAffected() > 0 {
+			stripped++
+		}
+	}
+
+	return stripped, nil
+}
+
+func contractBatchSummary(resolvedNames []string) string {
+	summary := resolvedNames[0]
+	if len(resolvedNames) > 1 {
+		summary = fmt.Sprintf("%d contracts", len(resolvedNames))
+	}
+	return summary
+}
+
 // cmdReverseContracts removes the AddedFlagsOnCompletion tags and strips the
 // Skills.Key.* ModuleData entries that cmdCompleteContracts wrote. Skill blocks
 // are only removed when SkillPointsSpent <= 1 — branches the player genuinely
@@ -1785,90 +1897,30 @@ func cmdReverseContracts(accountID int64, contractIDs []string) Cmd {
 		if globalDB == nil {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
-		if accountID == 0 {
-			return msgMutate{err: fmt.Errorf("account ID required")}
-		}
-		if len(contractIDs) == 0 {
-			return msgMutate{err: fmt.Errorf("at least one contract required")}
+		if err := validateContractMutationInput(accountID, contractIDs); err != nil {
+			return msgMutate{err: err}
 		}
 
-		seenTag := map[string]bool{}
-		var removeTags []string
-		seenSkill := map[string]bool{}
-		var removeSkills []string
-		var resolved []string
-
-		for _, id := range contractIDs {
-			name, tags, err := resolveContractTags(id)
-			if err != nil {
-				return msgMutate{err: err}
-			}
-			resolved = append(resolved, name)
-			for _, t := range tags {
-				if !seenTag[t] {
-					seenTag[t] = true
-					removeTags = append(removeTags, t)
-				}
-			}
-			for _, sk := range tagsData.ContractSkillGrants[name] {
-				if !seenSkill[sk] {
-					seenSkill[sk] = true
-					removeSkills = append(removeSkills, sk)
-				}
-			}
+		set, err := buildContractRemovalSet(contractIDs)
+		if err != nil {
+			return msgMutate{err: err}
 		}
 
 		ctx := context.Background()
-
-		if len(removeTags) > 0 {
-			if _, err := globalDB.Exec(ctx,
-				`SELECT dune.update_player_tags($1, '{}'::text[], $2::text[])`,
-				accountID, removeTags); err != nil {
-				return msgMutate{err: fmt.Errorf("remove tags: %w", err)}
-			}
+		if err := removeContractTags(ctx, accountID, set.removeTags); err != nil {
+			return msgMutate{err: err}
 		}
 
-		stripped := 0
-		if len(removeSkills) > 0 {
-			var pawnID int64
-			_ = globalDB.QueryRow(ctx,
-				`SELECT player_pawn_id FROM dune.player_state WHERE account_id = $1 LIMIT 1`,
-				accountID).Scan(&pawnID)
-			if pawnID != 0 {
-				for _, sk := range removeSkills {
-					key := fmt.Sprintf(`(TagName="%s")`, sk)
-					tag, err := globalDB.Exec(ctx, `
-						UPDATE dune.fgl_entities fe
-						SET components = jsonb_set(
-							fe.components,
-							ARRAY['FLevelComponent','1','ModuleData'],
-							(fe.components->'FLevelComponent'->1->'ModuleData') - $2::text)
-						WHERE fe.entity_id = (
-							SELECT entity_id FROM dune.actor_fgl_entities
-							WHERE actor_id = $1 AND slot_name = 'DuneCharacter'
-						)
-						AND COALESCE(
-							(fe.components->'FLevelComponent'->1->'ModuleData'->$2->>'SkillPointsSpent')::int,
-							0
-						) <= 1`,
-						pawnID, key)
-					if err != nil {
-						return msgMutate{err: fmt.Errorf("strip %s: %w", sk, err)}
-					}
-					if tag.RowsAffected() > 0 {
-						stripped++
-					}
-				}
-			}
+		pawnID := loadContractPawnID(ctx, accountID)
+		stripped, err := stripContractSkillBlocks(ctx, pawnID, set.removeSkills)
+		if err != nil {
+			return msgMutate{err: err}
 		}
 
-		summary := resolved[0]
-		if len(resolved) > 1 {
-			summary = fmt.Sprintf("%d contracts", len(resolved))
-		}
+		summary := contractBatchSummary(set.resolvedNames)
 		return msgMutate{ok: fmt.Sprintf(
 			"Reversed %s: removed %d tag(s), stripped %d skill block(s) — takes effect on next login",
-			summary, len(removeTags), stripped)}
+			summary, len(set.removeTags), stripped)}
 	}
 }
 

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -1708,70 +1708,39 @@ func cmdCompleteContracts(accountID int64, contractIDs []string) Cmd {
 		if globalDB == nil {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
-		if accountID == 0 {
-			return msgMutate{err: fmt.Errorf("account ID required")}
-		}
-		if len(contractIDs) == 0 {
-			return msgMutate{err: fmt.Errorf("at least one contract required")}
+		if err := validateContractMutationInput(accountID, contractIDs); err != nil {
+			return msgMutate{err: err}
 		}
 
-		seenTag := map[string]bool{}
-		var allTags []string
-		seenSkill := map[string]bool{}
-		var allSkillGrants []string
-		var resolved []string
-		for _, id := range contractIDs {
-			name, tags, err := resolveContractTags(id)
-			if err != nil {
-				return msgMutate{err: err}
-			}
-			resolved = append(resolved, name)
-			for _, t := range tags {
-				if !seenTag[t] {
-					seenTag[t] = true
-					allTags = append(allTags, t)
-				}
-			}
-			for _, sk := range tagsData.ContractSkillGrants[name] {
-				if !seenSkill[sk] {
-					seenSkill[sk] = true
-					allSkillGrants = append(allSkillGrants, sk)
-				}
-			}
-		}
-
-		ctx := context.Background()
-		extra, err := applyTagsWithTierBump(ctx, accountID, allTags)
+		set, err := buildContractRemovalSet(contractIDs)
 		if err != nil {
 			return msgMutate{err: err}
 		}
 
-		if len(allSkillGrants) > 0 {
-			grantedExtra, err := grantSkillBlocks(ctx, accountID, allSkillGrants)
-			if err != nil {
-				return msgMutate{err: err}
-			}
-			extra += grantedExtra
+		ctx := context.Background()
+		extra, err := applyTagsWithTierBump(ctx, accountID, set.removeTags)
+		if err != nil {
+			return msgMutate{err: err}
 		}
+
+		grantedExtra, err := applyContractSkillGrants(ctx, accountID, set.removeSkills)
+		if err != nil {
+			return msgMutate{err: err}
+		}
+		extra += grantedExtra
 
 		// Strip any in-progress ContractItem rows so the in-game quest
 		// tracker doesn't keep showing the conditions for a contract we just
 		// force-completed. ContractName.Name uses the short alias form
 		// (no DA_CT_ prefix).
-		shortNames := make([]string, 0, len(resolved))
-		for _, full := range resolved {
-			shortNames = append(shortNames, strings.TrimPrefix(full, "DA_CT_"))
-		}
+		shortNames := contractShortNames(set.resolvedNames)
 		dismissedExtra, err := dismissActiveContracts(ctx, accountID, shortNames)
 		if err != nil {
 			return msgMutate{err: err}
 		}
 		extra += dismissedExtra
 
-		summary := resolved[0]
-		if len(resolved) > 1 {
-			summary = fmt.Sprintf("%d contracts", len(resolved))
-		}
+		summary := contractBatchSummary(set.resolvedNames)
 		return msgMutate{ok: fmt.Sprintf("Applied %s%s — takes effect on next login", summary, extra)}
 	}
 }
@@ -1824,6 +1793,21 @@ func buildContractRemovalSet(contractIDs []string) (contractRemovalSet, error) {
 	}
 
 	return set, nil
+}
+
+func applyContractSkillGrants(ctx context.Context, accountID int64, skills []string) (string, error) {
+	if len(skills) == 0 {
+		return "", nil
+	}
+	return grantSkillBlocks(ctx, accountID, skills)
+}
+
+func contractShortNames(resolvedNames []string) []string {
+	shortNames := make([]string, 0, len(resolvedNames))
+	for _, full := range resolvedNames {
+		shortNames = append(shortNames, strings.TrimPrefix(full, "DA_CT_"))
+	}
+	return shortNames
 }
 
 func removeContractTags(ctx context.Context, accountID int64, removeTags []string) error {

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -2868,6 +2868,15 @@ type msgCharXP struct {
 	err   error
 }
 
+type charXPOutcome struct {
+	newXP        int64
+	newLevel     int64
+	newTotalSP   int64
+	newUnspentSP int64
+	newIntel     int64
+	capped       bool
+}
+
 func cmdFetchCharXP(playerID int64) Cmd {
 	return func() Msg {
 		if globalDB == nil {
@@ -2886,6 +2895,143 @@ func cmdFetchCharXP(playerID int64) Cmd {
 	}
 }
 
+func readCharXPState(ctx context.Context, playerID int64) (currentXP, spentSP int64, err error) {
+	err = globalDB.QueryRow(ctx, `
+		SELECT
+			(fe.components->'FLevelComponent'->1->>'TotalXPEarned')::bigint,
+			COALESCE((
+				SELECT SUM((v->>'SkillPointsSpent')::int)
+				FROM jsonb_each(fe.components->'FLevelComponent'->1->'ModuleData') AS kv(k, v)
+				WHERE k != format('(TagName="%s")',
+					fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName')
+			), 0)
+		FROM dune.fgl_entities fe
+		JOIN dune.actor_fgl_entities afe ON afe.entity_id = fe.entity_id
+		WHERE afe.actor_id = $1 AND afe.slot_name = 'DuneCharacter'`, playerID).Scan(&currentXP, &spentSP)
+	if err != nil {
+		return 0, 0, fmt.Errorf("read current state: %w", err)
+	}
+	return currentXP, spentSP, nil
+}
+
+func resolveControllerIDForPawn(ctx context.Context, playerID int64) (int64, error) {
+	var controllerID int64
+	err := globalDB.QueryRow(ctx, `
+		SELECT player_controller_id FROM dune.player_state
+		WHERE player_pawn_id = $1 LIMIT 1`, playerID).Scan(&controllerID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("resolve controller id: %w", err)
+	}
+	return controllerID, nil
+}
+
+func loadControllerKeystoneIDs(ctx context.Context, controllerID int64) ([]int16, error) {
+	if controllerID == 0 {
+		return nil, nil
+	}
+	rows, err := globalDB.Query(ctx, `
+		SELECT keystone_id FROM dune.purchased_specialization_keystones
+		WHERE player_id = $1::bigint`, controllerID)
+	if err != nil {
+		return nil, fmt.Errorf("read keystones: %w", err)
+	}
+	defer rows.Close()
+
+	ids := make([]int16, 0, 8)
+	for rows.Next() {
+		var id int16
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan keystone: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("scan keystone: %w", err)
+	}
+	return ids, nil
+}
+
+func fetchKeystoneBonusForPawn(ctx context.Context, playerID int64) (int64, error) {
+	controllerID, err := resolveControllerIDForPawn(ctx, playerID)
+	if err != nil {
+		return 0, err
+	}
+	ids, err := loadControllerKeystoneIDs(ctx, controllerID)
+	if err != nil {
+		return 0, err
+	}
+	return keystoneSPBonus(ids), nil
+}
+
+func computeAwardCharXPOutcome(currentXP, spentSP, keystoneBonus, amount int64) charXPOutcome {
+	newXP := currentXP + amount
+	if newXP > maxCharXP {
+		newXP = maxCharXP
+	}
+	newLevel := int64(xpToLevel(newXP))
+	newTotalSP := newLevel + keystoneBonus
+	// Starter job always occupies 1 SP that is excluded from spentSP.
+	newUnspentSP := newTotalSP - spentSP - 1
+	if newUnspentSP < 0 {
+		newUnspentSP = 0
+	}
+	newIntel := intelAtLevel(int(newLevel))
+	return charXPOutcome{
+		newXP:        newXP,
+		newLevel:     newLevel,
+		newTotalSP:   newTotalSP,
+		newUnspentSP: newUnspentSP,
+		newIntel:     newIntel,
+		capped:       newXP == maxCharXP,
+	}
+}
+
+func applyAwardCharXPFLevelUpdate(ctx context.Context, playerID int64, outcome charXPOutcome) error {
+	_, err := globalDB.Exec(ctx, `
+		UPDATE dune.fgl_entities
+		SET components = jsonb_set(jsonb_set(jsonb_set(
+			components,
+			'{FLevelComponent,1,TotalXPEarned}',    to_jsonb($2::bigint)),
+			'{FLevelComponent,1,TotalSkillPoints}',  to_jsonb($3::bigint)),
+			'{FLevelComponent,1,UnspentSkillPoints}', to_jsonb($4::bigint))
+		WHERE entity_id = (
+			SELECT entity_id FROM dune.actor_fgl_entities
+			WHERE actor_id = $1 AND slot_name = 'DuneCharacter'
+		)`, playerID, outcome.newXP, outcome.newTotalSP, outcome.newUnspentSP)
+	if err != nil {
+		return fmt.Errorf("update fgl xp/sp: %w", err)
+	}
+	return nil
+}
+
+func applyAwardCharXPIntelUpdate(ctx context.Context, playerID int64, newIntel int64) error {
+	_, err := globalDB.Exec(ctx, `
+		UPDATE dune.actors
+		SET properties = jsonb_set(
+			properties,
+			'{TechKnowledgePlayerComponent,m_TechKnowledgePoints}',
+			to_jsonb($2::bigint))
+		WHERE id = $1 AND properties ? 'TechKnowledgePlayerComponent'`,
+		playerID, newIntel)
+	if err != nil {
+		return fmt.Errorf("update intel: %w", err)
+	}
+	return nil
+}
+
+func formatAwardCharXPSuccess(playerID int64, outcome charXPOutcome, spentSP int64) string {
+	capped := ""
+	if outcome.capped {
+		capped = " (capped at level 200)"
+	}
+	return fmt.Sprintf(
+		"Player %d → level %d%s | XP %d | SP %d unspent (%d spent) | Intel %d",
+		playerID, outcome.newLevel, capped, outcome.newXP, outcome.newUnspentSP, spentSP, outcome.newIntel)
+}
+
 func cmdAwardCharXP(playerID int64, amount int64) Cmd {
 	return func() Msg {
 		if globalDB == nil {
@@ -2899,104 +3045,29 @@ func cmdAwardCharXP(playerID int64, amount int64) Cmd {
 			return msgMutate{err: err}
 		}
 
-		// Read current XP and count of skill points already spent in the tree.
-		var currentXP, spentSP int64
-		err := globalDB.QueryRow(ctx, `
-			SELECT
-				(fe.components->'FLevelComponent'->1->>'TotalXPEarned')::bigint,
-				COALESCE((
-					SELECT SUM((v->>'SkillPointsSpent')::int)
-					FROM jsonb_each(fe.components->'FLevelComponent'->1->'ModuleData') AS kv(k, v)
-					WHERE k != format('(TagName="%s")',
-						fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName')
-				), 0)
-			FROM dune.fgl_entities fe
-			JOIN dune.actor_fgl_entities afe ON afe.entity_id = fe.entity_id
-			WHERE afe.actor_id = $1 AND afe.slot_name = 'DuneCharacter'`, playerID).Scan(&currentXP, &spentSP)
+		currentXP, spentSP, err := readCharXPState(ctx, playerID)
 		if err != nil {
-			return msgMutate{err: fmt.Errorf("read current state: %w", err)}
+			return msgMutate{err: err}
 		}
 
-		// Resolve controller id from the pawn id so we can read purchased
-		// keystones (which are keyed by controller id). A missing player_state
-		// row means no keystones could have been purchased — treat bonus as 0.
-		var keystoneBonus int64
-		var controllerID int64
-		err = globalDB.QueryRow(ctx, `
-			SELECT player_controller_id FROM dune.player_state
-			WHERE player_pawn_id = $1 LIMIT 1`, playerID).Scan(&controllerID)
-		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return msgMutate{err: fmt.Errorf("resolve controller id: %w", err)}
-		}
-		if controllerID != 0 {
-			rows, err := globalDB.Query(ctx, `
-				SELECT keystone_id FROM dune.purchased_specialization_keystones
-				WHERE player_id = $1::bigint`, controllerID)
-			if err != nil {
-				return msgMutate{err: fmt.Errorf("read keystones: %w", err)}
-			}
-			var ids []int16
-			for rows.Next() {
-				var id int16
-				if err := rows.Scan(&id); err != nil {
-					rows.Close()
-					return msgMutate{err: fmt.Errorf("scan keystone: %w", err)}
-				}
-				ids = append(ids, id)
-			}
-			rows.Close()
-			keystoneBonus = keystoneSPBonus(ids)
+		keystoneBonus, err := fetchKeystoneBonusForPawn(ctx, playerID)
+		if err != nil {
+			return msgMutate{err: err}
 		}
 
-		newXP := currentXP + amount
-		if newXP > maxCharXP {
-			newXP = maxCharXP
-		}
-		newLevel := int64(xpToLevel(newXP))
-		newTotalSP := newLevel + keystoneBonus
-		// Starter job always occupies 1 SP that is excluded from spentSP.
-		newUnspentSP := newTotalSP - spentSP - 1
-		if newUnspentSP < 0 {
-			newUnspentSP = 0
-		}
-		newIntel := intelAtLevel(int(newLevel))
+		outcome := computeAwardCharXPOutcome(currentXP, spentSP, keystoneBonus, amount)
 
 		// Update FLevelComponent: XP + both skill point fields.
-		_, err = globalDB.Exec(ctx, `
-			UPDATE dune.fgl_entities
-			SET components = jsonb_set(jsonb_set(jsonb_set(
-				components,
-				'{FLevelComponent,1,TotalXPEarned}',    to_jsonb($2::bigint)),
-				'{FLevelComponent,1,TotalSkillPoints}',  to_jsonb($3::bigint)),
-				'{FLevelComponent,1,UnspentSkillPoints}', to_jsonb($4::bigint))
-			WHERE entity_id = (
-				SELECT entity_id FROM dune.actor_fgl_entities
-				WHERE actor_id = $1 AND slot_name = 'DuneCharacter'
-			)`, playerID, newXP, newTotalSP, newUnspentSP)
-		if err != nil {
-			return msgMutate{err: fmt.Errorf("update fgl xp/sp: %w", err)}
+		if err := applyAwardCharXPFLevelUpdate(ctx, playerID, outcome); err != nil {
+			return msgMutate{err: err}
 		}
 
 		// Update intel points on the PlayerCharacter actor.
-		_, err = globalDB.Exec(ctx, `
-			UPDATE dune.actors
-			SET properties = jsonb_set(
-				properties,
-				'{TechKnowledgePlayerComponent,m_TechKnowledgePoints}',
-				to_jsonb($2::bigint))
-			WHERE id = $1 AND properties ? 'TechKnowledgePlayerComponent'`,
-			playerID, newIntel)
-		if err != nil {
-			return msgMutate{err: fmt.Errorf("update intel: %w", err)}
+		if err := applyAwardCharXPIntelUpdate(ctx, playerID, outcome.newIntel); err != nil {
+			return msgMutate{err: err}
 		}
 
-		capped := ""
-		if newXP == maxCharXP {
-			capped = " (capped at level 200)"
-		}
-		return msgMutate{ok: fmt.Sprintf(
-			"Player %d → level %d%s | XP %d | SP %d unspent (%d spent) | Intel %d",
-			playerID, newLevel, capped, newXP, newUnspentSP, spentSP, newIntel)}
+		return msgMutate{ok: formatAwardCharXPSuccess(playerID, outcome, spentSP)}
 	}
 }
 

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -1423,35 +1423,57 @@ func cmdDescribeTable(tbl string) Cmd {
 	}
 }
 
+func sampleTableQuery(tbl string, limit int) string {
+	// Sanitize table name defensively even though tbl comes from pg_stat_user_tables.
+	// pgx.Identifier handles quoting and escaping to prevent SQL injection.
+	safeTable := pgx.Identifier{dbSchema, tbl}.Sanitize()
+	return fmt.Sprintf("SELECT * FROM %s LIMIT %d", safeTable, limit)
+}
+
+func sampleTableHeaders(rows pgx.Rows) []string {
+	descriptions := rows.FieldDescriptions()
+	headers := make([]string, 0, len(descriptions))
+	for _, description := range descriptions {
+		headers = append(headers, description.Name)
+	}
+	return headers
+}
+
+func formatSampleRow(values []any) []string {
+	row := make([]string, 0, len(values))
+	for _, value := range values {
+		row = append(row, fmt.Sprintf("%v", value))
+	}
+	return row
+}
+
+func sampleTableRows(rows pgx.Rows) ([][]string, error) {
+	result := make([][]string, 0)
+	for rows.Next() {
+		values, err := rows.Values()
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, formatSampleRow(values))
+	}
+	return result, nil
+}
+
 func cmdSampleTable(tbl string, limit int) Cmd {
 	return func() Msg {
 		if globalDB == nil {
 			return msgSample{err: fmt.Errorf("not connected")}
 		}
-		// Sanitize table name defensively even though tbl comes from pg_stat_user_tables.
-		// pgx.Identifier handles quoting and escaping to prevent SQL injection.
-		safeTable := pgx.Identifier{dbSchema, tbl}.Sanitize()
-		rows, err := globalDB.Query(context.Background(),
-			fmt.Sprintf("SELECT * FROM %s LIMIT %d", safeTable, limit))
+		rows, err := globalDB.Query(context.Background(), sampleTableQuery(tbl, limit))
 		if err != nil {
 			return msgSample{table: tbl, err: err}
 		}
 		defer rows.Close()
-		var headers []string
-		for _, fd := range rows.FieldDescriptions() {
-			headers = append(headers, fd.Name)
-		}
-		var result [][]string
-		for rows.Next() {
-			vals, err := rows.Values()
-			if err != nil {
-				return msgSample{table: tbl, err: err}
-			}
-			var row []string
-			for _, v := range vals {
-				row = append(row, fmt.Sprintf("%v", v))
-			}
-			result = append(result, row)
+
+		headers := sampleTableHeaders(rows)
+		result, err := sampleTableRows(rows)
+		if err != nil {
+			return msgSample{table: tbl, err: err}
 		}
 		if err := rows.Err(); err != nil {
 			return msgSample{table: tbl, err: err}

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -557,6 +557,114 @@ func formatGiveItemResult(playerID int64, template string, qty int64, toppedUp, 
 	return msg
 }
 
+type inventoryCapacityProfile struct {
+	id           int64
+	maxSlots     int
+	maxVolume    float64
+	hasSlotCap   bool
+	hasVolumeCap bool
+}
+
+type inventoryUsage struct {
+	usedSlots  int
+	usedVolume float64
+}
+
+func loadBackpackCapacity(ctx context.Context, playerID int64) (inventoryCapacityProfile, bool) {
+	var profile inventoryCapacityProfile
+	err := globalDB.QueryRow(ctx, `
+		SELECT id, COALESCE(max_item_count, -1), COALESCE(max_item_volume, -1)
+		FROM dune.inventories
+		WHERE actor_id = $1::bigint AND inventory_type = 0
+		LIMIT 1`, playerID).Scan(&profile.id, &profile.maxSlots, &profile.maxVolume)
+	if err != nil {
+		// No inventory found — cannot validate; let the game server decide.
+		return inventoryCapacityProfile{}, false
+	}
+	profile.hasSlotCap = profile.maxSlots > 0
+	profile.hasVolumeCap = profile.maxVolume > 0
+	return profile, true
+}
+
+func loadInventoryUsage(ctx context.Context, inventoryID int64, includeVolume bool) (inventoryUsage, error) {
+	rows, err := globalDB.Query(ctx, `
+		SELECT template_id, stack_size, volume_override
+		FROM dune.items
+		WHERE inventory_id = $1::bigint`, inventoryID)
+	if err != nil {
+		return inventoryUsage{}, err
+	}
+	defer rows.Close()
+
+	usage := inventoryUsage{}
+	for rows.Next() {
+		var templateID string
+		var stackSize int64
+		var volumeOverride pgtype.Float8
+		if err := rows.Scan(&templateID, &stackSize, &volumeOverride); err != nil {
+			continue
+		}
+		usage.usedSlots++
+		if includeVolume {
+			usage.usedVolume += inventoryItemVolume(templateID, volumeOverride) * float64(stackSize)
+		}
+	}
+	return usage, nil
+}
+
+func maxItemsByVolume(maxVolume, usedVolume, perItemVol float64) int64 {
+	availableVolume := maxVolume - usedVolume
+	if availableVolume < 0 {
+		availableVolume = 0
+	}
+	return int64(math.Floor(availableVolume / perItemVol))
+}
+
+func requiredStackCount(qty, stackMax int64) int {
+	return int((qty + stackMax - 1) / stackMax)
+}
+
+func checkInventoryVolumeLimit(
+	ctx context.Context,
+	profile inventoryCapacityProfile,
+	usage inventoryUsage,
+	template string,
+	qty int64,
+) error {
+	if !profile.hasVolumeCap {
+		return nil
+	}
+	perItemVol, err := resolveItemVolume(ctx, template)
+	if err != nil || perItemVol <= 0 {
+		return nil
+	}
+	maxByVolume := maxItemsByVolume(profile.maxVolume, usage.usedVolume, perItemVol)
+	if maxByVolume < qty {
+		return fmt.Errorf(
+			"over weight limit: room for %d more %s (%.2f/%.2f volume used)",
+			maxByVolume, template, usage.usedVolume, profile.maxVolume)
+	}
+	return nil
+}
+
+func checkInventorySlotLimit(ctx context.Context, profile inventoryCapacityProfile, usage inventoryUsage, template string, qty int64) error {
+	if !profile.hasSlotCap {
+		return nil
+	}
+	stackMax, err := resolveStackMax(ctx, template, 0)
+	if err != nil || stackMax < 1 {
+		stackMax = 1
+	}
+	freeSlots := profile.maxSlots - usage.usedSlots
+	newStacks := requiredStackCount(qty, stackMax)
+	if freeSlots < newStacks {
+		return fmt.Errorf(
+			"inventory full: need %d free slots, have %d",
+			newStacks, freeSlots)
+	}
+	return nil
+}
+
 // checkInventoryCapacity verifies that qty items of template fit in the player's
 // backpack (inventory_type=0). Returns an error if the inventory is over volume
 // or slot limits. Used to pre-validate RMQ give-item commands since the game
@@ -565,88 +673,22 @@ func checkInventoryCapacity(ctx context.Context, playerID int64, template string
 	if globalDB == nil {
 		return fmt.Errorf("not connected")
 	}
-	var invID int64
-	var maxSlots int
-	var maxVolume float64
-	err := globalDB.QueryRow(ctx, `
-		SELECT id, COALESCE(max_item_count, -1), COALESCE(max_item_volume, -1)
-		FROM dune.inventories
-		WHERE actor_id = $1::bigint AND inventory_type = 0
-		LIMIT 1`, playerID).Scan(&invID, &maxSlots, &maxVolume)
-	if err != nil {
-		// No inventory found — cannot validate; let the game server decide.
+	profile, ok := loadBackpackCapacity(ctx, playerID)
+	if !ok {
 		return nil
 	}
-
-	hasSlotCap := maxSlots > 0
-	hasVolumeCap := maxVolume > 0
-	if !hasSlotCap && !hasVolumeCap {
+	if !profile.hasSlotCap && !profile.hasVolumeCap {
 		return nil
 	}
-
-	usedSlots := 0
-	usedVolume := 0.0
-	rows, err := globalDB.Query(ctx, `
-		SELECT template_id, stack_size, volume_override
-		FROM dune.items
-		WHERE inventory_id = $1::bigint`, invID)
+	usage, err := loadInventoryUsage(ctx, profile.id, profile.hasVolumeCap)
 	if err != nil {
 		return nil
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var tmpl string
-		var stackSize int64
-		var vol pgtype.Float8
-		if err := rows.Scan(&tmpl, &stackSize, &vol); err != nil {
-			continue
-		}
-		usedSlots++
-		if hasVolumeCap {
-			itemVol := 0.0
-			if vol.Valid && vol.Float64 > 0 {
-				itemVol = vol.Float64
-			} else if itemData.Items != nil {
-				if rule, ok := itemData.Items[strings.ToLower(tmpl)]; ok {
-					itemVol = rule.Volume
-				} else if itemData.DefaultVolume > 0 {
-					itemVol = itemData.DefaultVolume
-				}
-			} else if itemData.DefaultVolume > 0 {
-				itemVol = itemData.DefaultVolume
-			}
-			usedVolume += itemVol * float64(stackSize)
-		}
+	if err := checkInventoryVolumeLimit(ctx, profile, usage, template, qty); err != nil {
+		return err
 	}
-
-	if hasVolumeCap {
-		perItemVol, err := resolveItemVolume(ctx, template)
-		if err == nil && perItemVol > 0 {
-			availableVol := maxVolume - usedVolume
-			if availableVol < 0 {
-				availableVol = 0
-			}
-			maxByVolume := int64(math.Floor(availableVol / perItemVol))
-			if maxByVolume < qty {
-				return fmt.Errorf(
-					"over weight limit: room for %d more %s (%.2f/%.2f volume used)",
-					maxByVolume, template, usedVolume, maxVolume)
-			}
-		}
-	}
-
-	if hasSlotCap {
-		stackMax, err := resolveStackMax(ctx, template, 0)
-		if err != nil || stackMax < 1 {
-			stackMax = 1
-		}
-		newStacks := int((qty + stackMax - 1) / stackMax)
-		freeSlots := maxSlots - usedSlots
-		if freeSlots < newStacks {
-			return fmt.Errorf(
-				"inventory full: need %d free slots, have %d",
-				newStacks, freeSlots)
-		}
+	if err := checkInventorySlotLimit(ctx, profile, usage, template, qty); err != nil {
+		return err
 	}
 	return nil
 }

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -2632,6 +2632,70 @@ func formatProgressionUnlockSuccess(
 		preset, faction, journeyNodeCount, factionName, progressionUnlockMaxTier, targetTier, controllerID)
 }
 
+func resolveProgressionAccountID(ctx context.Context, actorID int64) (int64, error) {
+	var accountID int64
+	if err := globalDB.QueryRow(ctx,
+		`SELECT COALESCE(owner_account_id, 0) FROM dune.actors WHERE id = $1`,
+		actorID).Scan(&accountID); err != nil || accountID == 0 {
+		return 0, fmt.Errorf("player %d not found or has no account", actorID)
+	}
+	return accountID, nil
+}
+
+func progressionReverseTags(baseTags, nodes []string) []string {
+	allTags := append([]string{}, baseTags...)
+	seen := make(map[string]bool, len(allTags))
+	for _, tag := range allTags {
+		seen[tag] = true
+	}
+	for _, node := range nodes {
+		for _, tag := range tagsForJourneyNodeSubtree(node) {
+			if seen[tag] {
+				continue
+			}
+			seen[tag] = true
+			allTags = append(allTags, tag)
+		}
+	}
+	return allTags
+}
+
+func applyProgressionReverse(ctx context.Context, accountID int64, allTags, nodes []string) (int64, error) {
+	tx, err := globalDB.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err = tx.Exec(ctx,
+		`SELECT dune.update_player_tags($1, '{}'::text[], $2::text[])`,
+		accountID, allTags); err != nil {
+		return 0, fmt.Errorf("remove tags: %w", err)
+	}
+
+	result, err := tx.Exec(ctx, `
+		UPDATE dune.journey_story_node
+		SET complete_condition_state = 'false'::jsonb,
+		    has_pending_reward       = false
+		WHERE account_id = $1
+		  AND story_node_id = ANY($2::text[])`,
+		accountID, nodes)
+	if err != nil {
+		return 0, fmt.Errorf("reset journey nodes: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+func formatProgressionReverseSuccess(preset, faction string, resetNodes int64, removedTags int) string {
+	return fmt.Sprintf(
+		"Reversed progression unlock (%s/%s): reset %d node(s), removed %d tag(s) — takes effect on next login",
+		preset, faction, resetNodes, removedTags)
+}
+
 // cmdProgressionUnlock completes all prerequisite faction story journey nodes,
 // writes the corresponding gameplay tags, and sets reputation to the preset's
 // target tier.
@@ -2698,111 +2762,36 @@ func cmdReverseProgressionUnlock(actorID int64, faction, preset string) Cmd {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
 
-		var factionID int16
-		var dialogueFlag, alignedFlag, metRecruiterFlag, factionUnlocked, recruitmentDone string
-		switch faction {
-		case "atreides":
-			factionID = 1
-			dialogueFlag = "DialogueFlags.Factions.SentToMeetHawat"
-			alignedFlag = "DialogueFlags.Factions.AlignedAtreides"
-			metRecruiterFlag = "DialogueFlags.Factions.MetHawat"
-			factionUnlocked = "Contract.Tracking.AtreidesFactionUnlocked"
-			recruitmentDone = "Contract.Tracking.AtreidesRecruitmentCompleted"
-		case "harkonnen":
-			factionID = 2
-			dialogueFlag = "DialogueFlags.Factions.SentToPiterDeVries"
-			alignedFlag = "DialogueFlags.Factions.AlignedHarkonnen"
-			metRecruiterFlag = "DialogueFlags.Factions.MetPiterDeVries"
-			factionUnlocked = "Contract.Tracking.HarkonnenFactionUnlocked"
-			recruitmentDone = "Contract.Tracking.HarkonnenRecruitmentCompleted"
-		default:
-			return msgMutate{err: fmt.Errorf("faction must be atreides or harkonnen")}
+		cfg, err := progressionFactionConfigFor(faction)
+		if err != nil {
+			return msgMutate{err: err}
 		}
-
-		var targetTier int
-		switch preset {
-		case "ch3_start":
-			targetTier = 5
-		case "rank19_eligible":
-			targetTier = 19
-		default:
-			return msgMutate{err: fmt.Errorf("preset must be ch3_start or rank19_eligible")}
+		targetTier, err := progressionTargetTierForPreset(preset)
+		if err != nil {
+			return msgMutate{err: err}
 		}
 
 		ctx := context.Background()
-
-		var accountID int64
-		if err := globalDB.QueryRow(ctx,
-			`SELECT COALESCE(owner_account_id, 0) FROM dune.actors WHERE id = $1`,
-			actorID).Scan(&accountID); err != nil || accountID == 0 {
-			return msgMutate{err: fmt.Errorf("player %d not found or has no account", actorID)}
+		accountID, err := resolveProgressionAccountID(ctx, actorID)
+		if err != nil {
+			return msgMutate{err: err}
 		}
 
-		// Build the exact same tag set the forward function writes so we can remove it.
-		factionName := factionDisplayName(factionID)
-		const maxTier = 5
-		allTags := []string{
-			dialogueFlag, alignedFlag, metRecruiterFlag,
-			factionUnlocked, recruitmentDone,
-			"DialogueFlags.Factions.FactionIntro",
-			"DialogueFlags.Factions.FactionRank1",
-			"DialogueFlags.Factions.FactionRank3",
-			"DialogueFlags.Factions.MetARecruiter",
-			"DialogueFlags.Factions.PlayedAllegianceCinematic",
-			"DialogueFlags.Factions.SeenAnvilCinematic",
-		}
-		if targetTier >= 19 {
-			allTags = append(allTags, "Journey.LandsraadContractsUnlocked")
-		}
-		for t := 0; t <= maxTier; t++ {
-			allTags = append(allTags, fmt.Sprintf("Faction.%s.Tier%d", factionName, t))
-		}
-
-		// Also collect any tags the journey nodes themselves emit on completion.
 		nodes := nodesForPreset(faction, preset)
-		seen := map[string]bool{}
-		for _, t := range allTags {
-			seen[t] = true
-		}
-		for _, node := range nodes {
-			for _, t := range tagsForJourneyNodeSubtree(node) {
-				if !seen[t] {
-					seen[t] = true
-					allTags = append(allTags, t)
-				}
-			}
-		}
+		baseTags := progressionUnlockTags(cfg, targetTier)
+		allTags := progressionReverseTags(baseTags, nodes)
 
-		tx, err := globalDB.Begin(ctx)
+		resetNodes, err := applyProgressionReverse(ctx, accountID, allTags, nodes)
 		if err != nil {
 			return msgMutate{err: err}
 		}
-		defer func() { _ = tx.Rollback(ctx) }()
 
-		if _, err = tx.Exec(ctx,
-			`SELECT dune.update_player_tags($1, '{}'::text[], $2::text[])`,
-			accountID, allTags); err != nil {
-			return msgMutate{err: fmt.Errorf("remove tags: %w", err)}
-		}
-
-		result, err := tx.Exec(ctx, `
-			UPDATE dune.journey_story_node
-			SET complete_condition_state = 'false'::jsonb,
-			    has_pending_reward       = false
-			WHERE account_id = $1
-			  AND story_node_id = ANY($2::text[])`,
-			accountID, nodes)
-		if err != nil {
-			return msgMutate{err: fmt.Errorf("reset journey nodes: %w", err)}
-		}
-
-		if err := tx.Commit(ctx); err != nil {
-			return msgMutate{err: err}
-		}
-
-		return msgMutate{ok: fmt.Sprintf(
-			"Reversed progression unlock (%s/%s): reset %d node(s), removed %d tag(s) — takes effect on next login",
-			preset, faction, result.RowsAffected(), len(allTags))}
+		return msgMutate{ok: formatProgressionReverseSuccess(
+			preset,
+			faction,
+			resetNodes,
+			len(allTags),
+		)}
 	}
 }
 

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -2471,6 +2471,167 @@ func nodesForPreset(faction, preset string) []string {
 	return nodes
 }
 
+const progressionUnlockMaxTier = 5
+
+type progressionFactionConfig struct {
+	factionID        int16
+	dialogueFlag     string
+	alignedFlag      string
+	metRecruiterFlag string
+	factionUnlocked  string
+	recruitmentDone  string
+}
+
+func progressionFactionConfigFor(faction string) (progressionFactionConfig, error) {
+	switch faction {
+	case "atreides":
+		return progressionFactionConfig{
+			factionID:        1,
+			dialogueFlag:     "DialogueFlags.Factions.SentToMeetHawat",
+			alignedFlag:      "DialogueFlags.Factions.AlignedAtreides",
+			metRecruiterFlag: "DialogueFlags.Factions.MetHawat",
+			factionUnlocked:  "Contract.Tracking.AtreidesFactionUnlocked",
+			recruitmentDone:  "Contract.Tracking.AtreidesRecruitmentCompleted",
+		}, nil
+	case "harkonnen":
+		return progressionFactionConfig{
+			factionID:        2,
+			dialogueFlag:     "DialogueFlags.Factions.SentToPiterDeVries",
+			alignedFlag:      "DialogueFlags.Factions.AlignedHarkonnen",
+			metRecruiterFlag: "DialogueFlags.Factions.MetPiterDeVries",
+			factionUnlocked:  "Contract.Tracking.HarkonnenFactionUnlocked",
+			recruitmentDone:  "Contract.Tracking.HarkonnenRecruitmentCompleted",
+		}, nil
+	default:
+		return progressionFactionConfig{}, fmt.Errorf("faction must be atreides or harkonnen")
+	}
+}
+
+func progressionTargetTierForPreset(preset string) (int, error) {
+	switch preset {
+	case "ch3_start":
+		return 5, nil
+	case "rank19_eligible":
+		return 19, nil
+	default:
+		return 0, fmt.Errorf("preset must be ch3_start or rank19_eligible")
+	}
+}
+
+func progressionUnlockTags(cfg progressionFactionConfig, targetTier int) []string {
+	factionName := factionDisplayName(cfg.factionID)
+	// Faction.<X>.TierN is only a real gameplay tag for N ∈ [0,5] — see
+	// DA_Atreides.json / DA_Harkonnen.json m_FactionTiers, where Tier 6+
+	// all have m_FactionTierTag.TagName == "None". Tier 5 flips
+	// m_bAllowPromotionThroughReputation to true, after which rep alone
+	// advances the displayed rank. So Tier0–5 + a rep >= threshold[19] is
+	// enough to display rank 19 — no need to write phantom Tier6..19 tags.
+	allTags := []string{
+		cfg.dialogueFlag, cfg.alignedFlag, cfg.metRecruiterFlag,
+		cfg.factionUnlocked, cfg.recruitmentDone,
+		"DialogueFlags.Factions.FactionIntro",
+		"DialogueFlags.Factions.FactionRank1",
+		"DialogueFlags.Factions.FactionRank3",
+		"DialogueFlags.Factions.MetARecruiter",
+		"DialogueFlags.Factions.PlayedAllegianceCinematic",
+		"DialogueFlags.Factions.SeenAnvilCinematic",
+	}
+	if targetTier >= 19 {
+		allTags = append(allTags, "Journey.LandsraadContractsUnlocked")
+	}
+	for tier := 0; tier <= progressionUnlockMaxTier; tier++ {
+		allTags = append(allTags, fmt.Sprintf("Faction.%s.Tier%d", factionName, tier))
+	}
+	return allTags
+}
+
+func resolveProgressionUnlockPlayer(ctx context.Context, actorID int64) (accountID, controllerID int64, flsID string, err error) {
+	if err = globalDB.QueryRow(ctx, `
+		SELECT COALESCE(a.owner_account_id, 0),
+		       COALESCE(ps.player_controller_id, 0)
+		FROM dune.actors a
+		LEFT JOIN dune.player_state ps ON ps.account_id = a.owner_account_id
+		WHERE a.id = $1`, actorID,
+	).Scan(&accountID, &controllerID); err != nil || accountID == 0 {
+		return 0, 0, "", fmt.Errorf("player %d not found or has no account", actorID)
+	}
+	if controllerID == 0 {
+		return 0, 0, "", fmt.Errorf("player %d has no controller actor", actorID)
+	}
+	flsID, err = rawFuncomID(ctx, accountID)
+	if err != nil || flsID == "" {
+		return 0, 0, "", fmt.Errorf("player %d has no FLS ID", actorID)
+	}
+	return accountID, controllerID, flsID, nil
+}
+
+func applyProgressionUnlock(
+	ctx context.Context,
+	accountID, controllerID int64,
+	flsID string,
+	factionID int16,
+	factionName string,
+	targetTier int,
+	journeyNodes, allTags []string,
+) error {
+	tx, err := globalDB.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err = tx.Exec(ctx,
+		`SELECT dune.complete_journey_story_nodes_for_player($1, $2::text[])`,
+		flsID, journeyNodes); err != nil {
+		return fmt.Errorf("complete journey nodes: %w", err)
+	}
+
+	// Align the player with the chosen faction. Required for fresh / unaligned
+	// characters (no player_faction row) — without this the rank UI doesn't
+	// reflect tier changes because the game treats the player as unaligned.
+	// neutral_faction_id = 3 ("None") so this proc takes the upsert branch.
+	if _, err = tx.Exec(ctx,
+		`SELECT dune.change_player_faction($1::bigint, $2::smallint, 3::smallint, NOW()::timestamp)`,
+		controllerID, factionID); err != nil {
+		return fmt.Errorf("change_player_faction: %w", err)
+	}
+
+	if _, err = tx.Exec(ctx,
+		`SELECT dune.update_player_tags($1, $2::text[], '{}'::text[])`, accountID, allTags); err != nil {
+		return fmt.Errorf("update player tags: %w", err)
+	}
+
+	// +1 over the tier threshold: the game UI floors at the threshold
+	// (rep == threshold shows the tier below), so we nudge just over.
+	targetRep := factionTierThresholds[targetTier] + 1
+	if _, err = tx.Exec(ctx,
+		`SELECT dune.set_player_faction_reputation($1, $2, $3)`,
+		controllerID, factionID, targetRep); err != nil {
+		return fmt.Errorf("set faction rep: %w", err)
+	}
+	if _, err = tx.Exec(ctx, factionPlayerComponentRepSQL,
+		controllerID, factionName, targetRep); err != nil {
+		return fmt.Errorf("update FactionPlayerComponent rep: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func formatProgressionUnlockSuccess(
+	preset, faction string,
+	journeyNodeCount int,
+	factionName string,
+	targetTier int,
+	controllerID int64,
+) string {
+	return fmt.Sprintf(
+		"Progression unlock (%s/%s): %d journey nodes completed + %s tier tags 0–%d + rep tier %d on controller %d — takes effect on next login",
+		preset, faction, journeyNodeCount, factionName, progressionUnlockMaxTier, targetTier, controllerID)
+}
+
 // cmdProgressionUnlock completes all prerequisite faction story journey nodes,
 // writes the corresponding gameplay tags, and sets reputation to the preset's
 // target tier.
@@ -2483,136 +2644,47 @@ func cmdProgressionUnlock(actorID int64, faction, preset string) Cmd {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
 
-		var factionID int16
-		var dialogueFlag, alignedFlag, metRecruiterFlag, factionUnlocked, recruitmentDone string
-		switch faction {
-		case "atreides":
-			factionID = 1
-			dialogueFlag = "DialogueFlags.Factions.SentToMeetHawat"
-			alignedFlag = "DialogueFlags.Factions.AlignedAtreides"
-			metRecruiterFlag = "DialogueFlags.Factions.MetHawat"
-			factionUnlocked = "Contract.Tracking.AtreidesFactionUnlocked"
-			recruitmentDone = "Contract.Tracking.AtreidesRecruitmentCompleted"
-		case "harkonnen":
-			factionID = 2
-			dialogueFlag = "DialogueFlags.Factions.SentToPiterDeVries"
-			alignedFlag = "DialogueFlags.Factions.AlignedHarkonnen"
-			metRecruiterFlag = "DialogueFlags.Factions.MetPiterDeVries"
-			factionUnlocked = "Contract.Tracking.HarkonnenFactionUnlocked"
-			recruitmentDone = "Contract.Tracking.HarkonnenRecruitmentCompleted"
-		default:
-			return msgMutate{err: fmt.Errorf("faction must be atreides or harkonnen")}
-		}
-
-		var targetTier int
-		switch preset {
-		case "ch3_start":
-			targetTier = 5
-		case "rank19_eligible":
-			targetTier = 19
-		default:
-			return msgMutate{err: fmt.Errorf("preset must be ch3_start or rank19_eligible")}
-		}
-
-		ctx := context.Background()
-
-		var accountID, controllerID int64
-		err := globalDB.QueryRow(ctx, `
-			SELECT COALESCE(a.owner_account_id, 0),
-			       COALESCE(ps.player_controller_id, 0)
-			FROM dune.actors a
-			LEFT JOIN dune.player_state ps ON ps.account_id = a.owner_account_id
-			WHERE a.id = $1`, actorID,
-		).Scan(&accountID, &controllerID)
-		if err != nil || accountID == 0 {
-			return msgMutate{err: fmt.Errorf("player %d not found or has no account", actorID)}
-		}
-		if controllerID == 0 {
-			return msgMutate{err: fmt.Errorf("player %d has no controller actor", actorID)}
-		}
-		flsID, err := rawFuncomID(ctx, accountID)
-		if err != nil || flsID == "" {
-			return msgMutate{err: fmt.Errorf("player %d has no FLS ID", actorID)}
-		}
-
-		journeyNodes := nodesForPreset(faction, preset)
-
-		factionName := factionDisplayName(factionID)
-		// Faction.<X>.TierN is only a real gameplay tag for N ∈ [0,5] — see
-		// DA_Atreides.json / DA_Harkonnen.json m_FactionTiers, where Tier 6+
-		// all have m_FactionTierTag.TagName == "None". Tier 5 flips
-		// m_bAllowPromotionThroughReputation to true, after which rep alone
-		// advances the displayed rank. So Tier0–5 + a rep >= threshold[19] is
-		// enough to display rank 19 — no need to write phantom Tier6..19 tags.
-		const maxTier = 5
-		// Baseline faction-progression tags observed on both rank-up reference
-		// characters (rank 19 Atreides + rank 8 Harkonnen). MetARecruiter,
-		// PlayedAllegianceCinematic, SeenAnvilCinematic, FactionRank1/3 are
-		// faction-neutral; the faction-specific flags are picked above.
-		allTags := []string{
-			dialogueFlag, alignedFlag, metRecruiterFlag,
-			factionUnlocked, recruitmentDone,
-			"DialogueFlags.Factions.FactionIntro",
-			"DialogueFlags.Factions.FactionRank1",
-			"DialogueFlags.Factions.FactionRank3",
-			"DialogueFlags.Factions.MetARecruiter",
-			"DialogueFlags.Factions.PlayedAllegianceCinematic",
-			"DialogueFlags.Factions.SeenAnvilCinematic",
-		}
-		if targetTier >= 19 {
-			allTags = append(allTags, "Journey.LandsraadContractsUnlocked")
-		}
-		for t := 0; t <= maxTier; t++ {
-			allTags = append(allTags, fmt.Sprintf("Faction.%s.Tier%d", factionName, t))
-		}
-
-		tx, err := globalDB.Begin(ctx)
+		cfg, err := progressionFactionConfigFor(faction)
 		if err != nil {
 			return msgMutate{err: err}
 		}
-		defer func() { _ = tx.Rollback(ctx) }()
-
-		if _, err = tx.Exec(ctx,
-			`SELECT dune.complete_journey_story_nodes_for_player($1, $2::text[])`,
-			flsID, journeyNodes); err != nil {
-			return msgMutate{err: fmt.Errorf("complete journey nodes: %w", err)}
-		}
-
-		// Align the player with the chosen faction. Required for fresh / unaligned
-		// characters (no player_faction row) — without this the rank UI doesn't
-		// reflect tier changes because the game treats the player as unaligned.
-		// neutral_faction_id = 3 ("None") so this proc takes the upsert branch.
-		if _, err = tx.Exec(ctx,
-			`SELECT dune.change_player_faction($1::bigint, $2::smallint, 3::smallint, NOW()::timestamp)`,
-			controllerID, factionID); err != nil {
-			return msgMutate{err: fmt.Errorf("change_player_faction: %w", err)}
-		}
-
-		if _, err = tx.Exec(ctx,
-			`SELECT dune.update_player_tags($1, $2::text[], '{}'::text[])`, accountID, allTags); err != nil {
-			return msgMutate{err: fmt.Errorf("update player tags: %w", err)}
-		}
-
-		// +1 over the tier threshold: the game UI floors at the threshold
-		// (rep == threshold shows the tier below), so we nudge just over.
-		targetRep := factionTierThresholds[targetTier] + 1
-		if _, err = tx.Exec(ctx,
-			`SELECT dune.set_player_faction_reputation($1, $2, $3)`,
-			controllerID, factionID, targetRep); err != nil {
-			return msgMutate{err: fmt.Errorf("set faction rep: %w", err)}
-		}
-		if _, err = tx.Exec(ctx, factionPlayerComponentRepSQL,
-			controllerID, factionName, targetRep); err != nil {
-			return msgMutate{err: fmt.Errorf("update FactionPlayerComponent rep: %w", err)}
-		}
-
-		if err := tx.Commit(ctx); err != nil {
+		targetTier, err := progressionTargetTierForPreset(preset)
+		if err != nil {
 			return msgMutate{err: err}
 		}
 
-		return msgMutate{ok: fmt.Sprintf(
-			"Progression unlock (%s/%s): %d journey nodes completed + %s tier tags 0–%d + rep tier %d on controller %d — takes effect on next login",
-			preset, faction, len(journeyNodes), factionName, maxTier, targetTier, controllerID)}
+		journeyNodes := nodesForPreset(faction, preset)
+		factionName := factionDisplayName(cfg.factionID)
+		allTags := progressionUnlockTags(cfg, targetTier)
+
+		ctx := context.Background()
+		accountID, controllerID, flsID, err := resolveProgressionUnlockPlayer(ctx, actorID)
+		if err != nil {
+			return msgMutate{err: err}
+		}
+
+		if err := applyProgressionUnlock(
+			ctx,
+			accountID,
+			controllerID,
+			flsID,
+			cfg.factionID,
+			factionName,
+			targetTier,
+			journeyNodes,
+			allTags,
+		); err != nil {
+			return msgMutate{err: err}
+		}
+
+		return msgMutate{ok: formatProgressionUnlockSuccess(
+			preset,
+			faction,
+			len(journeyNodes),
+			factionName,
+			targetTier,
+			controllerID,
+		)}
 	}
 }
 

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -216,6 +216,51 @@ func cmdFetchSpecs() Msg {
 	return msgSpecs{rows: out}
 }
 
+func sqlHeaderNames(rows pgx.Rows) []string {
+	descs := rows.FieldDescriptions()
+	headers := make([]string, len(descs))
+	for i, desc := range descs {
+		headers[i] = string(desc.Name)
+	}
+	return headers
+}
+
+func collectSQLRows(rows pgx.Rows, limit int) ([][]any, bool) {
+	collected := make([][]any, 0, limit)
+	for rows.Next() && len(collected) < limit {
+		values, err := rows.Values()
+		if err != nil {
+			continue
+		}
+		collected = append(collected, values)
+	}
+	return collected, len(collected) == limit
+}
+
+func formatSQLRow(values []any) string {
+	parts := make([]string, len(values))
+	for i, value := range values {
+		parts[i] = fmt.Sprintf("%v", value)
+	}
+	return strings.Join(parts, " │ ")
+}
+
+func buildSQLResult(headers []string, rows [][]any, truncated bool) string {
+	var sb strings.Builder
+	sb.WriteString(strings.Join(headers, " │ "))
+	sb.WriteString("\n")
+	sb.WriteString(strings.Repeat("─", 80))
+	sb.WriteString("\n")
+	for _, row := range rows {
+		sb.WriteString(formatSQLRow(row))
+		sb.WriteString("\n")
+	}
+	if truncated {
+		sb.WriteString("… (limited to 200 rows)\n")
+	}
+	return sb.String()
+}
+
 func cmdRunSQL(sql string) Cmd {
 	return func() Msg {
 		if globalDB == nil {
@@ -227,35 +272,9 @@ func cmdRunSQL(sql string) Cmd {
 		}
 		defer rows.Close()
 
-		var sb strings.Builder
-		descs := rows.FieldDescriptions()
-		headers := make([]string, len(descs))
-		for i, d := range descs {
-			headers[i] = string(d.Name)
-		}
-		sb.WriteString(strings.Join(headers, " │ "))
-		sb.WriteString("\n")
-		sb.WriteString(strings.Repeat("─", 80))
-		sb.WriteString("\n")
-
-		count := 0
-		for rows.Next() && count < 200 {
-			vals, err := rows.Values()
-			if err != nil {
-				continue
-			}
-			parts := make([]string, len(vals))
-			for i, v := range vals {
-				parts[i] = fmt.Sprintf("%v", v)
-			}
-			sb.WriteString(strings.Join(parts, " │ "))
-			sb.WriteString("\n")
-			count++
-		}
-		if count == 200 {
-			sb.WriteString("… (limited to 200 rows)\n")
-		}
-		return msgSQL{result: sb.String()}
+		headers := sqlHeaderNames(rows)
+		resultRows, truncated := collectSQLRows(rows, 200)
+		return msgSQL{result: buildSQLResult(headers, resultRows, truncated)}
 	}
 }
 

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -3473,107 +3473,155 @@ func cmdRepairItem(itemID int64) Cmd {
 // Carried inventories: backpack, equipment, emote wheel, equipped weapons, action wheel, bank.
 var repairGearInventoryTypes = []int32{0, 1, 14, 15, 27, 30}
 
+type repairCandidate struct {
+	id     int64
+	target float64
+}
+
+func parseDurabilityText(value pgtype.Text) float64 {
+	if !value.Valid {
+		return 0
+	}
+	parsed, _ := strconv.ParseFloat(value.String, 64)
+	return parsed
+}
+
+func repairTargetForItem(templateID string, maxDurability pgtype.Text) float64 {
+	// Target priority: catalog (vehicle modules stored as items) → stats.MaxDurability → 100.
+	if value, ok := itemMaxDurability(templateID); ok && value > 0 {
+		return value
+	}
+	if maxDurability.Valid {
+		if value, err := strconv.ParseFloat(maxDurability.String, 64); err == nil && value > 0 {
+			return value
+		}
+	}
+	return 100.0
+}
+
+func buildRepairCandidate(
+	id int64,
+	templateID string,
+	maxDurability, currentDurability, decayedDurability pgtype.Text,
+) (repairCandidate, bool) {
+	target := repairTargetForItem(templateID, maxDurability)
+	current := parseDurabilityText(currentDurability)
+	decayed := parseDurabilityText(decayedDurability)
+	if math.Abs(current-target) < 0.01 && math.Abs(decayed-target) < 0.01 {
+		return repairCandidate{}, false
+	}
+	return repairCandidate{id: id, target: target}, true
+}
+
+func loadPlayerGearRepairCandidates(ctx context.Context, playerID int64) ([]repairCandidate, int, error) {
+	rows, err := globalDB.Query(ctx, `
+		SELECT i.id, i.template_id,
+		       (i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability'),
+		       (i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability'),
+		       (i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')
+		FROM dune.items i
+		JOIN dune.inventories inv ON inv.id = i.inventory_id
+		WHERE inv.actor_id = $1::bigint
+		  AND inv.inventory_type = ANY($2::int[])
+		  AND i.stats ? 'FItemStackAndDurabilityStats'`,
+		playerID, repairGearInventoryTypes)
+	if err != nil {
+		return nil, 0, fmt.Errorf("scan items: %w", err)
+	}
+	defer rows.Close()
+
+	toRepair := make([]repairCandidate, 0, 64)
+	scanned := 0
+	for rows.Next() {
+		scanned++
+
+		var id int64
+		var templateID string
+		var maxDurability, currentDurability, decayedDurability pgtype.Text
+		if err := rows.Scan(&id, &templateID, &maxDurability, &currentDurability, &decayedDurability); err != nil {
+			return nil, scanned, fmt.Errorf("scan item: %w", err)
+		}
+
+		candidate, needsRepair := buildRepairCandidate(id, templateID, maxDurability, currentDurability, decayedDurability)
+		if needsRepair {
+			toRepair = append(toRepair, candidate)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("scan rows: %w", err)
+	}
+
+	return toRepair, scanned, nil
+}
+
+func validateRepairPlayerGearInput(playerID int64) error {
+	if globalDB == nil {
+		return fmt.Errorf("not connected")
+	}
+	if playerID == 0 {
+		return fmt.Errorf("player ID required")
+	}
+	return nil
+}
+
+type gearRepairRunResult struct {
+	repaired int
+	err      error
+}
+
+func runPlayerGearRepairs(ctx context.Context, toRepair []repairCandidate) gearRepairRunResult {
+	tx, err := globalDB.Begin(ctx)
+	if err != nil {
+		return gearRepairRunResult{err: fmt.Errorf("begin tx: %w", err)}
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	repaired := 0
+	for _, rc := range toRepair {
+		_, err := tx.Exec(ctx, `
+			UPDATE dune.items
+			SET stats = jsonb_set(
+				jsonb_set(stats,
+					'{FItemStackAndDurabilityStats,1,CurrentDurability}',
+					to_jsonb($2::float8), true),
+				'{FItemStackAndDurabilityStats,1,DecayedMaxDurability}',
+				to_jsonb($2::float8), true)
+			WHERE id = $1::bigint`, rc.id, rc.target)
+		if err != nil {
+			return gearRepairRunResult{
+				repaired: repaired,
+				err:      fmt.Errorf("repair item %d: %w", rc.id, err),
+			}
+		}
+		repaired++
+	}
+	if err := tx.Commit(ctx); err != nil {
+		// Keep the legacy response shape for commit failures: no repaired count.
+		return gearRepairRunResult{err: fmt.Errorf("commit: %w", err)}
+	}
+	return gearRepairRunResult{repaired: repaired}
+}
+
 func cmdRepairPlayerGear(playerID int64) Cmd {
 	return func() Msg {
-		if globalDB == nil {
-			return msgRepairGear{err: fmt.Errorf("not connected")}
-		}
-		if playerID == 0 {
-			return msgRepairGear{err: fmt.Errorf("player ID required")}
+		if err := validateRepairPlayerGearInput(playerID); err != nil {
+			return msgRepairGear{err: err}
 		}
 		ctx := context.Background()
 		if err := checkPlayerOffline(ctx, playerID); err != nil {
 			return msgRepairGear{err: err}
 		}
 
-		rows, err := globalDB.Query(ctx, `
-			SELECT i.id, i.template_id,
-			       (i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability'),
-			       (i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability'),
-			       (i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')
-			FROM dune.items i
-			JOIN dune.inventories inv ON inv.id = i.inventory_id
-			WHERE inv.actor_id = $1::bigint
-			  AND inv.inventory_type = ANY($2::int[])
-			  AND i.stats ? 'FItemStackAndDurabilityStats'`,
-			playerID, repairGearInventoryTypes)
+		toRepair, scanned, err := loadPlayerGearRepairCandidates(ctx, playerID)
 		if err != nil {
-			return msgRepairGear{err: fmt.Errorf("scan items: %w", err)}
-		}
-		defer rows.Close()
-
-		type repairCandidate struct {
-			id     int64
-			target float64
-		}
-		var toRepair []repairCandidate
-		scanned := 0
-		for rows.Next() {
-			scanned++
-			var id int64
-			var templateID string
-			var maxStr, curStr, decayedStr pgtype.Text
-			if err := rows.Scan(&id, &templateID, &maxStr, &curStr, &decayedStr); err != nil {
-				return msgRepairGear{scanned: scanned, err: fmt.Errorf("scan item: %w", err)}
-			}
-
-			// Target priority: catalog (vehicle modules stored as items) → stats.MaxDurability → 100.
-			var target float64
-			if v, ok := itemMaxDurability(templateID); ok && v > 0 {
-				target = v
-			} else if maxStr.Valid {
-				if v, perr := strconv.ParseFloat(maxStr.String, 64); perr == nil && v > 0 {
-					target = v
-				} else {
-					target = 100.0
-				}
-			} else {
-				target = 100.0
-			}
-
-			cur := 0.0
-			if curStr.Valid {
-				cur, _ = strconv.ParseFloat(curStr.String, 64)
-			}
-			decayed := 0.0
-			if decayedStr.Valid {
-				decayed, _ = strconv.ParseFloat(decayedStr.String, 64)
-			}
-			if math.Abs(cur-target) < 0.01 && math.Abs(decayed-target) < 0.01 {
-				continue
-			}
-			toRepair = append(toRepair, repairCandidate{id: id, target: target})
-		}
-		if err := rows.Err(); err != nil {
-			return msgRepairGear{err: fmt.Errorf("scan rows: %w", err)}
+			return msgRepairGear{scanned: scanned, err: err}
 		}
 
-		tx, err := globalDB.Begin(ctx)
-		if err != nil {
-			return msgRepairGear{scanned: scanned, err: fmt.Errorf("begin tx: %w", err)}
+		run := runPlayerGearRepairs(ctx, toRepair)
+		if run.err != nil {
+			return msgRepairGear{repaired: run.repaired, scanned: scanned, err: run.err}
 		}
-		defer func() { _ = tx.Rollback(ctx) }()
-
-		repaired := 0
-		for _, rc := range toRepair {
-			_, err := tx.Exec(ctx, `
-				UPDATE dune.items
-				SET stats = jsonb_set(
-					jsonb_set(stats,
-						'{FItemStackAndDurabilityStats,1,CurrentDurability}',
-						to_jsonb($2::float8), true),
-					'{FItemStackAndDurabilityStats,1,DecayedMaxDurability}',
-					to_jsonb($2::float8), true)
-				WHERE id = $1::bigint`, rc.id, rc.target)
-			if err != nil {
-				return msgRepairGear{repaired: repaired, scanned: scanned, err: fmt.Errorf("repair item %d: %w", rc.id, err)}
-			}
-			repaired++
-		}
-		if err := tx.Commit(ctx); err != nil {
-			return msgRepairGear{scanned: scanned, err: fmt.Errorf("commit: %w", err)}
-		}
-		return msgRepairGear{repaired: repaired, scanned: scanned}
+		return msgRepairGear{repaired: run.repaired, scanned: scanned}
 	}
 }
 

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -2019,6 +2019,103 @@ var starterAbilityByJob = map[string]string{
 	"Trooper":       "Skills.Ability.SuspensorGrenade_Reduction",
 }
 
+func resolveStarterClassAbility(job string) (string, error) {
+	if _, ok := tagsData.JobSkillBlocks[job]; !ok {
+		return "", fmt.Errorf("unknown job %q", job)
+	}
+	ability, ok := starterAbilityByJob[job]
+	if !ok {
+		return "", fmt.Errorf("no starter ability mapping for %q", job)
+	}
+	return ability, nil
+}
+
+func loadPawnIDForAccount(ctx context.Context, accountID int64) (int64, error) {
+	var pawnID int64
+	_ = globalDB.QueryRow(ctx, `
+		SELECT player_pawn_id FROM dune.player_state
+		WHERE account_id = $1 LIMIT 1`, accountID).Scan(&pawnID)
+	if pawnID == 0 {
+		return 0, fmt.Errorf("no pawn for account %d", accountID)
+	}
+	return pawnID, nil
+}
+
+func loadStarterTagForPawn(ctx context.Context, pawnID int64) string {
+	var starterTag string
+	_ = globalDB.QueryRow(ctx, `
+		SELECT fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName'
+		FROM dune.fgl_entities fe
+		JOIN dune.actor_fgl_entities afe ON afe.entity_id = fe.entity_id
+		WHERE afe.actor_id = $1 AND afe.slot_name = 'DuneCharacter'`,
+		pawnID).Scan(&starterTag)
+	return starterTag
+}
+
+func starterKeysToRemove(oldStarterTag, newJob string) []string {
+	if !strings.HasPrefix(oldStarterTag, "Skills.Key.") || !strings.HasSuffix(oldStarterTag, "1") {
+		return nil
+	}
+	oldJob := strings.TrimSuffix(strings.TrimPrefix(oldStarterTag, "Skills.Key."), "1")
+	if oldJob == "" || oldJob == newJob {
+		return nil
+	}
+	keys := []string{fmt.Sprintf(`(TagName="%s")`, oldStarterTag)}
+	if oldAbility, ok := starterAbilityByJob[oldJob]; ok {
+		keys = append(keys, fmt.Sprintf(`(TagName="%s")`, oldAbility))
+	}
+	return keys
+}
+
+func starterClassTagAndKeys(job, ability string) (starterTag, starterKey, abilityKey string) {
+	starterTag = fmt.Sprintf("Skills.Key.%s1", job)
+	starterKey = fmt.Sprintf(`(TagName="%s")`, starterTag)
+	abilityKey = fmt.Sprintf(`(TagName="%s")`, ability)
+	return starterTag, starterKey, abilityKey
+}
+
+func applyStarterClassUpdate(
+	ctx context.Context,
+	pawnID int64,
+	newStarterTag, newStarterKey string,
+	keysToRemove []string,
+	newAbilityKey string,
+) error {
+	_, err := globalDB.Exec(ctx, `
+		UPDATE dune.fgl_entities fe
+		SET components = jsonb_set(
+			jsonb_set(
+				jsonb_set(
+					jsonb_set(
+						fe.components,
+						ARRAY['FLevelComponent','1','ModuleData'],
+						(fe.components->'FLevelComponent'->1->'ModuleData') - $4::text[]),
+					ARRAY['FLevelComponent','1','StarterSkillTreeTag','TagName'],
+					to_jsonb($2::text)),
+				ARRAY['FLevelComponent','1','ModuleData',$3],
+				'{"SkillPointsSpent": 1}'::jsonb,
+				true),
+			ARRAY['FLevelComponent','1','ModuleData',$5],
+			'{"SkillPointsSpent": 1}'::jsonb,
+			true)
+		WHERE fe.entity_id = (
+			SELECT entity_id FROM dune.actor_fgl_entities
+			WHERE actor_id = $1 AND slot_name = 'DuneCharacter'
+		)`, pawnID, newStarterTag, newStarterKey, keysToRemove, newAbilityKey)
+	if err != nil {
+		return fmt.Errorf("set starter tag: %w", err)
+	}
+	return nil
+}
+
+func formatStarterClassMessage(job, newStarterTag, newAbility string, removedCount int) string {
+	msg := fmt.Sprintf("Starter class set to %s (%s + %s active)", job, newStarterTag, newAbility)
+	if removedCount > 0 {
+		msg += fmt.Sprintf(", cleared previous starter (%d module(s))", removedCount)
+	}
+	return msg
+}
+
 // cmdSetStarterClass swaps the player's starter class:
 //  1. removes the previous starter's Skills.Key.<Old>1 block + its starter
 //     ability from ModuleData (so you don't end up with two starters
@@ -2037,83 +2134,33 @@ func cmdSetStarterClass(accountID int64, job string) Cmd {
 		if accountID == 0 {
 			return msgMutate{err: fmt.Errorf("account ID required")}
 		}
-		if _, ok := tagsData.JobSkillBlocks[job]; !ok {
-			return msgMutate{err: fmt.Errorf("unknown job %q", job)}
-		}
-		newAbility, ok := starterAbilityByJob[job]
-		if !ok {
-			return msgMutate{err: fmt.Errorf("no starter ability mapping for %q", job)}
+		newAbility, err := resolveStarterClassAbility(job)
+		if err != nil {
+			return msgMutate{err: err}
 		}
 		ctx := context.Background()
 
-		var pawnID int64
-		_ = globalDB.QueryRow(ctx, `
-			SELECT player_pawn_id FROM dune.player_state
-			WHERE account_id = $1 LIMIT 1`, accountID).Scan(&pawnID)
-		if pawnID == 0 {
-			return msgMutate{err: fmt.Errorf("no pawn for account %d", accountID)}
+		pawnID, err := loadPawnIDForAccount(ctx, accountID)
+		if err != nil {
+			return msgMutate{err: err}
 		}
 
 		// Look up the current starter so we can deactivate it. Format is
 		// "Skills.Key.<Job>1"; we strip the prefix/suffix to recover the
 		// job name and look up its starter-ability for removal.
-		var oldStarterTag string
-		_ = globalDB.QueryRow(ctx, `
-			SELECT fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName'
-			FROM dune.fgl_entities fe
-			JOIN dune.actor_fgl_entities afe ON afe.entity_id = fe.entity_id
-			WHERE afe.actor_id = $1 AND afe.slot_name = 'DuneCharacter'`,
-			pawnID).Scan(&oldStarterTag)
-
-		var keysToRemove []string
-		if strings.HasPrefix(oldStarterTag, "Skills.Key.") && strings.HasSuffix(oldStarterTag, "1") {
-			oldJob := strings.TrimSuffix(strings.TrimPrefix(oldStarterTag, "Skills.Key."), "1")
-			if oldJob != "" && oldJob != job {
-				keysToRemove = append(keysToRemove, fmt.Sprintf(`(TagName="%s")`, oldStarterTag))
-				if oldAb, ok := starterAbilityByJob[oldJob]; ok {
-					keysToRemove = append(keysToRemove, fmt.Sprintf(`(TagName="%s")`, oldAb))
-				}
-			}
-		}
-
-		newStarterTag := fmt.Sprintf("Skills.Key.%s1", job)
-		newStarterKey := fmt.Sprintf(`(TagName="%s")`, newStarterTag)
-		newAbilityKey := fmt.Sprintf(`(TagName="%s")`, newAbility)
+		oldStarterTag := loadStarterTagForPawn(ctx, pawnID)
+		keysToRemove := starterKeysToRemove(oldStarterTag, job)
+		newStarterTag, newStarterKey, newAbilityKey := starterClassTagAndKeys(job, newAbility)
 
 		// One chained jsonb update: strip old keys, write new tag, activate
 		// new starter block, grant new starter ability. - operator on an
 		// empty text[] is a no-op so it's safe when there's no old starter
 		// to clean up (e.g. fresh character with StarterSkillTreeTag=None).
-		_, err := globalDB.Exec(ctx, `
-			UPDATE dune.fgl_entities fe
-			SET components = jsonb_set(
-				jsonb_set(
-					jsonb_set(
-						jsonb_set(
-							fe.components,
-							ARRAY['FLevelComponent','1','ModuleData'],
-							(fe.components->'FLevelComponent'->1->'ModuleData') - $4::text[]),
-						ARRAY['FLevelComponent','1','StarterSkillTreeTag','TagName'],
-						to_jsonb($2::text)),
-					ARRAY['FLevelComponent','1','ModuleData',$3],
-					'{"SkillPointsSpent": 1}'::jsonb,
-					true),
-				ARRAY['FLevelComponent','1','ModuleData',$5],
-				'{"SkillPointsSpent": 1}'::jsonb,
-				true)
-			WHERE fe.entity_id = (
-				SELECT entity_id FROM dune.actor_fgl_entities
-				WHERE actor_id = $1 AND slot_name = 'DuneCharacter'
-			)`, pawnID, newStarterTag, newStarterKey, keysToRemove, newAbilityKey)
-		if err != nil {
-			return msgMutate{err: fmt.Errorf("set starter tag: %w", err)}
+		if err := applyStarterClassUpdate(ctx, pawnID, newStarterTag, newStarterKey, keysToRemove, newAbilityKey); err != nil {
+			return msgMutate{err: err}
 		}
 
-		msg := fmt.Sprintf("Starter class set to %s (%s + %s active)", job, newStarterTag, newAbility)
-		if len(keysToRemove) > 0 {
-			msg += fmt.Sprintf(", cleared previous starter (%d module(s))", len(keysToRemove))
-		}
-		return msgMutate{ok: msg}
+		return msgMutate{ok: formatStarterClassMessage(job, newStarterTag, newAbility, len(keysToRemove))}
 	}
 }
 

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -261,212 +261,300 @@ func cmdRunSQL(sql string) Cmd {
 
 func cmdGiveItem(playerID int64, template string, qty, quality int64) Cmd {
 	return func() Msg {
-		if globalDB == nil {
-			return msgMutate{err: fmt.Errorf("not connected")}
-		}
-		if playerID == 0 {
-			return msgMutate{err: fmt.Errorf("player ID required")}
-		}
-		template = strings.TrimSpace(template)
-		if template == "" {
-			return msgMutate{err: fmt.Errorf("item template required")}
-		}
-		if qty <= 0 {
-			return msgMutate{err: fmt.Errorf("quantity must be > 0")}
-		}
-		ctx := context.Background()
+		return runGiveItem(playerID, template, qty, quality)
+	}
+}
 
-		// Prefer the backpack (inventory_type=0) — that's where resources live.
-		// Fall back to the first available inventory if not found.
-		var invID int64
-		var maxSlots int
-		var maxVolume float64
-		err := globalDB.QueryRow(ctx, `
-			SELECT id, COALESCE(max_item_count, -1), COALESCE(max_item_volume, -1)
-			FROM dune.inventories
-			WHERE actor_id = $1::bigint AND inventory_type = 0
-			LIMIT 1`, playerID).Scan(&invID, &maxSlots, &maxVolume)
-		if err != nil {
-			err = globalDB.QueryRow(ctx,
-				`SELECT id, COALESCE(max_item_count, -1), COALESCE(max_item_volume, -1)
-				 FROM dune.inventories WHERE actor_id = $1::bigint LIMIT 1`, playerID).Scan(&invID, &maxSlots, &maxVolume)
-			if err != nil {
-				return msgMutate{err: fmt.Errorf("find inventory: %w", err)}
+func runGiveItem(playerID int64, template string, qty, quality int64) Msg {
+	if globalDB == nil {
+		return msgMutate{err: fmt.Errorf("not connected")}
+	}
+	trimmedTemplate, err := validateGiveItemInput(playerID, template, qty)
+	if err != nil {
+		return msgMutate{err: err}
+	}
+	template = trimmedTemplate
+
+	ctx := context.Background()
+	inv, err := findGiveItemInventory(ctx, playerID)
+	if err != nil {
+		return msgMutate{err: err}
+	}
+	state, err := loadGiveItemInventoryState(ctx, inv.id, template, quality, inv.hasVolumeCap)
+	if err != nil {
+		return msgMutate{err: err}
+	}
+	stackMax, err := resolveStackMax(ctx, template, quality)
+	if err != nil {
+		return msgMutate{err: err}
+	}
+	if stackMax < 1 {
+		stackMax = 1
+	}
+	if err := ensureGiveItemVolumeCapacity(ctx, inv, state, template, qty); err != nil {
+		return msgMutate{err: err}
+	}
+
+	updates, newStacks := planGiveItemStacks(qty, stackMax, state.stacks)
+	if err := ensureGiveItemSlotCapacity(inv, state, len(newStacks)); err != nil {
+		return msgMutate{err: err}
+	}
+	if err := applyGiveItemChanges(ctx, inv.id, template, quality, state.maxPos, updates, newStacks); err != nil {
+		return msgMutate{err: err}
+	}
+	return msgMutate{ok: formatGiveItemResult(playerID, template, qty, len(updates), len(newStacks))}
+}
+
+type giveItemInventory struct {
+	id           int64
+	maxSlots     int
+	maxVolume    float64
+	hasSlotCap   bool
+	hasVolumeCap bool
+}
+
+type giveItemStackSlot struct {
+	id   int64
+	size int64
+}
+
+type giveItemInventoryState struct {
+	stacks     []giveItemStackSlot
+	usedSlots  int
+	usedVolume float64
+	maxPos     int64
+}
+
+type giveItemStackUpdate struct {
+	id  int64
+	add int64
+}
+
+func validateGiveItemInput(playerID int64, template string, qty int64) (string, error) {
+	if playerID == 0 {
+		return "", fmt.Errorf("player ID required")
+	}
+	template = strings.TrimSpace(template)
+	if template == "" {
+		return "", fmt.Errorf("item template required")
+	}
+	if qty <= 0 {
+		return "", fmt.Errorf("quantity must be > 0")
+	}
+	return template, nil
+}
+
+func findGiveItemInventory(ctx context.Context, playerID int64) (giveItemInventory, error) {
+	var inv giveItemInventory
+	err := globalDB.QueryRow(ctx, `
+		SELECT id, COALESCE(max_item_count, -1), COALESCE(max_item_volume, -1)
+		FROM dune.inventories
+		WHERE actor_id = $1::bigint AND inventory_type = 0
+		LIMIT 1`, playerID).Scan(&inv.id, &inv.maxSlots, &inv.maxVolume)
+	if err == nil {
+		inv.hasSlotCap = inv.maxSlots > 0
+		inv.hasVolumeCap = inv.maxVolume > 0
+		return inv, nil
+	}
+	err = globalDB.QueryRow(ctx, `
+		SELECT id, COALESCE(max_item_count, -1), COALESCE(max_item_volume, -1)
+		FROM dune.inventories
+		WHERE actor_id = $1::bigint
+		LIMIT 1`, playerID).Scan(&inv.id, &inv.maxSlots, &inv.maxVolume)
+	if err != nil {
+		return giveItemInventory{}, fmt.Errorf("find inventory: %w", err)
+	}
+	inv.hasSlotCap = inv.maxSlots > 0
+	inv.hasVolumeCap = inv.maxVolume > 0
+	return inv, nil
+}
+
+func loadGiveItemInventoryState(ctx context.Context, invID int64, template string, quality int64, includeVolume bool) (giveItemInventoryState, error) {
+	rows, err := globalDB.Query(ctx, `
+		SELECT id, template_id, stack_size, quality_level, volume_override, position_index
+		FROM dune.items
+		WHERE inventory_id = $1::bigint`, invID)
+	if err != nil {
+		return giveItemInventoryState{}, err
+	}
+	defer rows.Close()
+
+	state := giveItemInventoryState{maxPos: -1}
+	for rows.Next() {
+		var id int64
+		var tmpl string
+		var stackSize int64
+		var qLevel int64
+		var vol pgtype.Float8
+		var pos int64
+		if err := rows.Scan(&id, &tmpl, &stackSize, &qLevel, &vol, &pos); err != nil {
+			continue
+		}
+		state.usedSlots++
+		if pos > state.maxPos {
+			state.maxPos = pos
+		}
+		if qLevel == quality && tmpl == template {
+			state.stacks = append(state.stacks, giveItemStackSlot{id: id, size: stackSize})
+		}
+		if includeVolume {
+			state.usedVolume += inventoryItemVolume(tmpl, vol) * float64(stackSize)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return giveItemInventoryState{}, err
+	}
+	return state, nil
+}
+
+func inventoryItemVolume(template string, vol pgtype.Float8) float64 {
+	if vol.Valid && vol.Float64 > 0 {
+		return vol.Float64
+	}
+	if itemData.Items != nil {
+		if rule, ok := itemData.Items[strings.ToLower(template)]; ok {
+			return rule.Volume // 0 is valid — item takes no volume
+		}
+		if itemData.DefaultVolume > 0 {
+			return itemData.DefaultVolume
+		}
+		// Unknown volume: treat as 0 (no space consumed).
+		return 0
+	}
+	if itemData.DefaultVolume > 0 {
+		return itemData.DefaultVolume
+	}
+	return 0
+}
+
+func ensureGiveItemVolumeCapacity(
+	ctx context.Context,
+	inv giveItemInventory,
+	state giveItemInventoryState,
+	template string,
+	qty int64,
+) error {
+	if !inv.hasVolumeCap {
+		return nil
+	}
+	perItemVol, err := resolveItemVolume(ctx, template)
+	if err != nil {
+		return err
+	}
+	if perItemVol <= 0 {
+		return nil
+	}
+	availableVol := inv.maxVolume - state.usedVolume
+	if availableVol < 0 {
+		availableVol = 0
+	}
+	maxByVolume := int64(math.Floor(availableVol / perItemVol))
+	if maxByVolume < qty {
+		return fmt.Errorf(
+			"over weight limit: room for %d more %s (%.2f/%.2f volume used)",
+			maxByVolume, template, state.usedVolume, inv.maxVolume)
+	}
+	return nil
+}
+
+func planGiveItemStacks(qty, stackMax int64, stacks []giveItemStackSlot) ([]giveItemStackUpdate, []int64) {
+	sorted := make([]giveItemStackSlot, len(stacks))
+	copy(sorted, stacks)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].size > sorted[j].size
+	})
+	remaining := qty
+	updates := make([]giveItemStackUpdate, 0, len(sorted))
+	if stackMax > 1 {
+		for _, st := range sorted {
+			if remaining == 0 {
+				break
 			}
-		}
-
-		hasSlotCap := maxSlots > 0
-		hasVolumeCap := maxVolume > 0
-
-		type stackSlot struct {
-			id   int64
-			size int64
-		}
-		var stacks []stackSlot
-		usedSlots := 0
-		usedVolume := 0.0
-		maxPos := int64(-1)
-
-		rows, err := globalDB.Query(ctx, `
-			SELECT id, template_id, stack_size, quality_level, volume_override, position_index
-			FROM dune.items
-			WHERE inventory_id = $1::bigint`, invID)
-		if err != nil {
-			return msgMutate{err: err}
-		}
-		defer rows.Close()
-		for rows.Next() {
-			var id int64
-			var tmpl string
-			var stackSize int64
-			var qLevel int64
-			var vol pgtype.Float8
-			var pos int64
-			if err := rows.Scan(&id, &tmpl, &stackSize, &qLevel, &vol, &pos); err != nil {
+			space := stackMax - st.size
+			if space <= 0 {
 				continue
 			}
-			usedSlots++
-			if pos > maxPos {
-				maxPos = pos
+			add := space
+			if add > remaining {
+				add = remaining
 			}
-			if qLevel == quality && tmpl == template {
-				stacks = append(stacks, stackSlot{id: id, size: stackSize})
-			}
-			if hasVolumeCap {
-				itemVol := 0.0
-				if vol.Valid && vol.Float64 > 0 {
-					itemVol = vol.Float64
-				} else if itemData.Items != nil {
-					if rule, ok := itemData.Items[strings.ToLower(tmpl)]; ok {
-						itemVol = rule.Volume // 0 is valid — item takes no volume
-					} else if itemData.DefaultVolume > 0 {
-						itemVol = itemData.DefaultVolume
-					}
-					// Unknown volume: treat as 0 (no space consumed).
-				} else if itemData.DefaultVolume > 0 {
-					itemVol = itemData.DefaultVolume
-				}
-				usedVolume += itemVol * float64(stackSize)
-			}
+			updates = append(updates, giveItemStackUpdate{id: st.id, add: add})
+			remaining -= add
 		}
-		if rows.Err() != nil {
-			return msgMutate{err: rows.Err()}
-		}
-		stackMax, err := resolveStackMax(ctx, template, quality)
-		if err != nil {
-			return msgMutate{err: err}
-		}
-		if stackMax < 1 {
-			stackMax = 1
-		}
-
-		if hasVolumeCap {
-			perItemVol, err := resolveItemVolume(ctx, template)
-			if err != nil {
-				return msgMutate{err: err}
-			}
-			if perItemVol > 0 {
-				availableVol := maxVolume - usedVolume
-				if availableVol < 0 {
-					availableVol = 0
-				}
-				maxByVolume := int64(math.Floor(availableVol / perItemVol))
-				if maxByVolume < qty {
-					return msgMutate{err: fmt.Errorf(
-						"over weight limit: room for %d more %s (%.2f/%.2f volume used)",
-						maxByVolume, template, usedVolume, maxVolume)}
-				}
-			}
-			// perItemVol == 0: item takes no volume, always fits.
-		}
-
-		sort.Slice(stacks, func(i, j int) bool {
-			return stacks[i].size > stacks[j].size
-		})
-
-		remaining := qty
-		type stackUpdate struct {
-			id  int64
-			add int64
-		}
-		var updates []stackUpdate
-		if stackMax > 1 {
-			for _, st := range stacks {
-				if remaining == 0 {
-					break
-				}
-				space := stackMax - st.size
-				if space <= 0 {
-					continue
-				}
-				add := space
-				if add > remaining {
-					add = remaining
-				}
-				updates = append(updates, stackUpdate{id: st.id, add: add})
-				remaining -= add
-			}
-		}
-
-		var newStacks []int64
-		for remaining > 0 {
-			size := stackMax
-			if size > remaining {
-				size = remaining
-			}
-			newStacks = append(newStacks, size)
-			remaining -= size
-		}
-
-		if hasSlotCap {
-			freeSlots := maxSlots - usedSlots
-			if freeSlots < len(newStacks) {
-				return msgMutate{err: fmt.Errorf(
-					"inventory full: need %d free slots, have %d",
-					len(newStacks), freeSlots)}
-			}
-		}
-
-		tx, err := globalDB.Begin(ctx)
-		if err != nil {
-			return msgMutate{err: err}
-		}
-		defer func() { _ = tx.Rollback(ctx) }()
-
-		for _, u := range updates {
-			_, err = tx.Exec(ctx, `
-				UPDATE dune.items
-				SET stack_size = stack_size + $1::bigint
-				WHERE id = $2::bigint`, u.add, u.id)
-			if err != nil {
-				return msgMutate{err: err}
-			}
-		}
-
-		nextPos := maxPos + 1
-		for _, size := range newStacks {
-			_, err = tx.Exec(ctx, `
-				INSERT INTO dune.items (inventory_id, stack_size, position_index, template_id, quality_level, stats)
-				VALUES ($1::bigint, $2::bigint, $3::bigint, $4::text, $5::bigint, '{}'::jsonb)`,
-				invID, size, nextPos, template, quality)
-			if err != nil {
-				return msgMutate{err: err}
-			}
-			nextPos++
-		}
-
-		if err := tx.Commit(ctx); err != nil {
-			return msgMutate{err: err}
-		}
-
-		msg := fmt.Sprintf("Added %d × %s to player %d", qty, template, playerID)
-		if len(updates) > 0 || len(newStacks) > 0 {
-			msg = fmt.Sprintf(
-				"Added %d × %s to player %d (%d stack(s) topped up, %d new stack(s))",
-				qty, template, playerID, len(updates), len(newStacks))
-		}
-		return msgMutate{ok: msg}
 	}
+	newStackCap := 0
+	if stackMax > 0 {
+		newStackCap = int((remaining + stackMax - 1) / stackMax)
+	}
+	newStacks := make([]int64, 0, newStackCap)
+	for remaining > 0 {
+		size := stackMax
+		if size > remaining {
+			size = remaining
+		}
+		newStacks = append(newStacks, size)
+		remaining -= size
+	}
+	return updates, newStacks
+}
+
+func ensureGiveItemSlotCapacity(inv giveItemInventory, state giveItemInventoryState, newStackCount int) error {
+	if !inv.hasSlotCap {
+		return nil
+	}
+	freeSlots := inv.maxSlots - state.usedSlots
+	if freeSlots < newStackCount {
+		return fmt.Errorf("inventory full: need %d free slots, have %d", newStackCount, freeSlots)
+	}
+	return nil
+}
+
+func applyGiveItemChanges(
+	ctx context.Context,
+	invID int64,
+	template string,
+	quality int64,
+	maxPos int64,
+	updates []giveItemStackUpdate,
+	newStacks []int64,
+) error {
+	tx, err := globalDB.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	for _, u := range updates {
+		if _, err := tx.Exec(ctx, `
+			UPDATE dune.items
+			SET stack_size = stack_size + $1::bigint
+			WHERE id = $2::bigint`, u.add, u.id); err != nil {
+			return err
+		}
+	}
+
+	nextPos := maxPos + 1
+	for _, size := range newStacks {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO dune.items (inventory_id, stack_size, position_index, template_id, quality_level, stats)
+			VALUES ($1::bigint, $2::bigint, $3::bigint, $4::text, $5::bigint, '{}'::jsonb)`,
+			invID, size, nextPos, template, quality); err != nil {
+			return err
+		}
+		nextPos++
+	}
+
+	return tx.Commit(ctx)
+}
+
+func formatGiveItemResult(playerID int64, template string, qty int64, toppedUp, created int) string {
+	msg := fmt.Sprintf("Added %d × %s to player %d", qty, template, playerID)
+	if toppedUp > 0 || created > 0 {
+		return fmt.Sprintf(
+			"Added %d × %s to player %d (%d stack(s) topped up, %d new stack(s))",
+			qty, template, playerID, toppedUp, created)
+	}
+	return msg
 }
 
 // checkInventoryCapacity verifies that qty items of template fit in the player's

--- a/cmd/dune-admin/db_cmd_award_char_xp_test.go
+++ b/cmd/dune-admin/db_cmd_award_char_xp_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComputeAwardCharXPOutcome(t *testing.T) {
+	t.Parallel()
+
+	t.Run("caps xp and marks capped", func(t *testing.T) {
+		t.Parallel()
+		outcome := computeAwardCharXPOutcome(maxCharXP-10, 5, 3, 99)
+		if outcome.newXP != maxCharXP {
+			t.Fatalf("expected capped xp %d, got %d", maxCharXP, outcome.newXP)
+		}
+		if !outcome.capped {
+			t.Fatalf("expected capped=true")
+		}
+		if outcome.newTotalSP != outcome.newLevel+3 {
+			t.Fatalf("expected total SP to include keystone bonus, got level=%d total=%d", outcome.newLevel, outcome.newTotalSP)
+		}
+	})
+
+	t.Run("clamps unspent to zero", func(t *testing.T) {
+		t.Parallel()
+		outcome := computeAwardCharXPOutcome(0, 999, 0, 0)
+		if outcome.newUnspentSP != 0 {
+			t.Fatalf("expected unspent SP clamp to 0, got %d", outcome.newUnspentSP)
+		}
+		if outcome.capped {
+			t.Fatalf("expected capped=false")
+		}
+	})
+}
+
+func TestFormatAwardCharXPSuccess(t *testing.T) {
+	t.Parallel()
+
+	outcome := charXPOutcome{
+		newXP:        1234,
+		newLevel:     42,
+		newUnspentSP: 7,
+		newIntel:     99,
+		capped:       true,
+	}
+	msg := formatAwardCharXPSuccess(777, outcome, 11)
+	if !strings.Contains(msg, "Player 777") ||
+		!strings.Contains(msg, "level 42 (capped at level 200)") ||
+		!strings.Contains(msg, "XP 1234") ||
+		!strings.Contains(msg, "SP 7 unspent (11 spent)") ||
+		!strings.Contains(msg, "Intel 99") {
+		t.Fatalf("unexpected message: %q", msg)
+	}
+}
+
+func TestLoadControllerKeystoneIDs_NoController(t *testing.T) {
+	t.Parallel()
+
+	ids, err := loadControllerKeystoneIDs(t.Context(), 0)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if ids != nil {
+		t.Fatalf("expected nil ids, got %#v", ids)
+	}
+}

--- a/cmd/dune-admin/db_cmd_give_item_test.go
+++ b/cmd/dune-admin/db_cmd_give_item_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestValidateGiveItemInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		playerID  int64
+		template  string
+		qty       int64
+		wantTpl   string
+		wantError string
+	}{
+		{name: "valid", playerID: 123, template: "  Dune.Item  ", qty: 2, wantTpl: "Dune.Item"},
+		{name: "missing-player", playerID: 0, template: "x", qty: 1, wantError: "player ID required"},
+		{name: "missing-template", playerID: 1, template: "   ", qty: 1, wantError: "item template required"},
+		{name: "invalid-qty", playerID: 1, template: "x", qty: 0, wantError: "quantity must be > 0"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := validateGiveItemInput(tt.playerID, tt.template, tt.qty)
+			if tt.wantError != "" {
+				if err == nil || err.Error() != tt.wantError {
+					t.Fatalf("expected error %q, got %v", tt.wantError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantTpl {
+				t.Fatalf("expected template %q, got %q", tt.wantTpl, got)
+			}
+		})
+	}
+}
+
+func TestPlanGiveItemStacks(t *testing.T) {
+	t.Parallel()
+
+	stacks := []giveItemStackSlot{
+		{id: 1, size: 8},
+		{id: 2, size: 10},
+		{id: 3, size: 2},
+	}
+	updates, created := planGiveItemStacks(17, 10, stacks)
+
+	if len(updates) != 2 {
+		t.Fatalf("expected 2 updates, got %d", len(updates))
+	}
+	if updates[0].id != 1 || updates[0].add != 2 {
+		t.Fatalf("unexpected first update: %+v", updates[0])
+	}
+	if updates[1].id != 3 || updates[1].add != 8 {
+		t.Fatalf("unexpected second update: %+v", updates[1])
+	}
+	if len(created) != 1 || created[0] != 7 {
+		t.Fatalf("unexpected created stacks: %#v", created)
+	}
+}
+
+func TestPlanGiveItemStacks_NoStacking(t *testing.T) {
+	t.Parallel()
+
+	updates, created := planGiveItemStacks(3, 1, []giveItemStackSlot{{id: 1, size: 1}})
+	if len(updates) != 0 {
+		t.Fatalf("expected no updates, got %#v", updates)
+	}
+	if len(created) != 3 || created[0] != 1 || created[1] != 1 || created[2] != 1 {
+		t.Fatalf("unexpected created stacks: %#v", created)
+	}
+}
+
+func TestEnsureGiveItemSlotCapacity(t *testing.T) {
+	t.Parallel()
+
+	inv := giveItemInventory{maxSlots: 5, hasSlotCap: true}
+	state := giveItemInventoryState{usedSlots: 3}
+	if err := ensureGiveItemSlotCapacity(inv, state, 2); err != nil {
+		t.Fatalf("expected capacity to fit, got %v", err)
+	}
+	if err := ensureGiveItemSlotCapacity(inv, state, 3); err == nil {
+		t.Fatalf("expected slot-capacity error")
+	}
+}
+
+func TestInventoryItemVolume(t *testing.T) {
+	t.Parallel()
+
+	oldItemData := itemData
+	itemData = itemDataFile{
+		DefaultVolume: 2.5,
+		Items: map[string]itemRule{
+			"dune.item.known": {Volume: 1.25},
+			"dune.item.zero":  {Volume: 0},
+		},
+	}
+	t.Cleanup(func() { itemData = oldItemData })
+
+	override := pgtype.Float8{Float64: 3.0, Valid: true}
+	if got := inventoryItemVolume("any", override); got != 3.0 {
+		t.Fatalf("expected override volume 3.0, got %v", got)
+	}
+	if got := inventoryItemVolume("Dune.Item.Known", pgtype.Float8{}); got != 1.25 {
+		t.Fatalf("expected known-rule volume 1.25, got %v", got)
+	}
+	if got := inventoryItemVolume("Dune.Item.Zero", pgtype.Float8{}); got != 0 {
+		t.Fatalf("expected zero volume from rule, got %v", got)
+	}
+	if got := inventoryItemVolume("Dune.Item.Unknown", pgtype.Float8{}); got != 2.5 {
+		t.Fatalf("expected default volume 2.5, got %v", got)
+	}
+}
+
+func TestFormatGiveItemResult(t *testing.T) {
+	t.Parallel()
+
+	got := formatGiveItemResult(42, "Dune.Item", 3, 1, 2)
+	want := "Added 3 × Dune.Item to player 42 (1 stack(s) topped up, 2 new stack(s))"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestEnsureGiveItemVolumeCapacity(t *testing.T) {
+	t.Parallel()
+
+	oldItemData := itemData
+	itemData = itemDataFile{
+		Items: map[string]itemRule{
+			"dune.item": {Volume: 2},
+		},
+	}
+	t.Cleanup(func() { itemData = oldItemData })
+
+	inv := giveItemInventory{hasVolumeCap: true, maxVolume: 10}
+	state := giveItemInventoryState{usedVolume: 4}
+
+	if err := ensureGiveItemVolumeCapacity(t.Context(), inv, state, "Dune.Item", 3); err != nil {
+		t.Fatalf("expected capacity to fit, got %v", err)
+	}
+	err := ensureGiveItemVolumeCapacity(t.Context(), inv, state, "Dune.Item", 4)
+	if err == nil {
+		t.Fatalf("expected volume-capacity error")
+	}
+}

--- a/cmd/dune-admin/db_cmd_give_item_test.go
+++ b/cmd/dune-admin/db_cmd_give_item_test.go
@@ -153,3 +153,25 @@ func TestEnsureGiveItemVolumeCapacity(t *testing.T) {
 		t.Fatalf("expected volume-capacity error")
 	}
 }
+
+func TestMaxItemsByVolume(t *testing.T) {
+	t.Parallel()
+
+	if got := maxItemsByVolume(100, 40, 15); got != 4 {
+		t.Fatalf("expected 4 items by volume, got %d", got)
+	}
+	if got := maxItemsByVolume(100, 140, 10); got != 0 {
+		t.Fatalf("expected clamped 0 items by volume, got %d", got)
+	}
+}
+
+func TestRequiredStackCount(t *testing.T) {
+	t.Parallel()
+
+	if got := requiredStackCount(10, 3); got != 4 {
+		t.Fatalf("expected 4 required stacks, got %d", got)
+	}
+	if got := requiredStackCount(1, 1); got != 1 {
+		t.Fatalf("expected 1 required stack, got %d", got)
+	}
+}

--- a/cmd/dune-admin/db_cmd_give_item_test.go
+++ b/cmd/dune-admin/db_cmd_give_item_test.go
@@ -94,8 +94,6 @@ func TestEnsureGiveItemSlotCapacity(t *testing.T) {
 }
 
 func TestInventoryItemVolume(t *testing.T) {
-	t.Parallel()
-
 	oldItemData := itemData
 	itemData = itemDataFile{
 		DefaultVolume: 2.5,
@@ -132,8 +130,6 @@ func TestFormatGiveItemResult(t *testing.T) {
 }
 
 func TestEnsureGiveItemVolumeCapacity(t *testing.T) {
-	t.Parallel()
-
 	oldItemData := itemData
 	itemData = itemDataFile{
 		Items: map[string]itemRule{

--- a/cmd/dune-admin/db_cmd_grant_all_keystones_test.go
+++ b/cmd/dune-admin/db_cmd_grant_all_keystones_test.go
@@ -1,0 +1,41 @@
+package main
+
+import "testing"
+
+func TestAllKeystoneIDs(t *testing.T) {
+	t.Parallel()
+
+	ids := allKeystoneIDs()
+	if len(ids) != 205 {
+		t.Fatalf("expected 205 keystone ids, got %d", len(ids))
+	}
+	if ids[0] != 1 || ids[len(ids)-1] != 205 {
+		t.Fatalf("unexpected ID bounds: first=%d last=%d", ids[0], ids[len(ids)-1])
+	}
+	for i, id := range ids {
+		if int(id) != i+1 {
+			t.Fatalf("unexpected id sequence at index %d: got %d", i, id)
+		}
+	}
+}
+
+func TestGrantAllKeystoneTargets(t *testing.T) {
+	t.Parallel()
+
+	bonus := keystoneSPBonus(allKeystoneIDs())
+	expectedTotal, expectedUnspent, gotBonus := grantAllKeystoneTargets(0, 0)
+	if gotBonus != bonus {
+		t.Fatalf("expected bonus %d, got %d", bonus, gotBonus)
+	}
+	if expectedTotal != bonus {
+		t.Fatalf("expected total skill points %d at xp=0, got %d", bonus, expectedTotal)
+	}
+	if expectedUnspent != expectedTotal-1 {
+		t.Fatalf("expected unspent=%d, got %d", expectedTotal-1, expectedUnspent)
+	}
+
+	_, expectedUnspent, _ = grantAllKeystoneTargets(0, 99999)
+	if expectedUnspent != 0 {
+		t.Fatalf("expected negative unspent to clamp to 0, got %d", expectedUnspent)
+	}
+}

--- a/cmd/dune-admin/db_cmd_progression_unlock_test.go
+++ b/cmd/dune-admin/db_cmd_progression_unlock_test.go
@@ -75,6 +75,32 @@ func TestFormatProgressionUnlockSuccess(t *testing.T) {
 	}
 }
 
+func TestProgressionReverseTags(t *testing.T) {
+	t.Parallel()
+
+	base := []string{"A", "B"}
+	got := progressionReverseTags(base, []string{"unknown.node"})
+	if len(got) != 2 || got[0] != "A" || got[1] != "B" {
+		t.Fatalf("expected base tags unchanged for unknown node, got %#v", got)
+	}
+}
+
+func TestFormatProgressionReverseSuccess(t *testing.T) {
+	t.Parallel()
+
+	msg := formatProgressionReverseSuccess("rank19_eligible", "harkonnen", 7, 19)
+	expectParts := []string{
+		"Reversed progression unlock (rank19_eligible/harkonnen)",
+		"reset 7 node(s)",
+		"removed 19 tag(s)",
+	}
+	for _, part := range expectParts {
+		if !strings.Contains(msg, part) {
+			t.Fatalf("expected message to contain %q, got %q", part, msg)
+		}
+	}
+}
+
 func containsString(values []string, target string) bool {
 	for _, value := range values {
 		if value == target {

--- a/cmd/dune-admin/db_cmd_progression_unlock_test.go
+++ b/cmd/dune-admin/db_cmd_progression_unlock_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProgressionFactionConfigFor(t *testing.T) {
+	t.Parallel()
+
+	atreides, err := progressionFactionConfigFor("atreides")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if atreides.factionID != 1 || atreides.alignedFlag != "DialogueFlags.Factions.AlignedAtreides" {
+		t.Fatalf("unexpected atreides config: %+v", atreides)
+	}
+
+	if _, err := progressionFactionConfigFor("unknown"); err == nil {
+		t.Fatalf("expected error for unknown faction")
+	}
+}
+
+func TestProgressionTargetTierForPreset(t *testing.T) {
+	t.Parallel()
+
+	if tier, err := progressionTargetTierForPreset("ch3_start"); err != nil || tier != 5 {
+		t.Fatalf("expected ch3_start => 5, got tier=%d err=%v", tier, err)
+	}
+	if tier, err := progressionTargetTierForPreset("rank19_eligible"); err != nil || tier != 19 {
+		t.Fatalf("expected rank19_eligible => 19, got tier=%d err=%v", tier, err)
+	}
+	if _, err := progressionTargetTierForPreset("bad"); err == nil {
+		t.Fatalf("expected error for bad preset")
+	}
+}
+
+func TestProgressionUnlockTags(t *testing.T) {
+	t.Parallel()
+
+	cfg, _ := progressionFactionConfigFor("atreides")
+	tags := progressionUnlockTags(cfg, 19)
+
+	required := []string{
+		"DialogueFlags.Factions.SentToMeetHawat",
+		"DialogueFlags.Factions.AlignedAtreides",
+		"Journey.LandsraadContractsUnlocked",
+		"Faction.Atreides.Tier0",
+		"Faction.Atreides.Tier5",
+	}
+	for _, tag := range required {
+		if !containsString(tags, tag) {
+			t.Fatalf("expected tag %q in output: %#v", tag, tags)
+		}
+	}
+	if containsString(tags, "Faction.Atreides.Tier6") {
+		t.Fatalf("did not expect Tier6 tag in output")
+	}
+}
+
+func TestFormatProgressionUnlockSuccess(t *testing.T) {
+	t.Parallel()
+
+	msg := formatProgressionUnlockSuccess("ch3_start", "atreides", 12, "Atreides", 5, 777)
+	expectParts := []string{
+		"Progression unlock (ch3_start/atreides)",
+		"12 journey nodes completed",
+		"Atreides tier tags 0–5",
+		"rep tier 5 on controller 777",
+	}
+	for _, part := range expectParts {
+		if !strings.Contains(msg, part) {
+			t.Fatalf("expected message to contain %q, got %q", part, msg)
+		}
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/dune-admin/db_cmd_repair_item_test.go
+++ b/cmd/dune-admin/db_cmd_repair_item_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestRepairItemNoChangeMessage(t *testing.T) {
+	t.Parallel()
+
+	msg := repairItemNoChangeMessage(42, false)
+	if msg.err == nil || msg.err.Error() != "item 42 has no durability field" {
+		t.Fatalf("expected no-durability error, got %+v", msg)
+	}
+
+	msg = repairItemNoChangeMessage(42, true)
+	if msg.err != nil {
+		t.Fatalf("expected success message, got error %v", msg.err)
+	}
+	if msg.ok != "Item 42 already at full durability" {
+		t.Fatalf("unexpected success message: %q", msg.ok)
+	}
+}
+
+func TestRepairItemSuccessMessage(t *testing.T) {
+	t.Parallel()
+
+	msg := repairItemSuccessMessage(99)
+	if msg.err != nil {
+		t.Fatalf("expected nil error, got %v", msg.err)
+	}
+	if msg.ok != "Repaired item 99 — relog to see in-game" {
+		t.Fatalf("unexpected success message: %q", msg.ok)
+	}
+}

--- a/cmd/dune-admin/db_cmd_repair_player_gear_test.go
+++ b/cmd/dune-admin/db_cmd_repair_player_gear_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func floatPtr(v float64) *float64 {
+	return &v
+}
+
+func TestParseDurabilityText(t *testing.T) {
+	t.Parallel()
+
+	if got := parseDurabilityText(pgtype.Text{}); got != 0 {
+		t.Fatalf("expected invalid text to parse as 0, got %v", got)
+	}
+	if got := parseDurabilityText(pgtype.Text{String: "12.5", Valid: true}); got != 12.5 {
+		t.Fatalf("expected 12.5, got %v", got)
+	}
+	if got := parseDurabilityText(pgtype.Text{String: "not-a-number", Valid: true}); got != 0 {
+		t.Fatalf("expected parse failure to fall back to 0, got %v", got)
+	}
+}
+
+func TestRepairTargetForItem(t *testing.T) {
+	originalItemData := itemData
+	itemData = itemDataFile{
+		Items: map[string]itemRule{
+			"dune.item.catalog": {MaxDurability: floatPtr(250)},
+		},
+	}
+	t.Cleanup(func() { itemData = originalItemData })
+
+	tests := []struct {
+		name       string
+		templateID string
+		maxText    pgtype.Text
+		want       float64
+	}{
+		{
+			name:       "catalog value wins",
+			templateID: "Dune.Item.Catalog",
+			maxText:    pgtype.Text{String: "125", Valid: true},
+			want:       250,
+		},
+		{
+			name:       "falls back to max durability text",
+			templateID: "Dune.Item.Unknown",
+			maxText:    pgtype.Text{String: "125", Valid: true},
+			want:       125,
+		},
+		{
+			name:       "invalid max durability text",
+			templateID: "Dune.Item.Unknown",
+			maxText:    pgtype.Text{String: "oops", Valid: true},
+			want:       100,
+		},
+		{
+			name:       "missing max durability text",
+			templateID: "Dune.Item.Unknown",
+			maxText:    pgtype.Text{},
+			want:       100,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := repairTargetForItem(tt.templateID, tt.maxText); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestBuildRepairCandidate(t *testing.T) {
+	originalItemData := itemData
+	itemData = itemDataFile{
+		Items: map[string]itemRule{
+			"dune.item.catalog": {MaxDurability: floatPtr(250)},
+		},
+	}
+	t.Cleanup(func() { itemData = originalItemData })
+
+	tests := []struct {
+		name          string
+		itemID        int64
+		templateID    string
+		maxDurability pgtype.Text
+		current       pgtype.Text
+		decayed       pgtype.Text
+		wantNeedsFix  bool
+		wantTarget    float64
+	}{
+		{
+			name:          "already at target",
+			itemID:        1,
+			templateID:    "Dune.Item.Unknown",
+			maxDurability: pgtype.Text{String: "100", Valid: true},
+			current:       pgtype.Text{String: "100", Valid: true},
+			decayed:       pgtype.Text{String: "100", Valid: true},
+			wantNeedsFix:  false,
+		},
+		{
+			name:          "needs repair by current durability",
+			itemID:        2,
+			templateID:    "Dune.Item.Unknown",
+			maxDurability: pgtype.Text{String: "100", Valid: true},
+			current:       pgtype.Text{String: "75", Valid: true},
+			decayed:       pgtype.Text{String: "100", Valid: true},
+			wantNeedsFix:  true,
+			wantTarget:    100,
+		},
+		{
+			name:          "catalog durability target",
+			itemID:        3,
+			templateID:    "Dune.Item.Catalog",
+			maxDurability: pgtype.Text{String: "100", Valid: true},
+			current:       pgtype.Text{String: "150", Valid: true},
+			decayed:       pgtype.Text{String: "150", Valid: true},
+			wantNeedsFix:  true,
+			wantTarget:    250,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			candidate, needsFix := buildRepairCandidate(tt.itemID, tt.templateID, tt.maxDurability, tt.current, tt.decayed)
+			if needsFix != tt.wantNeedsFix {
+				t.Fatalf("expected needsFix=%v, got %v", tt.wantNeedsFix, needsFix)
+			}
+			if !needsFix {
+				return
+			}
+			if candidate.id != tt.itemID {
+				t.Fatalf("expected item ID %d, got %d", tt.itemID, candidate.id)
+			}
+			if math.Abs(candidate.target-tt.wantTarget) > 0.0001 {
+				t.Fatalf("expected target %.4f, got %.4f", tt.wantTarget, candidate.target)
+			}
+		})
+	}
+}
+
+func TestValidateRepairPlayerGearInput(t *testing.T) {
+	originalDB := globalDB
+	t.Cleanup(func() { globalDB = originalDB })
+
+	globalDB = nil
+	if err := validateRepairPlayerGearInput(42); err == nil || err.Error() != "not connected" {
+		t.Fatalf("expected not connected error, got %v", err)
+	}
+
+	globalDB = &pgxpool.Pool{}
+	if err := validateRepairPlayerGearInput(0); err == nil || err.Error() != "player ID required" {
+		t.Fatalf("expected player ID required error, got %v", err)
+	}
+	if err := validateRepairPlayerGearInput(42); err != nil {
+		t.Fatalf("expected valid input, got %v", err)
+	}
+}

--- a/cmd/dune-admin/db_cmd_repair_vehicle_test.go
+++ b/cmd/dune-admin/db_cmd_repair_vehicle_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestValidateRepairVehicleInput(t *testing.T) {
+	originalDB := globalDB
+	t.Cleanup(func() { globalDB = originalDB })
+
+	globalDB = nil
+	if err := validateRepairVehicleInput(42); err == nil || err.Error() != "not connected" {
+		t.Fatalf("expected not connected error, got %v", err)
+	}
+
+	globalDB = &pgxpool.Pool{}
+	if err := validateRepairVehicleInput(0); err == nil || err.Error() != "player ID required" {
+		t.Fatalf("expected player ID required error, got %v", err)
+	}
+	if err := validateRepairVehicleInput(42); err != nil {
+		t.Fatalf("expected valid input, got %v", err)
+	}
+}
+
+func TestVehicleRepairTarget(t *testing.T) {
+	originalItemData := itemData
+	itemData = itemDataFile{
+		Items: map[string]itemRule{
+			"dune.vehicle.catalog": {MaxDurability: floatPtr(300)},
+		},
+	}
+	t.Cleanup(func() { itemData = originalItemData })
+
+	target, ok := vehicleRepairTarget("Dune.Vehicle.Catalog")
+	if !ok || target != 300 {
+		t.Fatalf("expected catalog target=300, ok=true, got target=%v ok=%v", target, ok)
+	}
+
+	if target, ok = vehicleRepairTarget("Dune.Vehicle.Unknown"); ok || target != 0 {
+		t.Fatalf("expected unknown template to be skipped, got target=%v ok=%v", target, ok)
+	}
+}
+
+func TestRunVehicleModuleRepairs(t *testing.T) {
+	originalItemData := itemData
+	itemData = itemDataFile{
+		Items: map[string]itemRule{
+			"dune.vehicle.repairable": {MaxDurability: floatPtr(125)},
+		},
+	}
+	t.Cleanup(func() { itemData = originalItemData })
+
+	modules := []vehicleModule{
+		{id: 1, templateID: "Dune.Vehicle.Repairable"},
+		{id: 2, templateID: "Dune.Vehicle.Missing"},
+		{id: 3, templateID: "Dune.Vehicle.Repairable"},
+	}
+
+	var repairedIDs []int64
+	summary := runVehicleModuleRepairs(modules, func(module vehicleModule, target float64) error {
+		if target != 125 {
+			t.Fatalf("expected target 125, got %v", target)
+		}
+		repairedIDs = append(repairedIDs, module.id)
+		return nil
+	})
+	if summary.err != nil {
+		t.Fatalf("unexpected error: %v", summary.err)
+	}
+	if summary.total != 3 || summary.repaired != 2 || summary.skipped != 1 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if len(repairedIDs) != 2 || repairedIDs[0] != 1 || repairedIDs[1] != 3 {
+		t.Fatalf("unexpected repaired IDs: %v", repairedIDs)
+	}
+}
+
+func TestRunVehicleModuleRepairs_StopsOnError(t *testing.T) {
+	originalItemData := itemData
+	itemData = itemDataFile{
+		Items: map[string]itemRule{
+			"dune.vehicle.repairable": {MaxDurability: floatPtr(125)},
+		},
+	}
+	t.Cleanup(func() { itemData = originalItemData })
+
+	modules := []vehicleModule{
+		{id: 10, templateID: "Dune.Vehicle.Repairable"},
+		{id: 11, templateID: "Dune.Vehicle.Repairable"},
+		{id: 12, templateID: "Dune.Vehicle.Missing"},
+	}
+
+	failErr := errors.New("boom")
+	summary := runVehicleModuleRepairs(modules, func(module vehicleModule, _ float64) error {
+		if module.id == 11 {
+			return failErr
+		}
+		return nil
+	})
+	if summary.err == nil {
+		t.Fatalf("expected repair error")
+	}
+	if summary.err.Error() != "repair module 11: boom" {
+		t.Fatalf("unexpected error: %v", summary.err)
+	}
+	if summary.total != 3 || summary.repaired != 1 || summary.skipped != 0 {
+		t.Fatalf("unexpected summary after failure: %+v", summary)
+	}
+}

--- a/cmd/dune-admin/db_cmd_reverse_contracts_test.go
+++ b/cmd/dune-admin/db_cmd_reverse_contracts_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestValidateContractMutationInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		accountID int64
+		contracts []string
+		wantError string
+	}{
+		{name: "valid", accountID: 10, contracts: []string{"DA_CT_A"}},
+		{name: "missing-account", accountID: 0, contracts: []string{"DA_CT_A"}, wantError: "account ID required"},
+		{name: "missing-contracts", accountID: 10, contracts: nil, wantError: "at least one contract required"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateContractMutationInput(tt.accountID, tt.contracts)
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantError {
+				t.Fatalf("expected error %q, got %v", tt.wantError, err)
+			}
+		})
+	}
+}
+
+func TestBuildContractRemovalSet(t *testing.T) {
+	t.Parallel()
+
+	originalTagsData := tagsData
+	tagsData = tagsDataFile{
+		ContractAliases: map[string]string{
+			"shortA": "DA_CT_A",
+		},
+		ContractTags: map[string][]string{
+			"DA_CT_A": {"Tag.A", "Tag.B"},
+			"DA_CT_B": {"Tag.B", "Tag.C"},
+		},
+		ContractSkillGrants: map[string][]string{
+			"DA_CT_A": {"Skills.Key.A", "Skills.Key.B"},
+			"DA_CT_B": {"Skills.Key.B", "Skills.Key.C"},
+		},
+	}
+	t.Cleanup(func() { tagsData = originalTagsData })
+
+	set, err := buildContractRemovalSet([]string{"shortA", "DA_CT_B", "shortA"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantResolved := []string{"DA_CT_A", "DA_CT_B", "DA_CT_A"}
+	if !reflect.DeepEqual(set.resolvedNames, wantResolved) {
+		t.Fatalf("unexpected resolved names: %#v", set.resolvedNames)
+	}
+
+	wantTags := []string{"Tag.A", "Tag.B", "Tag.C"}
+	if !reflect.DeepEqual(set.removeTags, wantTags) {
+		t.Fatalf("unexpected remove tags: %#v", set.removeTags)
+	}
+
+	wantSkills := []string{"Skills.Key.A", "Skills.Key.B", "Skills.Key.C"}
+	if !reflect.DeepEqual(set.removeSkills, wantSkills) {
+		t.Fatalf("unexpected remove skills: %#v", set.removeSkills)
+	}
+}
+
+func TestBuildContractRemovalSet_UnknownContract(t *testing.T) {
+	t.Parallel()
+
+	originalTagsData := tagsData
+	tagsData = tagsDataFile{
+		ContractAliases: map[string]string{},
+		ContractTags:    map[string][]string{},
+	}
+	t.Cleanup(func() { tagsData = originalTagsData })
+
+	_, err := buildContractRemovalSet([]string{"missing"})
+	if err == nil {
+		t.Fatal("expected unknown contract error")
+	}
+}
+
+func TestContractBatchSummary(t *testing.T) {
+	t.Parallel()
+
+	if got := contractBatchSummary([]string{"DA_CT_SINGLE"}); got != "DA_CT_SINGLE" {
+		t.Fatalf("unexpected single summary: %q", got)
+	}
+	if got := contractBatchSummary([]string{"A", "B"}); got != "2 contracts" {
+		t.Fatalf("unexpected multi summary: %q", got)
+	}
+}
+
+func TestRemoveContractTags_NoTagsIsNoop(t *testing.T) {
+	t.Parallel()
+
+	if err := removeContractTags(context.Background(), 123, nil); err != nil {
+		t.Fatalf("expected no-op nil tags, got %v", err)
+	}
+}
+
+func TestStripContractSkillBlocks_NoopCases(t *testing.T) {
+	t.Parallel()
+
+	if stripped, err := stripContractSkillBlocks(context.Background(), 0, []string{"Skills.Key.A"}); err != nil || stripped != 0 {
+		t.Fatalf("expected pawn 0 no-op, stripped=%d err=%v", stripped, err)
+	}
+	if stripped, err := stripContractSkillBlocks(context.Background(), 10, nil); err != nil || stripped != 0 {
+		t.Fatalf("expected empty skills no-op, stripped=%d err=%v", stripped, err)
+	}
+}

--- a/cmd/dune-admin/db_cmd_reverse_contracts_test.go
+++ b/cmd/dune-admin/db_cmd_reverse_contracts_test.go
@@ -39,8 +39,6 @@ func TestValidateContractMutationInput(t *testing.T) {
 }
 
 func TestBuildContractRemovalSet(t *testing.T) {
-	t.Parallel()
-
 	originalTagsData := tagsData
 	tagsData = tagsDataFile{
 		ContractAliases: map[string]string{
@@ -79,8 +77,6 @@ func TestBuildContractRemovalSet(t *testing.T) {
 }
 
 func TestBuildContractRemovalSet_UnknownContract(t *testing.T) {
-	t.Parallel()
-
 	originalTagsData := tagsData
 	tagsData = tagsDataFile{
 		ContractAliases: map[string]string{},
@@ -121,5 +117,27 @@ func TestStripContractSkillBlocks_NoopCases(t *testing.T) {
 	}
 	if stripped, err := stripContractSkillBlocks(context.Background(), 10, nil); err != nil || stripped != 0 {
 		t.Fatalf("expected empty skills no-op, stripped=%d err=%v", stripped, err)
+	}
+}
+
+func TestApplyContractSkillGrants_NoSkillsIsNoop(t *testing.T) {
+	t.Parallel()
+
+	extra, err := applyContractSkillGrants(context.Background(), 123, nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if extra != "" {
+		t.Fatalf("expected empty extra string, got %q", extra)
+	}
+}
+
+func TestContractShortNames(t *testing.T) {
+	t.Parallel()
+
+	got := contractShortNames([]string{"DA_CT_Trainer", "NoPrefix"})
+	want := []string{"Trainer", "NoPrefix"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected short names: %#v", got)
 	}
 }

--- a/cmd/dune-admin/db_cmd_run_sql_test.go
+++ b/cmd/dune-admin/db_cmd_run_sql_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatSQLRow(t *testing.T) {
+	t.Parallel()
+
+	row := formatSQLRow([]any{int64(7), "name", nil})
+	if row != "7 │ name │ <nil>" {
+		t.Fatalf("unexpected row format: %q", row)
+	}
+}
+
+func TestBuildSQLResult(t *testing.T) {
+	t.Parallel()
+
+	result := buildSQLResult(
+		[]string{"id", "name"},
+		[][]any{
+			{int64(1), "alpha"},
+			{int64(2), "beta"},
+		},
+		false,
+	)
+	if !strings.Contains(result, "id │ name\n") {
+		t.Fatalf("expected header line in result: %q", result)
+	}
+	if !strings.Contains(result, "1 │ alpha\n") || !strings.Contains(result, "2 │ beta\n") {
+		t.Fatalf("expected row lines in result: %q", result)
+	}
+	if strings.Contains(result, "limited to 200 rows") {
+		t.Fatalf("did not expect truncation marker in non-truncated result")
+	}
+
+	truncated := buildSQLResult([]string{"id"}, [][]any{{1}}, true)
+	if !strings.Contains(truncated, "… (limited to 200 rows)\n") {
+		t.Fatalf("expected truncation marker in truncated result: %q", truncated)
+	}
+}

--- a/cmd/dune-admin/db_cmd_sample_table_test.go
+++ b/cmd/dune-admin/db_cmd_sample_table_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestSampleTableQuery(t *testing.T) {
+	t.Parallel()
+
+	origSchema := dbSchema
+	t.Cleanup(func() { dbSchema = origSchema })
+	dbSchema = "dune"
+
+	query := sampleTableQuery(`items"; DROP TABLE dune.items; --`, 25)
+	want := `SELECT * FROM "dune"."items""; DROP TABLE dune.items; --" LIMIT 25`
+	if query != want {
+		t.Fatalf("unexpected query sanitization\nwant: %q\ngot:  %q", want, query)
+	}
+}
+
+func TestFormatSampleRow(t *testing.T) {
+	t.Parallel()
+
+	row := formatSampleRow([]any{int64(1), "alpha", nil, true})
+	want := []string{"1", "alpha", "<nil>", "true"}
+	if len(row) != len(want) {
+		t.Fatalf("unexpected row length: got %d want %d", len(row), len(want))
+	}
+	for i := range want {
+		if row[i] != want[i] {
+			t.Fatalf("unexpected row[%d]: got %q want %q", i, row[i], want[i])
+		}
+	}
+}

--- a/cmd/dune-admin/db_cmd_set_starter_class_test.go
+++ b/cmd/dune-admin/db_cmd_set_starter_class_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveStarterClassAbility(t *testing.T) {
+	originalTagsData := tagsData
+	t.Cleanup(func() { tagsData = originalTagsData })
+
+	tagsData = tagsDataFile{
+		JobSkillBlocks: map[string][]string{
+			"Trooper": {"Skills.Key.Trooper1"},
+		},
+	}
+
+	ability, err := resolveStarterClassAbility("Trooper")
+	if err != nil {
+		t.Fatalf("unexpected error resolving known job: %v", err)
+	}
+	if ability != "Skills.Ability.SuspensorGrenade_Reduction" {
+		t.Fatalf("unexpected starter ability: %q", ability)
+	}
+
+	if _, err := resolveStarterClassAbility("Unknown"); err == nil {
+		t.Fatalf("expected error for unknown job")
+	}
+}
+
+func TestStarterKeysToRemove(t *testing.T) {
+	t.Parallel()
+
+	if keys := starterKeysToRemove("", "Trooper"); len(keys) != 0 {
+		t.Fatalf("expected no keys when old starter is empty, got %#v", keys)
+	}
+	if keys := starterKeysToRemove("Skills.Key.Trooper1", "Trooper"); len(keys) != 0 {
+		t.Fatalf("expected no keys when switching to same job, got %#v", keys)
+	}
+
+	keys := starterKeysToRemove("Skills.Key.Mentat1", "Trooper")
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys to remove, got %#v", keys)
+	}
+	if keys[0] != `(TagName="Skills.Key.Mentat1")` {
+		t.Fatalf("unexpected starter key removal: %q", keys[0])
+	}
+	if keys[1] != `(TagName="Skills.Ability.PoisonCapsuleLauncher")` {
+		t.Fatalf("unexpected ability key removal: %q", keys[1])
+	}
+}
+
+func TestStarterClassTagAndKeys(t *testing.T) {
+	t.Parallel()
+
+	tag, starterKey, abilityKey := starterClassTagAndKeys("Trooper", "Skills.Ability.SuspensorGrenade_Reduction")
+	if tag != "Skills.Key.Trooper1" {
+		t.Fatalf("unexpected starter tag: %q", tag)
+	}
+	if starterKey != `(TagName="Skills.Key.Trooper1")` {
+		t.Fatalf("unexpected starter key: %q", starterKey)
+	}
+	if abilityKey != `(TagName="Skills.Ability.SuspensorGrenade_Reduction")` {
+		t.Fatalf("unexpected ability key: %q", abilityKey)
+	}
+}
+
+func TestFormatStarterClassMessage(t *testing.T) {
+	t.Parallel()
+
+	msg := formatStarterClassMessage("Trooper", "Skills.Key.Trooper1", "Skills.Ability.SuspensorGrenade_Reduction", 2)
+	if !strings.Contains(msg, "Starter class set to Trooper") ||
+		!strings.Contains(msg, "Skills.Key.Trooper1 + Skills.Ability.SuspensorGrenade_Reduction active") ||
+		!strings.Contains(msg, "cleared previous starter (2 module(s))") {
+		t.Fatalf("unexpected message: %q", msg)
+	}
+}

--- a/cmd/dune-admin/handlers_bases.go
+++ b/cmd/dune-admin/handlers_bases.go
@@ -79,77 +79,56 @@ func handleListBases(w http.ResponseWriter, _ *http.Request) {
 	jsonOK(w, rows)
 }
 
-func handleExportBase(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
-	if err != nil {
-		jsonErr(w, fmt.Errorf("invalid id"), 400)
-		return
-	}
-	if globalDB == nil {
-		jsonErr(w, fmt.Errorf("not connected"), 500)
-		return
-	}
-	ctx := context.Background()
+type rawBaseInstance struct {
+	buildingType  string
+	transform     []float32
+	ownerEntityID int64
+}
 
-	iRows, err := globalDB.Query(ctx, `
+type rawBasePlaceable struct {
+	buildingType string
+	location     string
+	rotation     string
+	properties   map[string]any
+}
+
+func parseBasePathID(id string) (int64, error) {
+	parsedID, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid id")
+	}
+	return parsedID, nil
+}
+
+func queryBaseExportInstances(ctx context.Context, id int64) ([]rawBaseInstance, error) {
+	rows, err := globalDB.Query(ctx, `
 		SELECT building_type, transform, owner_entity_id
 		FROM dune.building_instances
 		WHERE building_id = $1`, id)
 	if err != nil {
-		jsonErr(w, fmt.Errorf("query instances: %w", err), 500)
-		return
+		return nil, fmt.Errorf("query instances: %w", err)
 	}
-	defer iRows.Close()
+	defer rows.Close()
 
-	type rawInstance struct {
-		btype         string
-		t             []float32
-		ownerEntityID int64
-	}
-	var raws []rawInstance
-	for iRows.Next() {
-		var ri rawInstance
-		if err := iRows.Scan(&ri.btype, &ri.t, &ri.ownerEntityID); err != nil {
+	raws := make([]rawBaseInstance, 0, 32)
+	for rows.Next() {
+		var ri rawBaseInstance
+		if err := rows.Scan(&ri.buildingType, &ri.transform, &ri.ownerEntityID); err != nil {
 			continue
 		}
-		if len(ri.t) < 7 {
+		if len(ri.transform) < 7 {
 			continue
 		}
 		raws = append(raws, ri)
 	}
-	if err := iRows.Err(); err != nil {
-		jsonErr(w, fmt.Errorf("read instances: %w", err), 500)
-		return
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read instances: %w", err)
 	}
-	if len(raws) == 0 {
-		jsonErr(w, fmt.Errorf("building %d not found or empty", id), 404)
-		return
-	}
+	return raws, nil
+}
 
-	ownerEntityID := raws[0].ownerEntityID
-
-	var sumX, sumY, sumZ float64
-	for _, ri := range raws {
-		sumX += float64(ri.t[0])
-		sumY += float64(ri.t[1])
-		sumZ += float64(ri.t[2])
-	}
-	n := float64(len(raws))
-	cx, cy, cz := sumX/n, sumY/n, sumZ/n
-
-	instances := make([]blueprintInstance, 0, len(raws))
-	for _, ri := range raws {
-		qx, qy, qz, qw := float64(ri.t[3]), float64(ri.t[4]), float64(ri.t[5]), float64(ri.t[6])
-		instances = append(instances, blueprintInstance{
-			BuildingType: ri.btype,
-			X:            float64(ri.t[0]) - cx,
-			Y:            float64(ri.t[1]) - cy,
-			Z:            float64(ri.t[2]) - cz,
-			Rotation:     quatToYaw(qx, qy, qz, qw),
-		})
-	}
-
-	pRows, err := globalDB.Query(ctx, `
+func queryBaseExportPlaceables(ctx context.Context, ownerEntityID int64) ([]rawBasePlaceable, error) {
+	rows, err := globalDB.Query(ctx, `
 		SELECT p.building_type,
 		       (a.transform).location::text,
 		       (a.transform).rotation::text,
@@ -158,83 +137,126 @@ func handleExportBase(w http.ResponseWriter, r *http.Request) {
 		JOIN dune.actors a ON a.id = p.id
 		WHERE p.owner_entity_id = $1`, ownerEntityID)
 	if err != nil {
-		jsonErr(w, fmt.Errorf("query placeables: %w", err), 500)
-		return
+		return nil, fmt.Errorf("query placeables: %w", err)
 	}
-	defer pRows.Close()
+	defer rows.Close()
 
-	var placeables []blueprintPlaceable
-	var pentashields []blueprintPentashield
-
-	for pRows.Next() {
-		var btype, locStr, rotStr string
-		var props map[string]any
-		if err := pRows.Scan(&btype, &locStr, &rotStr, &props); err != nil {
+	raws := make([]rawBasePlaceable, 0, 32)
+	for rows.Next() {
+		var rp rawBasePlaceable
+		if err := rows.Scan(&rp.buildingType, &rp.location, &rp.rotation, &rp.properties); err != nil {
 			continue
 		}
-		// Totem is base-specific (land claim anchor) — never export it.
-		if btype == "Totem_Placeable" {
-			continue
-		}
-		lx, ly, lz, locErr := parseVec3(locStr)
-		qx, qy, qz, qw, rotErr := parseVec4(rotStr)
-		if locErr != nil || rotErr != nil {
-			continue
-		}
-		rx, ry, rz := quatToEuler(qx, qy, qz, qw)
+		raws = append(raws, rp)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read placeables: %w", err)
+	}
+	return raws, nil
+}
 
-		if strings.Contains(btype, "PentashieldSurface") {
-			// Only include pentashield placeables if scale data is present;
-			// a zero scale means the server has no data and would crash on import.
-			scale := [3]int{0, 0, 0}
-			found := false
-			if props != nil {
-				if inner, ok := props[strings.TrimSuffix(btype, "_Placeable")+"_C"].(map[string]any); ok {
-					if sv, ok := inner["m_Scale"].([]any); ok && len(sv) >= 3 {
-						for i := range 3 {
-							if f, ok := sv[i].(float64); ok {
-								scale[i] = int(f)
-							}
-						}
-						found = true
-					}
-				}
-			}
-			if !found {
-				continue
-			}
-			idx := len(placeables)
-			placeables = append(placeables, blueprintPlaceable{
-				BuildingType: btype,
-				X:            lx - cx,
-				Y:            ly - cy,
-				Z:            lz - cz,
-				RX:           rx,
-				RY:           ry,
-				RZ:           rz,
-			})
-			pentashields = append(pentashields, blueprintPentashield{
-				PlaceableID: idx,
-				Scale:       scale,
-			})
-			continue
-		}
+func calculateBaseCentroid(raws []rawBaseInstance) (float64, float64, float64) {
+	var sumX, sumY, sumZ float64
+	for _, ri := range raws {
+		sumX += float64(ri.transform[0])
+		sumY += float64(ri.transform[1])
+		sumZ += float64(ri.transform[2])
+	}
+	n := float64(len(raws))
+	return sumX / n, sumY / n, sumZ / n
+}
 
-		placeables = append(placeables, blueprintPlaceable{
-			BuildingType: btype,
-			X:            lx - cx,
-			Y:            ly - cy,
-			Z:            lz - cz,
-			RX:           rx,
-			RY:           ry,
-			RZ:           rz,
+func buildBlueprintInstances(raws []rawBaseInstance, cx, cy, cz float64) []blueprintInstance {
+	instances := make([]blueprintInstance, 0, len(raws))
+	for _, ri := range raws {
+		qx, qy, qz, qw := float64(ri.transform[3]), float64(ri.transform[4]), float64(ri.transform[5]), float64(ri.transform[6])
+		instances = append(instances, blueprintInstance{
+			BuildingType: ri.buildingType,
+			X:            float64(ri.transform[0]) - cx,
+			Y:            float64(ri.transform[1]) - cy,
+			Z:            float64(ri.transform[2]) - cz,
+			Rotation:     quatToYaw(qx, qy, qz, qw),
 		})
 	}
-	if err := pRows.Err(); err != nil {
-		jsonErr(w, fmt.Errorf("read placeables: %w", err), 500)
-		return
-	}
+	return instances
+}
 
+func extractPentashieldScale(buildingType string, props map[string]any) ([3]int, bool) {
+	var scale [3]int
+	if props == nil {
+		return scale, false
+	}
+	inner, ok := props[strings.TrimSuffix(buildingType, "_Placeable")+"_C"].(map[string]any)
+	if !ok {
+		return scale, false
+	}
+	scaleValues, ok := inner["m_Scale"].([]any)
+	if !ok || len(scaleValues) < 3 {
+		return scale, false
+	}
+	for i := 0; i < 3; i++ {
+		value, ok := scaleValues[i].(float64)
+		if !ok {
+			return scale, false
+		}
+		scale[i] = int(value)
+	}
+	return scale, true
+}
+
+func convertExportPlaceable(raw rawBasePlaceable, cx, cy, cz float64, placeableID int) (blueprintPlaceable, *blueprintPentashield, bool) {
+	if raw.buildingType == "Totem_Placeable" {
+		return blueprintPlaceable{}, nil, false
+	}
+	lx, ly, lz, locErr := parseVec3(raw.location)
+	qx, qy, qz, qw, rotErr := parseVec4(raw.rotation)
+	if locErr != nil || rotErr != nil {
+		return blueprintPlaceable{}, nil, false
+	}
+	rx, ry, rz := quatToEuler(qx, qy, qz, qw)
+	placeable := blueprintPlaceable{
+		BuildingType: raw.buildingType,
+		X:            lx - cx,
+		Y:            ly - cy,
+		Z:            lz - cz,
+		RX:           rx,
+		RY:           ry,
+		RZ:           rz,
+	}
+	if !strings.Contains(raw.buildingType, "PentashieldSurface") {
+		return placeable, nil, true
+	}
+	scale, ok := extractPentashieldScale(raw.buildingType, raw.properties)
+	if !ok {
+		return blueprintPlaceable{}, nil, false
+	}
+	return placeable, &blueprintPentashield{PlaceableID: placeableID, Scale: scale}, true
+}
+
+func buildBlueprintPlaceables(raws []rawBasePlaceable, cx, cy, cz float64) ([]blueprintPlaceable, []blueprintPentashield) {
+	placeables := make([]blueprintPlaceable, 0, len(raws))
+	pentashields := make([]blueprintPentashield, 0, len(raws))
+	for _, raw := range raws {
+		nextID := len(placeables)
+		placeable, pentashield, ok := convertExportPlaceable(raw, cx, cy, cz, nextID)
+		if !ok {
+			continue
+		}
+		placeables = append(placeables, placeable)
+		if pentashield != nil {
+			pentashields = append(pentashields, *pentashield)
+		}
+	}
+	return placeables, pentashields
+}
+
+func writeExportBaseResponse(
+	w http.ResponseWriter,
+	id int64,
+	instances []blueprintInstance,
+	placeables []blueprintPlaceable,
+	pentashields []blueprintPentashield,
+) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="base_%d.json"`, id))
 	jsonOK(w, blueprintFile{
@@ -242,4 +264,38 @@ func handleExportBase(w http.ResponseWriter, r *http.Request) {
 		Placeables:   placeables,
 		Pentashields: pentashields,
 	})
+}
+
+func handleExportBase(w http.ResponseWriter, r *http.Request) {
+	id, err := parseBasePathID(r.PathValue("id"))
+	if err != nil {
+		jsonErr(w, err, 400)
+		return
+	}
+	if globalDB == nil {
+		jsonErr(w, fmt.Errorf("not connected"), 500)
+		return
+	}
+	ctx := context.Background()
+
+	rawInstances, err := queryBaseExportInstances(ctx, id)
+	if err != nil {
+		jsonErr(w, err, 500)
+		return
+	}
+	if len(rawInstances) == 0 {
+		jsonErr(w, fmt.Errorf("building %d not found or empty", id), 404)
+		return
+	}
+
+	cx, cy, cz := calculateBaseCentroid(rawInstances)
+	instances := buildBlueprintInstances(rawInstances, cx, cy, cz)
+
+	rawPlaceables, err := queryBaseExportPlaceables(ctx, rawInstances[0].ownerEntityID)
+	if err != nil {
+		jsonErr(w, err, 500)
+		return
+	}
+	placeables, pentashields := buildBlueprintPlaceables(rawPlaceables, cx, cy, cz)
+	writeExportBaseResponse(w, id, instances, placeables, pentashields)
 }

--- a/cmd/dune-admin/handlers_bases_export_test.go
+++ b/cmd/dune-admin/handlers_bases_export_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+func nearlyEqual(a, b, epsilon float64) bool {
+	return math.Abs(a-b) <= epsilon
+}
+
+func TestParseBasePathID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantID    int64
+		wantError string
+	}{
+		{name: "valid", input: "123", wantID: 123},
+		{name: "invalid", input: "abc", wantError: "invalid id"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseBasePathID(tt.input)
+			if tt.wantError != "" {
+				if err == nil || err.Error() != tt.wantError {
+					t.Fatalf("expected error %q, got %v", tt.wantError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantID {
+				t.Fatalf("expected ID %d, got %d", tt.wantID, got)
+			}
+		})
+	}
+}
+
+func TestCalculateBaseCentroid(t *testing.T) {
+	t.Parallel()
+
+	raws := []rawBaseInstance{
+		{transform: []float32{10, 20, 30, 0, 0, 0, 1}},
+		{transform: []float32{14, 24, 34, 0, 0, 0, 1}},
+	}
+
+	cx, cy, cz := calculateBaseCentroid(raws)
+	if cx != 12 || cy != 22 || cz != 32 {
+		t.Fatalf("unexpected centroid: (%v, %v, %v)", cx, cy, cz)
+	}
+}
+
+func TestBuildBlueprintInstances(t *testing.T) {
+	t.Parallel()
+
+	raws := []rawBaseInstance{
+		{
+			buildingType: "A",
+			transform:    []float32{10, 20, 30, 0, 0, 0, 1},
+		},
+		{
+			buildingType: "B",
+			transform:    []float32{14, 24, 34, 0, 0, 0.70710677, 0.70710677},
+		},
+	}
+
+	cx, cy, cz := calculateBaseCentroid(raws)
+	got := buildBlueprintInstances(raws, cx, cy, cz)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 instances, got %d", len(got))
+	}
+
+	if got[0].BuildingType != "A" || got[1].BuildingType != "B" {
+		t.Fatalf("unexpected building types: %#v", got)
+	}
+
+	if got[0].X != -2 || got[0].Y != -2 || got[0].Z != -2 {
+		t.Fatalf("unexpected first offsets: %+v", got[0])
+	}
+	if !nearlyEqual(got[0].Rotation, 0, 0.001) {
+		t.Fatalf("unexpected first rotation: %v", got[0].Rotation)
+	}
+	if !nearlyEqual(got[1].Rotation, 90, 0.01) {
+		t.Fatalf("unexpected second rotation: %v", got[1].Rotation)
+	}
+}
+
+func TestConvertExportPlaceable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		raw            rawBasePlaceable
+		cx             float64
+		cy             float64
+		cz             float64
+		placeableID    int
+		wantInclude    bool
+		wantHasPenta   bool
+		wantPlaceableX float64
+	}{
+		{
+			name:        "skip totem",
+			raw:         rawBasePlaceable{buildingType: "Totem_Placeable"},
+			wantInclude: false,
+		},
+		{
+			name: "skip invalid transform",
+			raw: rawBasePlaceable{
+				buildingType: "SomeType_Placeable",
+				location:     "invalid",
+				rotation:     "(0,0,0,1)",
+			},
+			wantInclude: false,
+		},
+		{
+			name: "normal placeable",
+			raw: rawBasePlaceable{
+				buildingType: "SomeType_Placeable",
+				location:     "(10,20,30)",
+				rotation:     "(0,0,0,1)",
+			},
+			cx:             1,
+			cy:             2,
+			cz:             3,
+			wantInclude:    true,
+			wantHasPenta:   false,
+			wantPlaceableX: 9,
+		},
+		{
+			name: "pentashield with scale",
+			raw: rawBasePlaceable{
+				buildingType: "MyPentashieldSurface_Placeable",
+				location:     "(10,20,30)",
+				rotation:     "(0,0,0,1)",
+				properties: map[string]any{
+					"MyPentashieldSurface_C": map[string]any{
+						"m_Scale": []any{3.0, 4.0, 5.0},
+					},
+				},
+			},
+			cx:             1,
+			cy:             2,
+			cz:             3,
+			placeableID:    7,
+			wantInclude:    true,
+			wantHasPenta:   true,
+			wantPlaceableX: 9,
+		},
+		{
+			name: "pentashield without scale skipped",
+			raw: rawBasePlaceable{
+				buildingType: "MyPentashieldSurface_Placeable",
+				location:     "(10,20,30)",
+				rotation:     "(0,0,0,1)",
+				properties: map[string]any{
+					"MyPentashieldSurface_C": map[string]any{},
+				},
+			},
+			wantInclude: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			placeable, pentashield, include := convertExportPlaceable(tt.raw, tt.cx, tt.cy, tt.cz, tt.placeableID)
+			if include != tt.wantInclude {
+				t.Fatalf("expected include=%v, got %v", tt.wantInclude, include)
+			}
+			if !include {
+				return
+			}
+			if placeable.X != tt.wantPlaceableX {
+				t.Fatalf("unexpected placeable X: %v", placeable.X)
+			}
+			if (pentashield != nil) != tt.wantHasPenta {
+				t.Fatalf("expected pentashield=%v, got %v", tt.wantHasPenta, pentashield != nil)
+			}
+			if pentashield != nil {
+				if pentashield.PlaceableID != tt.placeableID {
+					t.Fatalf("expected pentashield placeable id %d, got %d", tt.placeableID, pentashield.PlaceableID)
+				}
+				if pentashield.Scale != [3]int{3, 4, 5} {
+					t.Fatalf("unexpected pentashield scale: %#v", pentashield.Scale)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildBlueprintPlaceables_AssignsPentashieldIndex(t *testing.T) {
+	t.Parallel()
+
+	raws := []rawBasePlaceable{
+		{buildingType: "Totem_Placeable"},
+		{
+			buildingType: "Normal_Placeable",
+			location:     "(1,1,1)",
+			rotation:     "(0,0,0,1)",
+		},
+		{
+			buildingType: "ShieldPentashieldSurface_Placeable",
+			location:     "(2,2,2)",
+			rotation:     "(0,0,0,1)",
+			properties: map[string]any{
+				"ShieldPentashieldSurface_C": map[string]any{
+					"m_Scale": []any{1.0, 2.0, 3.0},
+				},
+			},
+		},
+	}
+
+	placeables, pentashields := buildBlueprintPlaceables(raws, 0, 0, 0)
+	if len(placeables) != 2 {
+		t.Fatalf("expected 2 placeables, got %d", len(placeables))
+	}
+	if len(pentashields) != 1 {
+		t.Fatalf("expected 1 pentashield, got %d", len(pentashields))
+	}
+	if pentashields[0].PlaceableID != 1 {
+		t.Fatalf("expected pentashield PlaceableID=1, got %d", pentashields[0].PlaceableID)
+	}
+}

--- a/cmd/dune-admin/handlers_battlegroup.go
+++ b/cmd/dune-admin/handlers_battlegroup.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -395,6 +396,65 @@ func handleBGRestore(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"output": out})
 }
 
+func allowedBackupArchiveEntry(entryName string) (string, bool) {
+	name := filepath.Base(entryName)
+	if strings.ContainsAny(name, "/\\") {
+		return "", false
+	}
+	if strings.HasSuffix(name, ".backup") || strings.HasSuffix(name, ".backup.yaml") {
+		return name, true
+	}
+	return "", false
+}
+
+func writeBackupArchiveEntries(dir string, zr *zip.Reader) (string, error) {
+	var backupName string
+	for _, zf := range zr.File {
+		name, ok := allowedBackupArchiveEntry(zf.Name)
+		if !ok {
+			continue
+		}
+		rc, err := zf.Open()
+		if err != nil {
+			continue
+		}
+		if err := writeBackupFile(dir, name, rc); err != nil {
+			_ = rc.Close()
+			return "", fmt.Errorf("upload failed for %s: %w", name, err)
+		}
+		if err := rc.Close(); err != nil {
+			continue
+		}
+		if strings.HasSuffix(name, ".backup") {
+			backupName = name
+		}
+	}
+	return backupName, nil
+}
+
+func uploadBackupArchive(dir string, file multipart.File) (string, int, error) {
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return "", 400, fmt.Errorf("read zip: %w", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", 400, fmt.Errorf("invalid zip: %w", err)
+	}
+	backupName, err := writeBackupArchiveEntries(dir, zr)
+	if err != nil {
+		return "", 500, err
+	}
+	if backupName == "" {
+		return "", 400, fmt.Errorf("zip contains no .backup file")
+	}
+	return backupName, 200, nil
+}
+
+func isDirectBackupUpload(filename string) bool {
+	return strings.HasSuffix(filename, ".backup") && !strings.ContainsAny(filename, "/\\")
+}
+
 func handleBGBackupUpload(w http.ResponseWriter, r *http.Request) {
 	if globalExecutor == nil {
 		jsonErr(w, fmt.Errorf("not connected"), 503)
@@ -424,55 +484,25 @@ func handleBGBackupUpload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if strings.HasSuffix(filename, ".zip") {
-		data, err := io.ReadAll(file)
+		backupName, status, err := uploadBackupArchive(dir, file)
 		if err != nil {
-			jsonErr(w, fmt.Errorf("read zip: %w", err), 400)
-			return
-		}
-		zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
-		if err != nil {
-			jsonErr(w, fmt.Errorf("invalid zip: %w", err), 400)
-			return
-		}
-		var backupName string
-		for _, zf := range zr.File {
-			name := filepath.Base(zf.Name)
-			if strings.ContainsAny(name, "/\\") {
-				continue
-			}
-			if !strings.HasSuffix(name, ".backup") && !strings.HasSuffix(name, ".backup.yaml") {
-				continue
-			}
-			rc, err := zf.Open()
-			if err != nil {
-				continue
-			}
-			if err := writeBackupFile(dir, name, rc); err != nil {
-				_ = rc.Close()
-				jsonErr(w, fmt.Errorf("upload failed for %s: %w", name, err), 500)
-				return
-			}
-			if err := rc.Close(); err != nil {
-				continue
-			}
-			if strings.HasSuffix(name, ".backup") && !strings.HasSuffix(name, ".yaml") {
-				backupName = name
-			}
-		}
-		if backupName == "" {
-			jsonErr(w, fmt.Errorf("zip contains no .backup file"), 400)
+			jsonErr(w, err, status)
 			return
 		}
 		jsonOK(w, map[string]string{"name": backupName})
-	} else if strings.HasSuffix(filename, ".backup") && !strings.ContainsAny(filename, "/\\") {
+		return
+	}
+
+	if isDirectBackupUpload(filename) {
 		if err := writeBackupFile(dir, filename, file); err != nil {
 			jsonErr(w, fmt.Errorf("upload failed: %w", err), 500)
 			return
 		}
 		jsonOK(w, map[string]string{"name": filename})
-	} else {
-		jsonErr(w, fmt.Errorf("file must be .backup or .zip"), 400)
+		return
 	}
+
+	jsonErr(w, fmt.Errorf("file must be .backup or .zip"), 400)
 }
 
 // restoreViaControl runs a restore command appropriate for the active control plane.

--- a/cmd/dune-admin/handlers_battlegroup_upload_test.go
+++ b/cmd/dune-admin/handlers_battlegroup_upload_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"testing"
+)
+
+type testMultipartFile struct {
+	*bytes.Reader
+}
+
+func (f testMultipartFile) Close() error { return nil }
+
+func TestAllowedBackupArchiveEntry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		entryName string
+		wantName  string
+		wantOK    bool
+	}{
+		{name: "backup", entryName: "save.backup", wantName: "save.backup", wantOK: true},
+		{name: "backup-yaml", entryName: "save.backup.yaml", wantName: "save.backup.yaml", wantOK: true},
+		{name: "nested-path", entryName: "dir/sub/save.backup", wantName: "save.backup", wantOK: true},
+		{name: "non-backup", entryName: "notes.txt", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotName, gotOK := allowedBackupArchiveEntry(tt.entryName)
+			if gotOK != tt.wantOK {
+				t.Fatalf("expected ok=%v, got %v", tt.wantOK, gotOK)
+			}
+			if gotName != tt.wantName {
+				t.Fatalf("expected name %q, got %q", tt.wantName, gotName)
+			}
+		})
+	}
+}
+
+func TestIsDirectBackupUpload(t *testing.T) {
+	t.Parallel()
+
+	if !isDirectBackupUpload("save.backup") {
+		t.Fatal("expected plain .backup filename to be accepted")
+	}
+	if isDirectBackupUpload("save.zip") {
+		t.Fatal("expected .zip to be rejected for direct backup upload")
+	}
+	if isDirectBackupUpload("../save.backup") {
+		t.Fatal("expected path traversal to be rejected")
+	}
+}
+
+func TestUploadBackupArchive_InvalidZip(t *testing.T) {
+	t.Parallel()
+
+	file := testMultipartFile{Reader: bytes.NewReader([]byte("not a zip"))}
+	_, status, err := uploadBackupArchive("/unused", file)
+	if err == nil {
+		t.Fatal("expected invalid zip error")
+	}
+	if status != 400 {
+		t.Fatalf("expected status 400, got %d", status)
+	}
+}
+
+func TestUploadBackupArchive_NoBackupFile(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("notes.txt")
+	if err != nil {
+		t.Fatalf("create zip entry: %v", err)
+	}
+	if _, err := w.Write([]byte("hello")); err != nil {
+		t.Fatalf("write zip entry: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+
+	file := testMultipartFile{Reader: bytes.NewReader(buf.Bytes())}
+	_, status, err := uploadBackupArchive("/unused", file)
+	if err == nil || err.Error() != "zip contains no .backup file" {
+		t.Fatalf("expected no-backup error, got %v", err)
+	}
+	if status != 400 {
+		t.Fatalf("expected status 400, got %d", status)
+	}
+}

--- a/cmd/dune-admin/handlers_blueprints.go
+++ b/cmd/dune-admin/handlers_blueprints.go
@@ -143,6 +143,150 @@ func isStructuralBuilding(buildingType string) bool {
 	return structuralBuildingTypes[buildingType]
 }
 
+func fetchBlueprintName(ctx context.Context, blueprintID int64) string {
+	var name string
+	_ = globalDB.QueryRow(ctx, `
+		SELECT COALESCE(i.stats->'FBuildingBlueprintItemStats'->1->>'BuildingBlueprintName', '')
+		FROM dune.building_blueprints bb
+		JOIN dune.items i ON i.id = bb.item_id
+		WHERE bb.id = $1`, blueprintID).Scan(&name)
+	return name
+}
+
+func buildBlueprintInstance(iid int, buildingType string, transform []float32, stability bool) (blueprintInstance, bool) {
+	if len(transform) < 4 {
+		return blueprintInstance{}, false
+	}
+	return blueprintInstance{
+		InstanceID:        &iid,
+		BuildingType:      buildingType,
+		X:                 float64(transform[0]),
+		Y:                 float64(transform[1]),
+		Z:                 float64(transform[2]),
+		Rotation:          float64(transform[3]),
+		ProvidesStability: &stability,
+	}, true
+}
+
+func fetchBlueprintInstances(ctx context.Context, blueprintID int64) ([]blueprintInstance, error) {
+	rows, err := globalDB.Query(ctx, `
+		SELECT instance_id, building_type, transform, provides_stability
+		FROM dune.building_blueprint_instances
+		WHERE building_blueprint_id = $1
+		ORDER BY instance_id`, blueprintID)
+	if err != nil {
+		return nil, fmt.Errorf("query instances: %w", err)
+	}
+	defer rows.Close()
+
+	var instances []blueprintInstance
+	for rows.Next() {
+		var iid int
+		var buildingType string
+		var transform []float32
+		var stability bool
+		if err := rows.Scan(&iid, &buildingType, &transform, &stability); err != nil {
+			continue
+		}
+		instance, ok := buildBlueprintInstance(iid, buildingType, transform, stability)
+		if !ok {
+			continue
+		}
+		instances = append(instances, instance)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read instances: %w", err)
+	}
+	return instances, nil
+}
+
+func buildBlueprintPlaceable(pid int, buildingType string, transform []float32) (blueprintPlaceable, bool) {
+	if len(transform) < 6 {
+		return blueprintPlaceable{}, false
+	}
+	return blueprintPlaceable{
+		PlaceableID:  &pid,
+		BuildingType: buildingType,
+		X:            float64(transform[0]),
+		Y:            float64(transform[1]),
+		Z:            float64(transform[2]),
+		RX:           float64(transform[3]),
+		RY:           float64(transform[4]),
+		RZ:           float64(transform[5]),
+	}, true
+}
+
+func fetchBlueprintPlaceables(ctx context.Context, blueprintID int64) ([]blueprintPlaceable, error) {
+	rows, err := globalDB.Query(ctx, `
+		SELECT placeable_id, building_type, transform
+		FROM dune.building_blueprint_placeables
+		WHERE building_blueprint_id = $1
+		ORDER BY placeable_id`, blueprintID)
+	if err != nil {
+		return nil, fmt.Errorf("query placeables: %w", err)
+	}
+	defer rows.Close()
+
+	var placeables []blueprintPlaceable
+	for rows.Next() {
+		var pid int
+		var buildingType string
+		var transform []float32
+		if err := rows.Scan(&pid, &buildingType, &transform); err != nil {
+			continue
+		}
+		placeable, ok := buildBlueprintPlaceable(pid, buildingType, transform)
+		if !ok {
+			continue
+		}
+		placeables = append(placeables, placeable)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read placeables: %w", err)
+	}
+	return placeables, nil
+}
+
+func buildBlueprintPentashield(pid int, scale []int16) (blueprintPentashield, bool) {
+	if len(scale) < 3 {
+		return blueprintPentashield{}, false
+	}
+	return blueprintPentashield{
+		PlaceableID: pid,
+		Scale:       [3]int{int(scale[0]), int(scale[1]), int(scale[2])},
+	}, true
+}
+
+func fetchBlueprintPentashields(ctx context.Context, blueprintID int64) ([]blueprintPentashield, error) {
+	rows, err := globalDB.Query(ctx, `
+		SELECT placeable_id, scale
+		FROM dune.building_blueprint_pentashields
+		WHERE building_blueprint_id = $1
+		ORDER BY placeable_id`, blueprintID)
+	if err != nil {
+		return nil, fmt.Errorf("query pentashields: %w", err)
+	}
+	defer rows.Close()
+
+	var pentashields []blueprintPentashield
+	for rows.Next() {
+		var pid int
+		var scale []int16
+		if err := rows.Scan(&pid, &scale); err != nil {
+			continue
+		}
+		pentashield, ok := buildBlueprintPentashield(pid, scale)
+		if !ok {
+			continue
+		}
+		pentashields = append(pentashields, pentashield)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read pentashields: %w", err)
+	}
+	return pentashields, nil
+}
+
 // fetchBlueprintData fetches blueprint instances, placeables, and pentashields
 // from the DB and returns a blueprintFile ready for JSON serialization.
 func fetchBlueprintData(ctx context.Context, blueprintID int64) (blueprintFile, error) {
@@ -150,116 +294,18 @@ func fetchBlueprintData(ctx context.Context, blueprintID int64) (blueprintFile, 
 		return blueprintFile{}, fmt.Errorf("not connected")
 	}
 
-	// Fetch the blueprint name from the item stats.
-	var name string
-	_ = globalDB.QueryRow(ctx, `
-		SELECT COALESCE(i.stats->'FBuildingBlueprintItemStats'->1->>'BuildingBlueprintName', '')
-		FROM dune.building_blueprints bb
-		JOIN dune.items i ON i.id = bb.item_id
-		WHERE bb.id = $1`, blueprintID).Scan(&name)
-
-	// Fetch instances.
-	iRows, err := globalDB.Query(ctx, `
-		SELECT instance_id, building_type, transform, provides_stability
-		FROM dune.building_blueprint_instances
-		WHERE building_blueprint_id = $1
-		ORDER BY instance_id`, blueprintID)
+	name := fetchBlueprintName(ctx, blueprintID)
+	instances, err := fetchBlueprintInstances(ctx, blueprintID)
 	if err != nil {
-		return blueprintFile{}, fmt.Errorf("query instances: %w", err)
+		return blueprintFile{}, err
 	}
-	defer iRows.Close()
-
-	var instances []blueprintInstance
-	for iRows.Next() {
-		var iid int
-		var btype string
-		var t []float32
-		var stability bool
-		if err := iRows.Scan(&iid, &btype, &t, &stability); err != nil {
-			continue
-		}
-		if len(t) < 4 {
-			continue
-		}
-		instances = append(instances, blueprintInstance{
-			InstanceID:        &iid,
-			BuildingType:      btype,
-			X:                 float64(t[0]),
-			Y:                 float64(t[1]),
-			Z:                 float64(t[2]),
-			Rotation:          float64(t[3]),
-			ProvidesStability: &stability,
-		})
-	}
-	if err := iRows.Err(); err != nil {
-		return blueprintFile{}, fmt.Errorf("read instances: %w", err)
-	}
-
-	// Fetch placeables.
-	pRows, err := globalDB.Query(ctx, `
-		SELECT placeable_id, building_type, transform
-		FROM dune.building_blueprint_placeables
-		WHERE building_blueprint_id = $1
-		ORDER BY placeable_id`, blueprintID)
+	placeables, err := fetchBlueprintPlaceables(ctx, blueprintID)
 	if err != nil {
-		return blueprintFile{}, fmt.Errorf("query placeables: %w", err)
+		return blueprintFile{}, err
 	}
-	defer pRows.Close()
-
-	var placeables []blueprintPlaceable
-	for pRows.Next() {
-		var pid int
-		var btype string
-		var t []float32
-		if err := pRows.Scan(&pid, &btype, &t); err != nil {
-			continue
-		}
-		if len(t) < 6 {
-			continue
-		}
-		placeables = append(placeables, blueprintPlaceable{
-			PlaceableID:  &pid,
-			BuildingType: btype,
-			X:            float64(t[0]),
-			Y:            float64(t[1]),
-			Z:            float64(t[2]),
-			RX:           float64(t[3]),
-			RY:           float64(t[4]),
-			RZ:           float64(t[5]),
-		})
-	}
-	if err := pRows.Err(); err != nil {
-		return blueprintFile{}, fmt.Errorf("read placeables: %w", err)
-	}
-
-	// Fetch pentashield scale data.
-	psRows, err := globalDB.Query(ctx, `
-		SELECT placeable_id, scale
-		FROM dune.building_blueprint_pentashields
-		WHERE building_blueprint_id = $1
-		ORDER BY placeable_id`, blueprintID)
+	pentashields, err := fetchBlueprintPentashields(ctx, blueprintID)
 	if err != nil {
-		return blueprintFile{}, fmt.Errorf("query pentashields: %w", err)
-	}
-	defer psRows.Close()
-
-	var pentashields []blueprintPentashield
-	for psRows.Next() {
-		var pid int
-		var scale []int16
-		if err := psRows.Scan(&pid, &scale); err != nil {
-			continue
-		}
-		if len(scale) < 3 {
-			continue
-		}
-		pentashields = append(pentashields, blueprintPentashield{
-			PlaceableID: pid,
-			Scale:       [3]int{int(scale[0]), int(scale[1]), int(scale[2])},
-		})
-	}
-	if err := psRows.Err(); err != nil {
-		return blueprintFile{}, fmt.Errorf("read pentashields: %w", err)
+		return blueprintFile{}, err
 	}
 
 	return blueprintFile{

--- a/cmd/dune-admin/handlers_blueprints.go
+++ b/cmd/dune-admin/handlers_blueprints.go
@@ -270,6 +270,167 @@ func fetchBlueprintData(ctx context.Context, blueprintID int64) (blueprintFile, 
 	}, nil
 }
 
+const blueprintImportBatchSize = 50
+
+const blueprintPlaceholderStats = `{"FCustomizationStats":[[], {}],"FBuildingBlueprintItemStats":[[], {"PlayerBlueprintId":"!!bbp#0"}],"FItemStackAndDurabilityStats":[[], {"DecayedMaxDurability":0.0}]}`
+
+func findBackpackInventoryID(ctx context.Context, tx pgx.Tx, playerPawnID int64) (int64, error) {
+	var invID int64
+	err := tx.QueryRow(ctx, `
+		SELECT id FROM dune.inventories
+		WHERE actor_id = $1 AND inventory_type = 0
+		LIMIT 1`, playerPawnID).Scan(&invID)
+	if err != nil {
+		return 0, fmt.Errorf("find inventory: %w", err)
+	}
+	return invID, nil
+}
+
+func nextInventoryPosition(ctx context.Context, tx pgx.Tx, inventoryID int64) int64 {
+	var nextPos int64
+	_ = tx.QueryRow(ctx, `
+		SELECT COALESCE(MAX(position_index), -1) + 1
+		FROM dune.items WHERE inventory_id = $1`, inventoryID).Scan(&nextPos)
+	return nextPos
+}
+
+func createBlueprintItem(ctx context.Context, tx pgx.Tx, inventoryID, position int64) (int64, error) {
+	var itemID int64
+	err := tx.QueryRow(ctx, `
+		INSERT INTO dune.items
+			(inventory_id, stack_size, position_index, template_id, quality_level, stats)
+		VALUES ($1, 1, $2, 'BuildingBlueprint_CopyDevice', 0, $3::jsonb)
+		RETURNING id`,
+		inventoryID, position, blueprintPlaceholderStats).Scan(&itemID)
+	if err != nil {
+		return 0, fmt.Errorf("create item: %w", err)
+	}
+	return itemID, nil
+}
+
+func createBlueprintRecord(ctx context.Context, tx pgx.Tx, itemID int64) (int64, error) {
+	var blueprintID int64
+	err := tx.QueryRow(ctx, `
+		INSERT INTO dune.building_blueprints (item_id, player_id, building_blueprint_map)
+		VALUES ($1, null, '')
+		RETURNING id`, itemID).Scan(&blueprintID)
+	if err != nil {
+		return 0, fmt.Errorf("create blueprint: %w", err)
+	}
+	return blueprintID, nil
+}
+
+func blueprintItemStatsJSON(blueprintID int64, name string) string {
+	nameJSON := ""
+	if name != "" {
+		nameJSON = fmt.Sprintf(`,"BuildingBlueprintName":%q`, name)
+	}
+	return fmt.Sprintf(
+		`{"FCustomizationStats":[[], {}],"FBuildingBlueprintItemStats":[[], {"PlayerBlueprintId":"!!bbp#%d"%s}],"FItemStackAndDurabilityStats":[[], {"DecayedMaxDurability":0.0}]}`,
+		blueprintID, nameJSON)
+}
+
+func updateBlueprintItemStats(ctx context.Context, tx pgx.Tx, itemID, blueprintID int64, name string) error {
+	if _, err := tx.Exec(ctx, `UPDATE dune.items SET stats = $1::jsonb WHERE id = $2`,
+		blueprintItemStatsJSON(blueprintID, name), itemID); err != nil {
+		return fmt.Errorf("update item stats: %w", err)
+	}
+	return nil
+}
+
+func resolveBlueprintImportInstance(start, offset int, inst blueprintInstance) (instanceID int, transform string, stability bool) {
+	transform = fmt.Sprintf("{%g,%g,%g,%g}",
+		float32(inst.X), float32(inst.Y), float32(inst.Z), float32(inst.Rotation))
+	instanceID = start + offset + 1
+	if inst.InstanceID != nil {
+		instanceID = *inst.InstanceID
+	}
+	stability = isStructuralBuilding(inst.BuildingType)
+	if inst.ProvidesStability != nil {
+		stability = *inst.ProvidesStability
+	}
+	return instanceID, transform, stability
+}
+
+func insertBlueprintInstances(ctx context.Context, tx pgx.Tx, blueprintID int64, instances []blueprintInstance) error {
+	for start := 0; start < len(instances); start += blueprintImportBatchSize {
+		end := start + blueprintImportBatchSize
+		if end > len(instances) {
+			end = len(instances)
+		}
+		batch := &pgx.Batch{}
+		for i, inst := range instances[start:end] {
+			instanceID, transform, stability := resolveBlueprintImportInstance(start, i, inst)
+			batch.Queue(`
+				INSERT INTO dune.building_blueprint_instances
+					(building_blueprint_id, instance_id, building_type, transform, hologram, provides_stability, health)
+				VALUES ($1, $2, $3, $4::real[], true, $5, 0)`,
+				blueprintID, instanceID, inst.BuildingType, transform, stability)
+		}
+		br := tx.SendBatch(ctx, batch)
+		for i := start; i < end; i++ {
+			if _, err := br.Exec(); err != nil {
+				_ = br.Close()
+				return fmt.Errorf("insert instance %d: %w", i, err)
+			}
+		}
+		_ = br.Close()
+	}
+	return nil
+}
+
+func resolveBlueprintImportPlaceable(start, offset int, pl blueprintPlaceable) (placeableID int, transform string) {
+	transform = fmt.Sprintf("{%g,%g,%g,%g,%g,%g}",
+		float32(pl.X), float32(pl.Y), float32(pl.Z),
+		float32(pl.RX), float32(pl.RY), float32(pl.RZ))
+	placeableID = start + offset + 1
+	if pl.PlaceableID != nil {
+		placeableID = *pl.PlaceableID
+	}
+	return placeableID, transform
+}
+
+func insertBlueprintPlaceables(ctx context.Context, tx pgx.Tx, blueprintID int64, placeables []blueprintPlaceable) error {
+	for start := 0; start < len(placeables); start += blueprintImportBatchSize {
+		end := start + blueprintImportBatchSize
+		if end > len(placeables) {
+			end = len(placeables)
+		}
+		batch := &pgx.Batch{}
+		for i, pl := range placeables[start:end] {
+			placeableID, transform := resolveBlueprintImportPlaceable(start, i, pl)
+			batch.Queue(`
+				INSERT INTO dune.building_blueprint_placeables
+					(building_blueprint_id, placeable_id, building_type, transform, hologram)
+				VALUES ($1, $2, $3, $4::real[], true)`,
+				blueprintID, placeableID, pl.BuildingType, transform)
+		}
+		br := tx.SendBatch(ctx, batch)
+		for i := start; i < end; i++ {
+			if _, err := br.Exec(); err != nil {
+				_ = br.Close()
+				return fmt.Errorf("insert placeable %d: %w", i, err)
+			}
+		}
+		_ = br.Close()
+	}
+	return nil
+}
+
+func insertBlueprintPentashields(ctx context.Context, tx pgx.Tx, blueprintID int64, pentashields []blueprintPentashield) error {
+	for _, ps := range pentashields {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO dune.building_blueprint_pentashields
+				(building_blueprint_id, placeable_id, scale)
+			VALUES ($1, $2, ARRAY[$3,$4,$5]::smallint[])`,
+			blueprintID, ps.PlaceableID,
+			int16(ps.Scale[0]), int16(ps.Scale[1]), int16(ps.Scale[2])); err != nil {
+			return fmt.Errorf("insert pentashield %d: %w", ps.PlaceableID, err)
+		}
+	}
+	return nil
+}
+
 // importBlueprintData imports a blueprintFile into the DB for the given player pawn ID.
 func importBlueprintData(ctx context.Context, playerPawnID int64, bf blueprintFile) Msg {
 	if globalDB == nil {
@@ -287,57 +448,24 @@ func importBlueprintData(ctx context.Context, playerPawnID int64, bf blueprintFi
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	// Get backpack inventory.
-	var invID int64
-	err = tx.QueryRow(ctx, `
-		SELECT id FROM dune.inventories
-		WHERE actor_id = $1 AND inventory_type = 0
-		LIMIT 1`, playerPawnID).Scan(&invID)
+	invID, err := findBackpackInventoryID(ctx, tx, playerPawnID)
 	if err != nil {
-		return msgMutate{err: fmt.Errorf("find inventory: %w", err)}
+		return msgMutate{err: err}
 	}
 
-	// Next free position index.
-	var nextPos int64
-	_ = tx.QueryRow(ctx, `
-		SELECT COALESCE(MAX(position_index), -1) + 1
-		FROM dune.items WHERE inventory_id = $1`, invID).Scan(&nextPos)
-
-	// Placeholder stats — will be updated with real blueprint ID after insert.
-	placeholderStats := `{"FCustomizationStats":[[], {}],"FBuildingBlueprintItemStats":[[], {"PlayerBlueprintId":"!!bbp#0"}],"FItemStackAndDurabilityStats":[[], {"DecayedMaxDurability":0.0}]}`
-
-	var itemID int64
-	err = tx.QueryRow(ctx, `
-		INSERT INTO dune.items
-			(inventory_id, stack_size, position_index, template_id, quality_level, stats)
-		VALUES ($1, 1, $2, 'BuildingBlueprint_CopyDevice', 0, $3::jsonb)
-		RETURNING id`,
-		invID, nextPos, placeholderStats).Scan(&itemID)
+	itemID, err := createBlueprintItem(ctx, tx, invID, nextInventoryPosition(ctx, tx, invID))
 	if err != nil {
-		return msgMutate{err: fmt.Errorf("create item: %w", err)}
+		return msgMutate{err: err}
 	}
 
-	// Insert blueprint master record.
-	var blueprintID int64
-	err = tx.QueryRow(ctx, `
-		INSERT INTO dune.building_blueprints (item_id, player_id, building_blueprint_map)
-		VALUES ($1, null, '')
-		RETURNING id`, itemID).Scan(&blueprintID)
+	blueprintID, err := createBlueprintRecord(ctx, tx, itemID)
 	if err != nil {
-		return msgMutate{err: fmt.Errorf("create blueprint: %w", err)}
+		return msgMutate{err: err}
 	}
 
 	// Update item stats with real blueprint ID and name (no PlayerBaseBackupId — crashes the game).
-	nameJSON := ""
-	if bf.Name != "" {
-		nameJSON = fmt.Sprintf(`,"BuildingBlueprintName":%q`, bf.Name)
-	}
-	fullStats := fmt.Sprintf(
-		`{"FCustomizationStats":[[], {}],"FBuildingBlueprintItemStats":[[], {"PlayerBlueprintId":"!!bbp#%d"%s}],"FItemStackAndDurabilityStats":[[], {"DecayedMaxDurability":0.0}]}`,
-		blueprintID, nameJSON)
-	if _, err = tx.Exec(ctx, `UPDATE dune.items SET stats = $1::jsonb WHERE id = $2`,
-		fullStats, itemID); err != nil {
-		return msgMutate{err: fmt.Errorf("update item stats: %w", err)}
+	if err := updateBlueprintItemStats(ctx, tx, itemID, blueprintID, bf.Name); err != nil {
+		return msgMutate{err: err}
 	}
 
 	// Insert instances in batches of 50.
@@ -346,81 +474,18 @@ func importBlueprintData(ctx context.Context, playerPawnID int64, bf blueprintFi
 	// back to 1-based sequential ids and a structural-type stability lookup —
 	// matching the indexing scheme used by every existing blueprint in the DB
 	// that the source pentashield placeable_id references assume.
-	const batchSize = 50
-	for start := 0; start < len(bf.Instances); start += batchSize {
-		end := start + batchSize
-		if end > len(bf.Instances) {
-			end = len(bf.Instances)
-		}
-		batch := &pgx.Batch{}
-		for i, inst := range bf.Instances[start:end] {
-			transform := fmt.Sprintf("{%g,%g,%g,%g}",
-				float32(inst.X), float32(inst.Y), float32(inst.Z), float32(inst.Rotation))
-			instanceID := start + i + 1
-			if inst.InstanceID != nil {
-				instanceID = *inst.InstanceID
-			}
-			stability := isStructuralBuilding(inst.BuildingType)
-			if inst.ProvidesStability != nil {
-				stability = *inst.ProvidesStability
-			}
-			batch.Queue(`
-				INSERT INTO dune.building_blueprint_instances
-					(building_blueprint_id, instance_id, building_type, transform, hologram, provides_stability, health)
-				VALUES ($1, $2, $3, $4::real[], true, $5, 0)`,
-				blueprintID, instanceID, inst.BuildingType, transform, stability)
-		}
-		br := tx.SendBatch(ctx, batch)
-		for i := start; i < end; i++ {
-			if _, err := br.Exec(); err != nil {
-				_ = br.Close()
-				return msgMutate{err: fmt.Errorf("insert instance %d: %w", i, err)}
-			}
-		}
-		_ = br.Close()
+	if err := insertBlueprintInstances(ctx, tx, blueprintID, bf.Instances); err != nil {
+		return msgMutate{err: err}
 	}
 
 	// Insert placeables in batches of 50.
-	for start := 0; start < len(bf.Placeables); start += batchSize {
-		end := start + batchSize
-		if end > len(bf.Placeables) {
-			end = len(bf.Placeables)
-		}
-		batch := &pgx.Batch{}
-		for i, pl := range bf.Placeables[start:end] {
-			transform := fmt.Sprintf("{%g,%g,%g,%g,%g,%g}",
-				float32(pl.X), float32(pl.Y), float32(pl.Z),
-				float32(pl.RX), float32(pl.RY), float32(pl.RZ))
-			placeableID := start + i + 1
-			if pl.PlaceableID != nil {
-				placeableID = *pl.PlaceableID
-			}
-			batch.Queue(`
-				INSERT INTO dune.building_blueprint_placeables
-					(building_blueprint_id, placeable_id, building_type, transform, hologram)
-				VALUES ($1, $2, $3, $4::real[], true)`,
-				blueprintID, placeableID, pl.BuildingType, transform)
-		}
-		br := tx.SendBatch(ctx, batch)
-		for i := start; i < end; i++ {
-			if _, err := br.Exec(); err != nil {
-				_ = br.Close()
-				return msgMutate{err: fmt.Errorf("insert placeable %d: %w", i, err)}
-			}
-		}
-		_ = br.Close()
+	if err := insertBlueprintPlaceables(ctx, tx, blueprintID, bf.Placeables); err != nil {
+		return msgMutate{err: err}
 	}
 
 	// Insert pentashield scale data.
-	for _, ps := range bf.Pentashields {
-		if _, err = tx.Exec(ctx, `
-			INSERT INTO dune.building_blueprint_pentashields
-				(building_blueprint_id, placeable_id, scale)
-			VALUES ($1, $2, ARRAY[$3,$4,$5]::smallint[])`,
-			blueprintID, ps.PlaceableID,
-			int16(ps.Scale[0]), int16(ps.Scale[1]), int16(ps.Scale[2])); err != nil {
-			return msgMutate{err: fmt.Errorf("insert pentashield %d: %w", ps.PlaceableID, err)}
-		}
+	if err := insertBlueprintPentashields(ctx, tx, blueprintID, bf.Pentashields); err != nil {
+		return msgMutate{err: err}
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/cmd/dune-admin/handlers_blueprints_fetch_test.go
+++ b/cmd/dune-admin/handlers_blueprints_fetch_test.go
@@ -1,0 +1,60 @@
+package main
+
+import "testing"
+
+func TestBuildBlueprintInstance(t *testing.T) {
+	t.Parallel()
+
+	instance, ok := buildBlueprintInstance(7, "TypeA", []float32{1, 2, 3, 4}, true)
+	if !ok {
+		t.Fatalf("expected valid transform to produce an instance")
+	}
+	if instance.InstanceID == nil || *instance.InstanceID != 7 {
+		t.Fatalf("unexpected instance id: %+v", instance.InstanceID)
+	}
+	if instance.BuildingType != "TypeA" || instance.X != 1 || instance.Y != 2 || instance.Z != 3 || instance.Rotation != 4 {
+		t.Fatalf("unexpected instance payload: %+v", instance)
+	}
+	if instance.ProvidesStability == nil || !*instance.ProvidesStability {
+		t.Fatalf("expected stability=true pointer in instance")
+	}
+
+	if _, ok := buildBlueprintInstance(1, "TypeB", []float32{1, 2, 3}, false); ok {
+		t.Fatalf("expected short transform to be rejected")
+	}
+}
+
+func TestBuildBlueprintPlaceable(t *testing.T) {
+	t.Parallel()
+
+	placeable, ok := buildBlueprintPlaceable(9, "TypeP", []float32{1, 2, 3, 4, 5, 6})
+	if !ok {
+		t.Fatalf("expected valid transform to produce a placeable")
+	}
+	if placeable.PlaceableID == nil || *placeable.PlaceableID != 9 {
+		t.Fatalf("unexpected placeable id: %+v", placeable.PlaceableID)
+	}
+	if placeable.BuildingType != "TypeP" || placeable.X != 1 || placeable.Y != 2 || placeable.Z != 3 || placeable.RX != 4 || placeable.RY != 5 || placeable.RZ != 6 {
+		t.Fatalf("unexpected placeable payload: %+v", placeable)
+	}
+
+	if _, ok := buildBlueprintPlaceable(1, "TypeBad", []float32{1, 2, 3, 4, 5}); ok {
+		t.Fatalf("expected short placeable transform to be rejected")
+	}
+}
+
+func TestBuildBlueprintPentashield(t *testing.T) {
+	t.Parallel()
+
+	pentashield, ok := buildBlueprintPentashield(11, []int16{10, 20, 30})
+	if !ok {
+		t.Fatalf("expected valid scale to produce pentashield")
+	}
+	if pentashield.PlaceableID != 11 || pentashield.Scale != [3]int{10, 20, 30} {
+		t.Fatalf("unexpected pentashield payload: %+v", pentashield)
+	}
+
+	if _, ok := buildBlueprintPentashield(1, []int16{1, 2}); ok {
+		t.Fatalf("expected short pentashield scale to be rejected")
+	}
+}

--- a/cmd/dune-admin/handlers_blueprints_import_test.go
+++ b/cmd/dune-admin/handlers_blueprints_import_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func boolPtr(v bool) *bool {
+	return &v
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func TestBlueprintItemStatsJSON(t *testing.T) {
+	withName := blueprintItemStatsJSON(123, "My Blueprint")
+	if !strings.Contains(withName, `"PlayerBlueprintId":"!!bbp#123"`) {
+		t.Fatalf("missing blueprint id in stats JSON: %s", withName)
+	}
+	if !strings.Contains(withName, `"BuildingBlueprintName":"My Blueprint"`) {
+		t.Fatalf("missing blueprint name in stats JSON: %s", withName)
+	}
+
+	withoutName := blueprintItemStatsJSON(77, "")
+	if strings.Contains(withoutName, "BuildingBlueprintName") {
+		t.Fatalf("expected no blueprint name when empty, got: %s", withoutName)
+	}
+}
+
+func TestResolveBlueprintImportInstance(t *testing.T) {
+	inst := blueprintInstance{
+		BuildingType: "Atreides_Outpost_Foundation",
+		X:            1,
+		Y:            2,
+		Z:            3,
+		Rotation:     90,
+	}
+	id, transform, stability := resolveBlueprintImportInstance(50, 2, inst)
+	if id != 53 {
+		t.Fatalf("expected fallback instance id 53, got %d", id)
+	}
+	if transform != "{1,2,3,90}" {
+		t.Fatalf("unexpected transform: %q", transform)
+	}
+	if !stability {
+		t.Fatal("expected structural building fallback to set stability=true")
+	}
+
+	customID := 900
+	inst.InstanceID = intPtr(customID)
+	inst.ProvidesStability = boolPtr(false)
+	id, _, stability = resolveBlueprintImportInstance(0, 0, inst)
+	if id != customID {
+		t.Fatalf("expected explicit instance id %d, got %d", customID, id)
+	}
+	if stability {
+		t.Fatal("expected explicit ProvidesStability override to win")
+	}
+}
+
+func TestResolveBlueprintImportPlaceable(t *testing.T) {
+	pl := blueprintPlaceable{
+		BuildingType: "SomePlaceable",
+		X:            4,
+		Y:            5,
+		Z:            6,
+		RX:           1,
+		RY:           2,
+		RZ:           3,
+	}
+	id, transform := resolveBlueprintImportPlaceable(10, 1, pl)
+	if id != 12 {
+		t.Fatalf("expected fallback placeable id 12, got %d", id)
+	}
+	if transform != "{4,5,6,1,2,3}" {
+		t.Fatalf("unexpected transform: %q", transform)
+	}
+
+	customID := 321
+	pl.PlaceableID = intPtr(customID)
+	id, _ = resolveBlueprintImportPlaceable(0, 0, pl)
+	if id != customID {
+		t.Fatalf("expected explicit placeable id %d, got %d", customID, id)
+	}
+}

--- a/cmd/dune-admin/handlers_config.go
+++ b/cmd/dune-admin/handlers_config.go
@@ -28,44 +28,42 @@ func handleGetConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleSaveConfig writes an updated config, then reconnects.
-func handleSaveConfig(w http.ResponseWriter, r *http.Request) {
-	var cfg appConfig
-	if err := decode(r, &cfg); err != nil {
-		jsonErr(w, fmt.Errorf("decode: %w", err), 400)
+func preserveMaskedDBPass(
+	cfg *appConfig,
+	readFile func(string) ([]byte, error),
+	path string,
+	fallback string,
+) {
+	if cfg.DBPass != "••••••••" {
 		return
 	}
-
-	// If the client sent back the masked placeholder, keep the existing password.
+	existing, err := readFile(path)
+	if err == nil {
+		var old appConfig
+		if yaml.Unmarshal(existing, &old) == nil && old.DBPass != "" {
+			cfg.DBPass = old.DBPass
+		}
+	}
 	if cfg.DBPass == "••••••••" {
-		existing, err := os.ReadFile(configPath())
-		if err == nil {
-			var old appConfig
-			if yaml.Unmarshal(existing, &old) == nil && old.DBPass != "" {
-				cfg.DBPass = old.DBPass
-			}
-		}
-		if cfg.DBPass == "••••••••" {
-			cfg.DBPass = dbPass // fall back to in-memory value
-		}
+		cfg.DBPass = fallback
 	}
+}
 
+func writeConfigFile(cfg appConfig) error {
 	if err := os.MkdirAll(configDir(), 0700); err != nil {
-		jsonErr(w, fmt.Errorf("create config dir: %w", err), 500)
-		return
+		return fmt.Errorf("create config dir: %w", err)
 	}
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
-		jsonErr(w, fmt.Errorf("marshal config: %w", err), 500)
-		return
+		return fmt.Errorf("marshal config: %w", err)
 	}
 	if err := os.WriteFile(configPath(), data, 0600); err != nil {
-		jsonErr(w, fmt.Errorf("write config: %w", err), 500)
-		return
+		return fmt.Errorf("write config: %w", err)
 	}
+	return nil
+}
 
-	// Apply the new values to globals so connectAll picks them up.
-	applyConfig(cfg)
-
+func resetRuntimeConnections() {
 	if globalDB != nil {
 		globalDB.Close()
 		globalDB = nil
@@ -76,6 +74,26 @@ func handleSaveConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	globalSSH = nil
 	globalControl = nil
+}
+
+func handleSaveConfig(w http.ResponseWriter, r *http.Request) {
+	var cfg appConfig
+	if err := decode(r, &cfg); err != nil {
+		jsonErr(w, fmt.Errorf("decode: %w", err), 400)
+		return
+	}
+
+	// If the client sent back the masked placeholder, keep the existing password.
+	preserveMaskedDBPass(&cfg, os.ReadFile, configPath(), dbPass)
+
+	if err := writeConfigFile(cfg); err != nil {
+		jsonErr(w, err, 500)
+		return
+	}
+
+	// Apply the new values to globals so connectAll picks them up.
+	applyConfig(cfg)
+	resetRuntimeConnections()
 
 	if err := connectAll(); err != nil {
 		jsonErr(w, fmt.Errorf("reconnect failed: %w", err), 500)

--- a/cmd/dune-admin/handlers_config_test.go
+++ b/cmd/dune-admin/handlers_config_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPreserveMaskedDBPass(t *testing.T) {
+	t.Parallel()
+
+	t.Run("keeps explicit password", func(t *testing.T) {
+		cfg := appConfig{DBPass: "new-pass"}
+		preserveMaskedDBPass(&cfg, func(string) ([]byte, error) {
+			t.Fatalf("readFile should not be called for explicit password")
+			return nil, nil
+		}, "/tmp/unused", "fallback")
+		if cfg.DBPass != "new-pass" {
+			t.Fatalf("expected explicit password to stay unchanged, got %q", cfg.DBPass)
+		}
+	})
+
+	t.Run("uses existing config password", func(t *testing.T) {
+		cfg := appConfig{DBPass: "••••••••"}
+		preserveMaskedDBPass(&cfg, func(string) ([]byte, error) {
+			return []byte("db_pass: stored-pass\n"), nil
+		}, "/tmp/config.yaml", "fallback")
+		if cfg.DBPass != "stored-pass" {
+			t.Fatalf("expected stored password from config file, got %q", cfg.DBPass)
+		}
+	})
+
+	t.Run("falls back to in-memory password", func(t *testing.T) {
+		cfg := appConfig{DBPass: "••••••••"}
+		preserveMaskedDBPass(&cfg, func(string) ([]byte, error) {
+			return nil, errors.New("no file")
+		}, "/tmp/missing.yaml", "fallback")
+		if cfg.DBPass != "fallback" {
+			t.Fatalf("expected fallback password, got %q", cfg.DBPass)
+		}
+	})
+}

--- a/cmd/dune-admin/handlers_market.go
+++ b/cmd/dune-admin/handlers_market.go
@@ -7,6 +7,86 @@ import (
 	"strings"
 )
 
+type marketItemsFilter struct {
+	search   string
+	category string
+	tier     *int
+	rarity   string
+	owner    string
+}
+
+func buildMarketItemsFilter(r *http.Request) marketItemsFilter {
+	q := r.URL.Query()
+	filter := marketItemsFilter{
+		search:   strings.ToLower(q.Get("search")),
+		category: q.Get("category"),
+		rarity:   strings.ToLower(q.Get("rarity")),
+		owner:    q.Get("owner"),
+	}
+	if tierStr := q.Get("tier"); tierStr != "" {
+		if tier, err := strconv.Atoi(tierStr); err == nil {
+			filter.tier = &tier
+		}
+	}
+	return filter
+}
+
+func marketItemMatchesFilter(it marketItem, filter marketItemsFilter) bool {
+	if filter.search != "" {
+		if !strings.Contains(strings.ToLower(it.DisplayName), filter.search) &&
+			!strings.Contains(strings.ToLower(it.TemplateID), filter.search) {
+			return false
+		}
+	}
+	if filter.category != "" && !strings.HasPrefix(it.Category, filter.category) {
+		return false
+	}
+	if filter.tier != nil && it.Tier != *filter.tier {
+		return false
+	}
+	if filter.rarity != "" && !strings.EqualFold(it.Rarity, filter.rarity) {
+		return false
+	}
+	if filter.owner == "bot" && it.BotStock == 0 {
+		return false
+	}
+	if filter.owner == "player" && (it.TotalStock-it.BotStock) == 0 {
+		return false
+	}
+	return true
+}
+
+func filterMarketItems(items []marketItem, filter marketItemsFilter) []marketItem {
+	filtered := make([]marketItem, 0, len(items))
+	for _, it := range items {
+		if marketItemMatchesFilter(it, filter) {
+			filtered = append(filtered, it)
+		}
+	}
+	return filtered
+}
+
+func marketItemsPagination(r *http.Request, total int) (start, end, page, limit int) {
+	q := r.URL.Query()
+	limit = 100
+	page = 0
+	if parsedLimit, err := strconv.Atoi(q.Get("limit")); err == nil && parsedLimit > 0 && parsedLimit <= 500 {
+		limit = parsedLimit
+	}
+	if parsedPage, err := strconv.Atoi(q.Get("page")); err == nil && parsedPage > 0 {
+		page = parsedPage
+	}
+	start = page * limit
+	end = start + limit
+	if start >= total {
+		start = total
+	}
+	if end > total {
+		end = total
+	}
+	return start, end, page, limit
+}
+
 // handleMarketItems returns all active exchange listings aggregated by template ID.
 // Query params: search, category, tier, rarity, owner (bot|player|all), page, limit.
 func handleMarketItems(w http.ResponseWriter, r *http.Request) {
@@ -25,59 +105,9 @@ func handleMarketItems(w http.ResponseWriter, r *http.Request) {
 		items = []marketItem{}
 	}
 
-	q := r.URL.Query()
-	search := strings.ToLower(q.Get("search"))
-	category := q.Get("category")
-	tierStr := q.Get("tier")
-	rarity := strings.ToLower(q.Get("rarity"))
-	owner := q.Get("owner") // "bot", "player", or "" for all
-
-	// Apply filters in Go — simpler than parameterised SQL for this aggregation query.
-	filtered := items[:0]
-	for _, it := range items {
-		if search != "" {
-			if !strings.Contains(strings.ToLower(it.DisplayName), search) &&
-				!strings.Contains(strings.ToLower(it.TemplateID), search) {
-				continue
-			}
-		}
-		if category != "" && !strings.HasPrefix(it.Category, category) {
-			continue
-		}
-		if tierStr != "" {
-			if t, err := strconv.Atoi(tierStr); err == nil && it.Tier != t {
-				continue
-			}
-		}
-		if rarity != "" && !strings.EqualFold(it.Rarity, rarity) {
-			continue
-		}
-		if owner == "bot" && it.BotStock == 0 {
-			continue
-		}
-		if owner == "player" && (it.TotalStock-it.BotStock) == 0 {
-			continue
-		}
-		filtered = append(filtered, it)
-	}
-
-	// Pagination.
-	limit := 100
-	page := 0
-	if l, err := strconv.Atoi(q.Get("limit")); err == nil && l > 0 && l <= 500 {
-		limit = l
-	}
-	if p, err := strconv.Atoi(q.Get("page")); err == nil && p > 0 {
-		page = p
-	}
-	start := page * limit
-	end := start + limit
-	if start >= len(filtered) {
-		start = len(filtered)
-	}
-	if end > len(filtered) {
-		end = len(filtered)
-	}
+	filter := buildMarketItemsFilter(r)
+	filtered := filterMarketItems(items, filter)
+	start, end, page, limit := marketItemsPagination(r, len(filtered))
 
 	jsonOK(w, map[string]any{
 		"items": filtered[start:end],

--- a/cmd/dune-admin/handlers_market_items_test.go
+++ b/cmd/dune-admin/handlers_market_items_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBuildMarketItemsFilter(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest("GET", "/api/v1/market/items?search=Spice&category=resources&tier=3&rarity=rare&owner=bot", nil)
+	filter := buildMarketItemsFilter(r)
+
+	if filter.search != "spice" || filter.category != "resources" || filter.rarity != "rare" || filter.owner != "bot" {
+		t.Fatalf("unexpected filter fields: %+v", filter)
+	}
+	if filter.tier == nil || *filter.tier != 3 {
+		t.Fatalf("expected tier=3, got %+v", filter.tier)
+	}
+
+	rInvalid := httptest.NewRequest("GET", "/api/v1/market/items?tier=not-a-number", nil)
+	filter = buildMarketItemsFilter(rInvalid)
+	if filter.tier != nil {
+		t.Fatalf("expected invalid tier to be ignored, got %+v", filter.tier)
+	}
+}
+
+func TestMarketItemMatchesFilter(t *testing.T) {
+	t.Parallel()
+
+	item := marketItem{
+		TemplateID:  "Dune.Spice.Raw",
+		DisplayName: "Raw Spice",
+		Category:    "resources/spice",
+		Tier:        3,
+		Rarity:      "Rare",
+		TotalStock:  12,
+		BotStock:    2,
+	}
+
+	if !marketItemMatchesFilter(item, marketItemsFilter{search: "spice"}) {
+		t.Fatal("expected search filter to match")
+	}
+	if marketItemMatchesFilter(item, marketItemsFilter{search: "water"}) {
+		t.Fatal("expected non-matching search to fail")
+	}
+	if marketItemMatchesFilter(item, marketItemsFilter{category: "weapons"}) {
+		t.Fatal("expected non-matching category to fail")
+	}
+	if marketItemMatchesFilter(item, marketItemsFilter{owner: "player", tier: intRef(4)}) {
+		t.Fatal("expected tier mismatch to fail")
+	}
+	if !marketItemMatchesFilter(item, marketItemsFilter{owner: "player"}) {
+		t.Fatal("expected player-owner filter to match when player stock exists")
+	}
+}
+
+func TestFilterMarketItems(t *testing.T) {
+	t.Parallel()
+
+	items := []marketItem{
+		{TemplateID: "A", DisplayName: "Alpha", Category: "cat/a", TotalStock: 5, BotStock: 0},
+		{TemplateID: "B", DisplayName: "Bravo", Category: "cat/b", TotalStock: 5, BotStock: 5},
+	}
+	filtered := filterMarketItems(items, marketItemsFilter{owner: "player"})
+	if len(filtered) != 1 || filtered[0].TemplateID != "A" {
+		t.Fatalf("unexpected filtered items: %#v", filtered)
+	}
+}
+
+func TestMarketItemsPagination(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest("GET", "/api/v1/market/items?page=2&limit=3", nil)
+	start, end, page, limit := marketItemsPagination(r, 8)
+	if start != 6 || end != 8 || page != 2 || limit != 3 {
+		t.Fatalf("unexpected pagination: start=%d end=%d page=%d limit=%d", start, end, page, limit)
+	}
+
+	rDefault := httptest.NewRequest("GET", "/api/v1/market/items?page=-1&limit=9999", nil)
+	start, end, page, limit = marketItemsPagination(rDefault, 4)
+	if start != 0 || end != 4 || page != 0 || limit != 100 {
+		t.Fatalf("unexpected default pagination: start=%d end=%d page=%d limit=%d", start, end, page, limit)
+	}
+}
+
+func intRef(v int) *int {
+	return &v
+}

--- a/cmd/dune-admin/handlers_players.go
+++ b/cmd/dune-admin/handlers_players.go
@@ -227,52 +227,68 @@ func handleGiveItem(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]any{"ok": msg.ok, "path": "db"})
 }
 
-func handleGiveItems(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		PlayerID int64 `json:"player_id"`
-		Items    []struct {
-			Template string `json:"template"`
-			Qty      int64  `json:"qty"`
-			Quality  int64  `json:"quality"`
-		} `json:"items"`
-	}
-	if err := decode(r, &req); err != nil {
-		jsonErr(w, err, 400)
-		return
-	}
-	type skippedItem struct {
-		Template string `json:"template"`
-		Reason   string `json:"reason"`
-	}
-	given := []string{}
-	skipped := []skippedItem{}
+type giveItemInput struct {
+	Template string `json:"template"`
+	Qty      int64  `json:"qty"`
+	Quality  int64  `json:"quality"`
+}
 
-	ctx := context.Background()
-	// Determine path once for all items in the batch.
-	online := req.PlayerID != 0 && checkPlayerOffline(ctx, req.PlayerID) != nil
-	var flsID string
-	if online {
-		var err error
-		flsID, err = flsIDFromActorID(ctx, req.PlayerID)
-		if err != nil {
-			online = false // fall back to DB path if FLS ID resolution fails
-		}
-	}
+type giveItemsRequest struct {
+	PlayerID int64           `json:"player_id"`
+	Items    []giveItemInput `json:"items"`
+}
 
+type skippedItem struct {
+	Template string `json:"template"`
+	Reason   string `json:"reason"`
+}
+
+type giveItemsDeps struct {
+	checkCapacity func(context.Context, int64, string, int64) error
+	rmqAdd        func(string, string, int, float64) error
+	dbGive        func(int64, string, int64, int64) (msgMutate, bool)
+}
+
+func resolveGiveItemsOnlinePath(
+	ctx context.Context,
+	playerID int64,
+	isOffline func(context.Context, int64) error,
+	resolveFLS func(context.Context, int64) (string, error),
+) (bool, string) {
+	online := playerID != 0 && isOffline(ctx, playerID) != nil
+	if !online {
+		return false, ""
+	}
+	flsID, err := resolveFLS(ctx, playerID)
+	if err != nil {
+		return false, ""
+	}
+	return true, flsID
+}
+
+func processGiveItems(
+	ctx context.Context,
+	req giveItemsRequest,
+	online bool,
+	flsID string,
+	deps giveItemsDeps,
+) ([]string, []skippedItem) {
+	given := make([]string, 0, len(req.Items))
+	skipped := make([]skippedItem, 0)
 	for _, item := range req.Items {
 		if online && item.Quality == 0 {
-			if err := checkInventoryCapacity(ctx, req.PlayerID, item.Template, item.Qty); err != nil {
+			if err := deps.checkCapacity(ctx, req.PlayerID, item.Template, item.Qty); err != nil {
 				skipped = append(skipped, skippedItem{Template: item.Template, Reason: err.Error()})
 				continue
 			}
-			if err := rmqAddItemToInventory(flsID, item.Template, int(item.Qty), 1.0); err != nil {
+			if err := deps.rmqAdd(flsID, item.Template, int(item.Qty), 1.0); err != nil {
 				skipped = append(skipped, skippedItem{Template: item.Template, Reason: err.Error()})
 				continue
 			}
 			given = append(given, item.Template)
 			continue
 		}
-		msg, ok := cmdGiveItem(req.PlayerID, item.Template, item.Qty, item.Quality)().(msgMutate)
+		msg, ok := deps.dbGive(req.PlayerID, item.Template, item.Qty, item.Quality)
 		if !ok || msg.err != nil {
 			reason := "internal error"
 			if ok && msg.err != nil {
@@ -283,6 +299,26 @@ func handleGiveItems(w http.ResponseWriter, r *http.Request) {
 		}
 		given = append(given, item.Template)
 	}
+	return given, skipped
+}
+
+func handleGiveItems(w http.ResponseWriter, r *http.Request) {
+	var req giveItemsRequest
+	if err := decode(r, &req); err != nil {
+		jsonErr(w, err, 400)
+		return
+	}
+	ctx := context.Background()
+	online, flsID := resolveGiveItemsOnlinePath(ctx, req.PlayerID, checkPlayerOffline, flsIDFromActorID)
+	given, skipped := processGiveItems(ctx, req, online, flsID, giveItemsDeps{
+		checkCapacity: checkInventoryCapacity,
+		rmqAdd:        rmqAddItemToInventory,
+		dbGive: func(playerID int64, template string, qty, quality int64) (msgMutate, bool) {
+			msg, ok := cmdGiveItem(playerID, template, qty, quality)().(msgMutate)
+			return msg, ok
+		},
+	})
+
 	jsonOK(w, map[string]any{"given": given, "skipped": skipped})
 }
 

--- a/cmd/dune-admin/handlers_players_give_items_test.go
+++ b/cmd/dune-admin/handlers_players_give_items_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestResolveGiveItemsOnlinePath(t *testing.T) {
+	t.Parallel()
+
+	offline := func(context.Context, int64) error { return nil }
+	online := func(context.Context, int64) error { return errors.New("online") }
+	resolve := func(context.Context, int64) (string, error) { return "fls-123", nil }
+	failResolve := func(context.Context, int64) (string, error) { return "", errors.New("boom") }
+
+	if on, fls := resolveGiveItemsOnlinePath(context.Background(), 0, online, resolve); on || fls != "" {
+		t.Fatalf("expected playerID=0 to force DB path, got on=%v fls=%q", on, fls)
+	}
+	if on, fls := resolveGiveItemsOnlinePath(context.Background(), 42, offline, resolve); on || fls != "" {
+		t.Fatalf("expected offline player to use DB path, got on=%v fls=%q", on, fls)
+	}
+	if on, fls := resolveGiveItemsOnlinePath(context.Background(), 42, online, resolve); !on || fls != "fls-123" {
+		t.Fatalf("expected online RMQ path with fls id, got on=%v fls=%q", on, fls)
+	}
+	if on, fls := resolveGiveItemsOnlinePath(context.Background(), 42, online, failResolve); on || fls != "" {
+		t.Fatalf("expected FLS resolve failure to fall back to DB, got on=%v fls=%q", on, fls)
+	}
+}
+
+func TestProcessGiveItems(t *testing.T) {
+	t.Parallel()
+
+	req := giveItemsRequest{
+		PlayerID: 11,
+		Items: []giveItemInput{
+			{Template: "A", Qty: 2, Quality: 0},
+			{Template: "B", Qty: 1, Quality: 5},
+			{Template: "C", Qty: 1, Quality: 0},
+		},
+	}
+
+	var rmqSent []string
+	given, skipped := processGiveItems(context.Background(), req, true, "fls-123", giveItemsDeps{
+		checkCapacity: func(_ context.Context, _ int64, template string, _ int64) error {
+			if template == "C" {
+				return errors.New("inventory full")
+			}
+			return nil
+		},
+		rmqAdd: func(_ string, template string, _ int, _ float64) error {
+			rmqSent = append(rmqSent, template)
+			return nil
+		},
+		dbGive: func(_ int64, template string, _, _ int64) (msgMutate, bool) {
+			if template != "B" {
+				t.Fatalf("unexpected DB call for template %q", template)
+			}
+			return msgMutate{ok: "done"}, true
+		},
+	})
+
+	if len(given) != 2 || given[0] != "A" || given[1] != "B" {
+		t.Fatalf("unexpected given: %v", given)
+	}
+	if len(skipped) != 1 || skipped[0].Template != "C" || skipped[0].Reason != "inventory full" {
+		t.Fatalf("unexpected skipped: %+v", skipped)
+	}
+	if len(rmqSent) != 1 || rmqSent[0] != "A" {
+		t.Fatalf("unexpected RMQ calls: %v", rmqSent)
+	}
+}
+
+func TestProcessGiveItems_DBFailureReasons(t *testing.T) {
+	t.Parallel()
+
+	req := giveItemsRequest{
+		PlayerID: 11,
+		Items: []giveItemInput{
+			{Template: "X", Qty: 1, Quality: 9},
+			{Template: "Y", Qty: 1, Quality: 9},
+		},
+	}
+
+	given, skipped := processGiveItems(context.Background(), req, false, "", giveItemsDeps{
+		checkCapacity: func(context.Context, int64, string, int64) error { return nil },
+		rmqAdd:        func(string, string, int, float64) error { return nil },
+		dbGive: func(_ int64, template string, _, _ int64) (msgMutate, bool) {
+			if template == "X" {
+				return msgMutate{}, false
+			}
+			return msgMutate{err: errors.New("db failed")}, true
+		},
+	})
+
+	if len(given) != 0 {
+		t.Fatalf("expected no successful grants, got %v", given)
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("expected two skipped items, got %+v", skipped)
+	}
+	if skipped[0].Template != "X" || skipped[0].Reason != "internal error" {
+		t.Fatalf("unexpected first skipped entry: %+v", skipped[0])
+	}
+	if skipped[1].Template != "Y" || skipped[1].Reason != "db failed" {
+		t.Fatalf("unexpected second skipped entry: %+v", skipped[1])
+	}
+}

--- a/cmd/dune-admin/handlers_server_settings.go
+++ b/cmd/dune-admin/handlers_server_settings.go
@@ -1041,6 +1041,39 @@ func joinINILinesWithoutSkipped(lines []string, skip map[int]bool) string {
 // or "-Foo" appears in owned, any line with that exact prefixed key is removed;
 // if plain "Foo" is owned, all variants (plain, +Foo, -Foo) are removed.
 // Comments and unrelated lines are left alone.
+func parseOwnedINIKey(trim string) (lineKey, baseKey string, ok bool) {
+	if len(trim) == 0 || trim[0] == ';' || trim[0] == '#' {
+		return "", "", false
+	}
+	rest := trim
+	prefix := ""
+	if trim[0] == '+' || trim[0] == '-' {
+		prefix = string(trim[0])
+		rest = trim[1:]
+	}
+	eq := strings.Index(rest, "=")
+	if eq <= 0 {
+		return "", "", false
+	}
+	baseKey = strings.TrimSpace(rest[:eq])
+	return prefix + baseKey, baseKey, true
+}
+
+func shouldStripOwnedLine(section, trim string, owned map[string]map[string]bool) bool {
+	if section == "" {
+		return false
+	}
+	lineKey, baseKey, ok := parseOwnedINIKey(trim)
+	if !ok {
+		return false
+	}
+	secOwned := owned[section]
+	if secOwned == nil {
+		return false
+	}
+	return secOwned[lineKey] || secOwned[baseKey]
+}
+
 func stripKeysFromContent(content string, owned map[string]map[string]bool) string {
 	if len(owned) == 0 || content == "" {
 		return content
@@ -1056,24 +1089,8 @@ func stripKeysFromContent(content string, owned map[string]map[string]bool) stri
 			out = append(out, line)
 			continue
 		}
-		// Drop lines where the (possibly-prefixed) key is dune-admin-owned.
-		// Comments, blank lines, and section headers are preserved as-is.
-		if curSec != "" && len(trim) > 0 && trim[0] != ';' && trim[0] != '#' {
-			rest := trim
-			pfx := ""
-			if trim[0] == '+' || trim[0] == '-' {
-				pfx = string(trim[0])
-				rest = trim[1:]
-			}
-			if eq := strings.Index(rest, "="); eq > 0 {
-				baseKey := strings.TrimSpace(rest[:eq])
-				lineKey := pfx + baseKey
-				secOwned := owned[curSec]
-				// Drop if: exact prefixed key owned, OR plain base key owned (covers all variants).
-				if secOwned != nil && (secOwned[lineKey] || secOwned[baseKey]) {
-					continue
-				}
-			}
+		if shouldStripOwnedLine(curSec, trim, owned) {
+			continue
 		}
 		out = append(out, line)
 	}

--- a/cmd/dune-admin/handlers_server_settings.go
+++ b/cmd/dune-admin/handlers_server_settings.go
@@ -978,45 +978,60 @@ func stripEmptySections(content string) string {
 		return content
 	}
 	lines := strings.Split(content, "\n")
-	// Find each section's (headerIdx, nextHeaderIdx). For each, check whether
-	// the body is empty; if so, mark the header line for removal.
-	skip := make(map[int]bool)
-	var headerIdxs []int
-	for i, l := range lines {
-		trim := strings.TrimSpace(l)
-		if strings.HasPrefix(trim, "[") && strings.HasSuffix(trim, "]") {
-			headerIdxs = append(headerIdxs, i)
-		}
-	}
-	for k, idx := range headerIdxs {
-		end := len(lines)
-		if k+1 < len(headerIdxs) {
-			end = headerIdxs[k+1]
-		}
-		empty := true
-		for j := idx + 1; j < end; j++ {
-			if strings.TrimSpace(lines[j]) != "" {
-				empty = false
-				break
-			}
-		}
-		if empty {
-			skip[idx] = true
-			// Also consume the trailing blank lines so we don't leave a void.
-			for j := idx + 1; j < end; j++ {
-				skip[j] = true
-			}
+	skip := map[int]bool{}
+	headerIdxs := findINISectionHeaders(lines)
+	for i, headerIdx := range headerIdxs {
+		sectionEnd := nextINISectionStart(i, headerIdxs, len(lines))
+		if isINISectionBodyEmpty(lines, headerIdx+1, sectionEnd) {
+			markINISectionRange(skip, headerIdx, sectionEnd)
 		}
 	}
 	if len(skip) == 0 {
 		return content
 	}
+	return joinINILinesWithoutSkipped(lines, skip)
+}
+
+func findINISectionHeaders(lines []string) []int {
+	headerIdxs := make([]int, 0, len(lines))
+	for i, line := range lines {
+		trim := strings.TrimSpace(line)
+		if strings.HasPrefix(trim, "[") && strings.HasSuffix(trim, "]") {
+			headerIdxs = append(headerIdxs, i)
+		}
+	}
+	return headerIdxs
+}
+
+func nextINISectionStart(current int, headerIdxs []int, lineCount int) int {
+	if current+1 < len(headerIdxs) {
+		return headerIdxs[current+1]
+	}
+	return lineCount
+}
+
+func isINISectionBodyEmpty(lines []string, start, end int) bool {
+	for i := start; i < end; i++ {
+		if strings.TrimSpace(lines[i]) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func markINISectionRange(skip map[int]bool, start, end int) {
+	for i := start; i < end; i++ {
+		skip[i] = true
+	}
+}
+
+func joinINILinesWithoutSkipped(lines []string, skip map[int]bool) string {
 	out := make([]string, 0, len(lines))
-	for i, l := range lines {
+	for i, line := range lines {
 		if skip[i] {
 			continue
 		}
-		out = append(out, l)
+		out = append(out, line)
 	}
 	return strings.Join(out, "\n")
 }

--- a/cmd/dune-admin/handlers_server_settings.go
+++ b/cmd/dune-admin/handlers_server_settings.go
@@ -1289,7 +1289,7 @@ func handleUpdateServerSettings(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, fmt.Errorf("UserGame.ini: %w", err), 409)
 		return
 	}
-	if gameBody != "" {
+	if len(gameUpdates) > 0 {
 		if err := writeINIContent(gamePath, gameBody); err != nil {
 			jsonErr(w, fmt.Errorf("write UserGame.ini: %w", err), 500)
 			return
@@ -1302,7 +1302,7 @@ func handleUpdateServerSettings(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, fmt.Errorf("UserEngine.ini: %w", err), 409)
 		return
 	}
-	if engineBody != "" {
+	if len(engineUpdates) > 0 {
 		if err := writeINIContent(enginePath, engineBody); err != nil {
 			jsonErr(w, fmt.Errorf("write UserEngine.ini: %w", err), 500)
 			return

--- a/cmd/dune-admin/handlers_server_settings.go
+++ b/cmd/dune-admin/handlers_server_settings.go
@@ -203,45 +203,82 @@ func parseINILines(content, source string, schemaKeys map[string]bool) []RawSect
 
 	for _, raw := range strings.Split(content, "\n") {
 		line := strings.TrimSpace(raw)
-		if line == "" || strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#") {
+		if shouldSkipINILine(line) {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			curSec = line[1 : len(line)-1]
-			if _, ok := secMap[curSec]; !ok {
-				secMap[curSec] = len(result)
-				result = append(result, RawSection{Section: curSec, Source: source})
-			}
+		if section, ok := parseINISectionHeader(line); ok {
+			curSec = section
+			ensureRawSectionIndex(curSec, source, secMap, &result)
 			continue
 		}
 		if curSec == "" {
 			continue
 		}
-		prefix, rest := "", line
-		if len(line) > 0 && (line[0] == '+' || line[0] == '-') {
-			prefix = string(line[0])
-			rest = line[1:]
-		}
-		eq := strings.Index(rest, "=")
-		if eq <= 0 {
+		rawLine, ok := parseRawINILine(line)
+		if !ok {
 			continue
 		}
-		key := strings.TrimSpace(rest[:eq])
-		value := strings.TrimSpace(rest[eq+1:])
-
-		// Include if it's an array line OR the key is not in the schema.
-		if prefix != "" || !schemaKeys[curSec+"|"+key] {
-			idx := secMap[curSec]
-			result[idx].Lines = append(result[idx].Lines, RawLine{Prefix: prefix, Key: key, Value: value})
+		if shouldIncludeRawLine(curSec, rawLine, schemaKeys) {
+			idx := ensureRawSectionIndex(curSec, source, secMap, &result)
+			result[idx].Lines = append(result[idx].Lines, rawLine)
 		}
 	}
 
-	// Drop sections with no lines.
+	return compactRawSections(result)
+}
+
+func shouldSkipINILine(line string) bool {
+	return line == "" || strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#")
+}
+
+func parseINISectionHeader(line string) (string, bool) {
+	if !strings.HasPrefix(line, "[") || !strings.HasSuffix(line, "]") {
+		return "", false
+	}
+	return line[1 : len(line)-1], true
+}
+
+func parseRawINILine(line string) (RawLine, bool) {
+	prefix, rest := "", line
+	if line[0] == '+' || line[0] == '-' {
+		prefix = string(line[0])
+		rest = line[1:]
+	}
+	eq := strings.Index(rest, "=")
+	if eq <= 0 {
+		return RawLine{}, false
+	}
+	return RawLine{
+		Prefix: prefix,
+		Key:    strings.TrimSpace(rest[:eq]),
+		Value:  strings.TrimSpace(rest[eq+1:]),
+	}, true
+}
+
+func shouldIncludeRawLine(section string, line RawLine, schemaKeys map[string]bool) bool {
+	if line.Prefix != "" {
+		return true
+	}
+	return !schemaKeys[section+"|"+line.Key]
+}
+
+func ensureRawSectionIndex(section, source string, secMap map[string]int, result *[]RawSection) int {
+	if idx, ok := secMap[section]; ok {
+		return idx
+	}
+	idx := len(*result)
+	secMap[section] = idx
+	*result = append(*result, RawSection{Section: section, Source: source})
+	return idx
+}
+
+func compactRawSections(result []RawSection) []RawSection {
 	out := result[:0]
-	for _, s := range result {
-		if len(s.Lines) > 0 {
-			out = append(out, s)
+	for _, section := range result {
+		if len(section.Lines) == 0 {
+			continue
 		}
+		out = append(out, section)
 	}
 	return out
 }

--- a/cmd/dune-admin/handlers_server_settings.go
+++ b/cmd/dune-admin/handlers_server_settings.go
@@ -1064,6 +1064,75 @@ func applyDuneAdminRawSection(content, section, rawLines string) (string, error)
 	return strings.TrimRight(preMarker, "\n") + "\n\n" + block, nil
 }
 
+type normalizedServerSettingUpdates struct {
+	updates map[string]map[string]string
+	applied int
+	cleared int
+}
+
+func buildServerSettingsSchemaMap() map[string]settingDef {
+	schemaMap := make(map[string]settingDef, len(serverSettingsSchema))
+	for _, d := range serverSettingsSchema {
+		schemaMap[d.Section+"|"+d.Key] = d
+	}
+	return schemaMap
+}
+
+func normalizeServerSettingsUpdates(
+	requested []serverSettingUpdate,
+	schemaMap map[string]settingDef,
+) (normalizedServerSettingUpdates, error) {
+	normalized := normalizedServerSettingUpdates{
+		updates: make(map[string]map[string]string, len(requested)),
+	}
+	for _, update := range requested {
+		if normalized.updates[update.Section] == nil {
+			normalized.updates[update.Section] = map[string]string{}
+		}
+		if update.Value == "" {
+			normalized.updates[update.Section][update.Key] = ""
+			normalized.cleared++
+			continue
+		}
+
+		def, known := schemaMap[update.Section+"|"+update.Key]
+		if known {
+			norm, err := normalizeValue(def.Type, update.Value)
+			if err != nil {
+				return normalizedServerSettingUpdates{}, fmt.Errorf("invalid value for %s: %w", update.Key, err)
+			}
+			normalized.updates[update.Section][update.Key] = norm
+		} else {
+			normalized.updates[update.Section][update.Key] = update.Value
+		}
+		normalized.applied++
+	}
+	return normalized, nil
+}
+
+func splitServerSettingsUpdatesByFile(
+	defaultEngineIni map[string]map[string]string,
+	updates map[string]map[string]string,
+) (gameUpdates, engineUpdates map[string]map[string]string) {
+	gameUpdates = map[string]map[string]string{}
+	engineUpdates = map[string]map[string]string{}
+	for sec, kvs := range updates {
+		if _, inEngine := defaultEngineIni[sec]; inEngine {
+			engineUpdates[sec] = kvs
+		} else {
+			gameUpdates[sec] = kvs
+		}
+	}
+	return gameUpdates, engineUpdates
+}
+
+func buildUpdatedINIContent(path string, updates map[string]map[string]string) (string, error) {
+	if len(updates) == 0 {
+		return "", nil
+	}
+	return applyDuneAdminUpdates(readINIContent(path), updates)
+}
+
 func handleUpdateServerSettings(w http.ResponseWriter, r *http.Request) {
 	if globalExecutor == nil {
 		jsonErr(w, fmt.Errorf("not connected"), 503)
@@ -1083,79 +1152,48 @@ func handleUpdateServerSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build schema lookup for type validation.
-	schemaMap := map[string]settingDef{}
-	for _, d := range serverSettingsSchema {
-		schemaMap[d.Section+"|"+d.Key] = d
-	}
-
-	// Normalise values and build the update map.
-	updates := map[string]map[string]string{}
-	applied, cleared := 0, 0
-	for _, u := range req.Updates {
-		if updates[u.Section] == nil {
-			updates[u.Section] = map[string]string{}
-		}
-		if u.Value == "" {
-			updates[u.Section][u.Key] = ""
-			cleared++
-		} else {
-			def, known := schemaMap[u.Section+"|"+u.Key]
-			if known {
-				norm, err := normalizeValue(def.Type, u.Value)
-				if err != nil {
-					jsonErr(w, fmt.Errorf("invalid value for %s: %w", u.Key, err), 400)
-					return
-				}
-				updates[u.Section][u.Key] = norm
-			} else {
-				updates[u.Section][u.Key] = u.Value
-			}
-			applied++
-		}
+	normalized, err := normalizeServerSettingsUpdates(req.Updates, buildServerSettingsSchemaMap())
+	if err != nil {
+		jsonErr(w, err, 400)
+		return
 	}
 
 	// Route each section to UserGame.ini or UserEngine.ini based on which default
 	// file declares it. Sections found in DefaultEngine.ini go to UserEngine.ini;
 	// everything else goes to UserGame.ini.
 	defaultEngineIni := parseINI(readDefaultINIContent(dir, "DefaultEngine.ini"))
-	gameUpdates, engineUpdates := map[string]map[string]string{}, map[string]map[string]string{}
-	for sec, kvs := range updates {
-		if _, inEngine := defaultEngineIni[sec]; inEngine {
-			engineUpdates[sec] = kvs
-		} else {
-			gameUpdates[sec] = kvs
-		}
+	gameUpdates, engineUpdates := splitServerSettingsUpdatesByFile(defaultEngineIni, normalized.updates)
+
+	gamePath := dir + "/UserGame.ini"
+	gameBody, err := buildUpdatedINIContent(gamePath, gameUpdates)
+	if err != nil {
+		jsonErr(w, fmt.Errorf("UserGame.ini: %w", err), 409)
+		return
 	}
-	if len(gameUpdates) > 0 {
-		path := dir + "/UserGame.ini"
-		body, err := applyDuneAdminUpdates(readINIContent(path), gameUpdates)
-		if err != nil {
-			jsonErr(w, fmt.Errorf("UserGame.ini: %w", err), 409)
-			return
-		}
-		if err := writeINIContent(path, body); err != nil {
+	if gameBody != "" {
+		if err := writeINIContent(gamePath, gameBody); err != nil {
 			jsonErr(w, fmt.Errorf("write UserGame.ini: %w", err), 500)
 			return
 		}
 	}
-	if len(engineUpdates) > 0 {
-		path := dir + "/UserEngine.ini"
-		body, err := applyDuneAdminUpdates(readINIContent(path), engineUpdates)
-		if err != nil {
-			jsonErr(w, fmt.Errorf("UserEngine.ini: %w", err), 409)
-			return
-		}
-		if err := writeINIContent(path, body); err != nil {
+
+	enginePath := dir + "/UserEngine.ini"
+	engineBody, err := buildUpdatedINIContent(enginePath, engineUpdates)
+	if err != nil {
+		jsonErr(w, fmt.Errorf("UserEngine.ini: %w", err), 409)
+		return
+	}
+	if engineBody != "" {
+		if err := writeINIContent(enginePath, engineBody); err != nil {
 			jsonErr(w, fmt.Errorf("write UserEngine.ini: %w", err), 500)
 			return
 		}
 	}
 
 	jsonOK(w, map[string]any{
-		"ok":      fmt.Sprintf("Saved (%d set, %d cleared). Restart the game server to apply.", applied, cleared),
-		"applied": applied,
-		"cleared": cleared,
+		"ok":      fmt.Sprintf("Saved (%d set, %d cleared). Restart the game server to apply.", normalized.applied, normalized.cleared),
+		"applied": normalized.applied,
+		"cleared": normalized.cleared,
 	})
 }
 

--- a/cmd/dune-admin/handlers_server_settings.go
+++ b/cmd/dune-admin/handlers_server_settings.go
@@ -498,6 +498,145 @@ func readINIContent(path string) string {
 	return out
 }
 
+type layerSource struct {
+	name string
+	ini  map[string]map[string]string
+}
+
+type discoveredKey struct {
+	section string
+	key     string
+}
+
+func serverSettingsSchemaKeys() map[string]bool {
+	schemaKeys := make(map[string]bool, len(serverSettingsSchema))
+	for _, def := range serverSettingsSchema {
+		schemaKeys[def.Section+"|"+def.Key] = true
+	}
+	return schemaKeys
+}
+
+func buildLayerSources(
+	defaultEngineIni,
+	defaultGameIni,
+	engineIni,
+	gameIni map[string]map[string]string,
+) []layerSource {
+	return []layerSource{
+		{name: "defaultEngine", ini: defaultEngineIni},
+		{name: "defaultGame", ini: defaultGameIni},
+		{name: "userEngine", ini: engineIni},
+		{name: "userGame", ini: gameIni},
+	}
+}
+
+func applySettingLayers(s *ServerSetting, layerSources []layerSource) {
+	for _, src := range layerSources {
+		if v, ok := src.ini[s.Section][s.Key]; ok {
+			if s.Type == "" {
+				s.Type = string(inferType(v))
+			}
+			s.Layers = append(s.Layers, SettingLayer{Source: src.name, Value: v})
+			s.Current = v
+			s.Source = src.name
+		}
+	}
+	s.IsOverride = strings.HasPrefix(s.Source, "user")
+	if s.Layers == nil {
+		s.Layers = []SettingLayer{}
+	}
+}
+
+func buildSchemaSettings(layerSources []layerSource) []ServerSetting {
+	settings := make([]ServerSetting, 0, len(serverSettingsSchema))
+	for _, def := range serverSettingsSchema {
+		s := ServerSetting{
+			Section:     def.Section,
+			Key:         def.Key,
+			Type:        string(def.Type),
+			Default:     def.Default,
+			Label:       def.Label,
+			Description: def.Description,
+			Category:    def.Category,
+			Current:     def.Default,
+		}
+		applySettingLayers(&s, layerSources)
+		settings = append(settings, s)
+	}
+	return settings
+}
+
+func discoverUnknownSettings(layerSources []layerSource, schemaKeys map[string]bool) []discoveredKey {
+	seenKeys := make(map[string]bool, len(schemaKeys))
+	for k := range schemaKeys {
+		seenKeys[k] = true
+	}
+
+	discovered := make([]discoveredKey, 0, 32)
+	for _, src := range layerSources {
+		for section, keys := range src.ini {
+			for key := range keys {
+				// Skip array-prefix lines (+/-); they belong in raw sections.
+				if strings.HasPrefix(key, "+") || strings.HasPrefix(key, "-") {
+					continue
+				}
+				composite := section + "|" + key
+				if seenKeys[composite] {
+					continue
+				}
+				seenKeys[composite] = true
+				discovered = append(discovered, discoveredKey{section: section, key: key})
+			}
+		}
+	}
+	sort.Slice(discovered, func(i, j int) bool {
+		if discovered[i].section != discovered[j].section {
+			return discovered[i].section < discovered[j].section
+		}
+		return discovered[i].key < discovered[j].key
+	})
+	return discovered
+}
+
+func buildDiscoveredSettings(
+	discovered []discoveredKey,
+	layerSources []layerSource,
+	schemaKeys map[string]bool,
+) []ServerSetting {
+	settings := make([]ServerSetting, 0, len(discovered))
+	for _, dk := range discovered {
+		s := ServerSetting{
+			Section:  dk.section,
+			Key:      dk.key,
+			Label:    dk.key,
+			Category: shortSectionName(dk.section),
+			Layers:   []SettingLayer{},
+		}
+		applySettingLayers(&s, layerSources)
+		if s.Type == "" {
+			s.Type = string(settingString)
+		}
+		settings = append(settings, s)
+		schemaKeys[dk.section+"|"+dk.key] = true
+	}
+	return settings
+}
+
+func buildServerSettingsRawSections(
+	defaultGameContent,
+	defaultEngineContent,
+	gameContent,
+	engineContent string,
+	schemaKeys map[string]bool,
+) []RawSection {
+	raw := make([]RawSection, 0, 16)
+	raw = append(raw, parseINILines(defaultGameContent, "defaultGame", schemaKeys)...)
+	raw = append(raw, parseINILines(defaultEngineContent, "defaultEngine", schemaKeys)...)
+	raw = append(raw, parseINILines(gameContent, "userGame", schemaKeys)...)
+	raw = append(raw, parseINILines(engineContent, "userEngine", schemaKeys)...)
+	return raw
+}
+
 func writeINIContent(path, body string) error {
 	if globalExecutor == nil {
 		return fmt.Errorf("not connected")
@@ -539,113 +678,12 @@ func handleGetServerSettings(w http.ResponseWriter, r *http.Request) {
 	defaultGameIni := parseINI(defaultGameContent)
 	defaultEngineIni := parseINI(defaultEngineContent)
 
-	// Build schema key set for raw-line filtering.
-	schemaKeys := map[string]bool{}
-	for _, def := range serverSettingsSchema {
-		schemaKeys[def.Section+"|"+def.Key] = true
-	}
-
-	// Schema settings — build layers from all INI sources and always include all entries.
-	type layerSource struct {
-		name string
-		ini  map[string]map[string]string
-	}
-	layerSources := []layerSource{
-		{"defaultEngine", defaultEngineIni},
-		{"defaultGame", defaultGameIni},
-		{"userEngine", engineIni},
-		{"userGame", gameIni},
-	}
-
-	var settings []ServerSetting
-	for _, def := range serverSettingsSchema {
-		s := ServerSetting{
-			Section:     def.Section,
-			Key:         def.Key,
-			Type:        string(def.Type),
-			Default:     def.Default,
-			Label:       def.Label,
-			Description: def.Description,
-			Category:    def.Category,
-			Current:     def.Default,
-		}
-		for _, src := range layerSources {
-			if v, ok := src.ini[def.Section][def.Key]; ok {
-				s.Layers = append(s.Layers, SettingLayer{Source: src.name, Value: v})
-				s.Current = v
-				s.Source = src.name
-			}
-		}
-		s.IsOverride = strings.HasPrefix(s.Source, "user")
-		if s.Layers == nil {
-			s.Layers = []SettingLayer{}
-		}
-		settings = append(settings, s)
-	}
-
-	// Discover all keys present in any INI file that aren't in the hardcoded schema.
-	// These get typed settings with inferred types so they participate in the layer UI.
-	type discoveredKey struct{ section, key string }
-	seenKeys := make(map[string]bool, len(schemaKeys))
-	for k := range schemaKeys {
-		seenKeys[k] = true
-	}
-	var discovered []discoveredKey
-	for _, src := range layerSources {
-		for section, keys := range src.ini {
-			for key := range keys {
-				// Skip array-prefix lines (+/-); they belong in raw sections.
-				if strings.HasPrefix(key, "+") || strings.HasPrefix(key, "-") {
-					continue
-				}
-				k := section + "|" + key
-				if !seenKeys[k] {
-					seenKeys[k] = true
-					discovered = append(discovered, discoveredKey{section, key})
-				}
-			}
-		}
-	}
-	sort.Slice(discovered, func(i, j int) bool {
-		if discovered[i].section != discovered[j].section {
-			return discovered[i].section < discovered[j].section
-		}
-		return discovered[i].key < discovered[j].key
-	})
-	for _, dk := range discovered {
-		s := ServerSetting{
-			Section:  dk.section,
-			Key:      dk.key,
-			Label:    dk.key,
-			Category: shortSectionName(dk.section),
-			Layers:   []SettingLayer{},
-		}
-		for _, src := range layerSources {
-			if v, ok := src.ini[dk.section][dk.key]; ok {
-				if s.Type == "" {
-					s.Type = string(inferType(v))
-				}
-				s.Layers = append(s.Layers, SettingLayer{Source: src.name, Value: v})
-				s.Current = v
-				s.Source = src.name
-			}
-		}
-		if s.Type == "" {
-			s.Type = string(settingString)
-		}
-		s.IsOverride = strings.HasPrefix(s.Source, "user")
-		settings = append(settings, s)
-		schemaKeys[dk.section+"|"+dk.key] = true
-	}
-
-	// Raw lines — array entries and anything not promoted to a typed setting.
-	// All four files use the same schemaKeys (which now includes discovered keys)
-	// so nothing appears in both the typed panel and the raw panel.
-	var raw []RawSection
-	raw = append(raw, parseINILines(defaultGameContent, "defaultGame", schemaKeys)...)
-	raw = append(raw, parseINILines(defaultEngineContent, "defaultEngine", schemaKeys)...)
-	raw = append(raw, parseINILines(gameContent, "userGame", schemaKeys)...)
-	raw = append(raw, parseINILines(engineContent, "userEngine", schemaKeys)...)
+	layerSources := buildLayerSources(defaultEngineIni, defaultGameIni, engineIni, gameIni)
+	schemaKeys := serverSettingsSchemaKeys()
+	settings := buildSchemaSettings(layerSources)
+	discovered := discoverUnknownSettings(layerSources, schemaKeys)
+	settings = append(settings, buildDiscoveredSettings(discovered, layerSources, schemaKeys)...)
+	raw := buildServerSettingsRawSections(defaultGameContent, defaultEngineContent, gameContent, engineContent, schemaKeys)
 
 	jsonOK(w, map[string]any{
 		"settings": settings,

--- a/cmd/dune-admin/handlers_server_settings.go
+++ b/cmd/dune-admin/handlers_server_settings.go
@@ -384,72 +384,122 @@ func readDefaultINIContent(iniDir, filename string) string {
 //  3. Common host paths — /home, /root, /dune first, then k3s containerd layers
 //  4. Relative path traversal from iniDir (Hyper-V / bare-metal layouts)
 //  5. kubectl/docker exec into the game container (requires pod running)
+func configuredDefaultINIPath(filename string) string {
+	if loadedConfig.DefaultIniDir == "" {
+		return ""
+	}
+	return filepath.Join(loadedConfig.DefaultIniDir, filename)
+}
+
+func k8sDerivedDefaultINICandidates(inPodDir, filename string) []string {
+	return []string{
+		pathpkg.Clean(pathpkg.Join(inPodDir, "..", "..", "..", "Config", filename)),
+		pathpkg.Clean(pathpkg.Join(inPodDir, "..", "..", "Config", filename)),
+		pathpkg.Clean(pathpkg.Join(inPodDir, "..", "..", "..", "..", "Config", filename)),
+		"/DuneSandbox/Config/" + filename,
+		"/home/dune/server/DuneSandbox/Config/" + filename,
+		"/home/dune/DuneSandbox/Config/" + filename,
+		"/game/DuneSandbox/Config/" + filename,
+	}
+}
+
+func hostDefaultINICandidates(filename string) []string {
+	return []string{
+		"/home/dune/" + filename,
+		"/home/" + filename,
+		"/root/" + filename,
+		"/dune/" + filename,
+		"/home/dune/server/DuneSandbox/Config/" + filename,
+	}
+}
+
+func relativeDefaultINICandidates(iniDir, filename string) []string {
+	return []string{
+		filepath.Join(iniDir, "..", "..", "..", "Config", filename),
+		filepath.Join(iniDir, "..", "..", "Config", filename),
+		filepath.Join(iniDir, "..", "..", "..", "..", "Config", filename),
+	}
+}
+
+func discoverViaConfiguredPath(filename string) string {
+	path := configuredDefaultINIPath(filename)
+	if path == "" {
+		return ""
+	}
+	if data, err := os.ReadFile(path); err == nil && len(data) > 0 {
+		return string(data)
+	}
+	return readINIContent(path)
+}
+
+func discoverViaK8sDerivedPath(iniDir, filename string) string {
+	ns, pod, inPodDir, ok := parseK8sINIPath(iniDir)
+	if !ok {
+		return ""
+	}
+	for _, inPodPath := range k8sDerivedDefaultINICandidates(inPodDir, filename) {
+		if content := readINIContent(fmt.Sprintf("k8s://%s/%s%s", ns, pod, inPodPath)); content != "" {
+			return content
+		}
+	}
+	return ""
+}
+
+func discoverViaHostPaths(filename string) string {
+	for _, path := range hostDefaultINICandidates(filename) {
+		if content := readINIContent(path); content != "" {
+			return content
+		}
+	}
+	return ""
+}
+
+func discoverViaHostFind(filename string) string {
+	out, _ := globalExecutor.Exec(fmt.Sprintf(
+		"sudo find /home /root /dune /run/k3s/containerd /var/lib/rancher/k3s/agent/containerd"+
+			" -maxdepth 10 -name %s -not -path '*/Saved/*' -not -path '*/saved/*' 2>/dev/null | head -1",
+		shellQuote(filename)))
+	if path := strings.TrimSpace(out); path != "" {
+		return readINIContent(path)
+	}
+	return ""
+}
+
+func discoverViaRelativePath(iniDir, filename string) string {
+	for _, path := range relativeDefaultINICandidates(iniDir, filename) {
+		if content := readINIContent(path); content != "" {
+			return content
+		}
+	}
+	return ""
+}
+
 func discoverDefaultINI(iniDir, filename string) string {
-	// 1. Explicit config path.
-	if loadedConfig.DefaultIniDir != "" {
-		p := filepath.Join(loadedConfig.DefaultIniDir, filename)
-		if data, err := os.ReadFile(p); err == nil && len(data) > 0 {
-			return string(data)
-		}
-		if c := readINIContent(p); c != "" {
-			return c
-		}
+	if content := discoverViaConfiguredPath(filename); content != "" {
+		return content
 	}
 
 	// 1b. When INI dir points to a k8s pod path, derive nearby Config paths in
 	// the same pod first. This is the most reliable source in deployed mode.
-	if ns, pod, inPodDir, ok := parseK8sINIPath(iniDir); ok {
-		candidates := []string{
-			pathpkg.Clean(pathpkg.Join(inPodDir, "..", "..", "..", "Config", filename)),
-			pathpkg.Clean(pathpkg.Join(inPodDir, "..", "..", "Config", filename)),
-			pathpkg.Clean(pathpkg.Join(inPodDir, "..", "..", "..", "..", "Config", filename)),
-			"/DuneSandbox/Config/" + filename,
-			"/home/dune/server/DuneSandbox/Config/" + filename,
-			"/home/dune/DuneSandbox/Config/" + filename,
-			"/game/DuneSandbox/Config/" + filename,
-		}
-		for _, inPodPath := range candidates {
-			if c := readINIContent(fmt.Sprintf("k8s://%s/%s%s", ns, pod, inPodPath)); c != "" {
-				return c
-			}
-		}
+	if content := discoverViaK8sDerivedPath(iniDir, filename); content != "" {
+		return content
 	}
 
 	if globalExecutor != nil {
 		// 2a. Well-known host directories — tried in order before any find.
-		for _, p := range []string{
-			"/home/dune/" + filename,
-			"/home/" + filename,
-			"/root/" + filename,
-			"/dune/" + filename,
-			"/home/dune/server/DuneSandbox/Config/" + filename,
-		} {
-			if c := readINIContent(p); c != "" {
-				return c
-			}
+		if content := discoverViaHostPaths(filename); content != "" {
+			return content
 		}
 
 		// 2b. Host filesystem scan: /home /root /dune first, then k3s containerd
 		// paths. These require sudo but the executor already runs with sudo access.
-		out, _ := globalExecutor.Exec(fmt.Sprintf(
-			"sudo find /home /root /dune /run/k3s/containerd /var/lib/rancher/k3s/agent/containerd"+
-				" -maxdepth 10 -name %s -not -path '*/Saved/*' -not -path '*/saved/*' 2>/dev/null | head -1",
-			shellQuote(filename)))
-		if p := strings.TrimSpace(out); p != "" {
-			if c := readINIContent(p); c != "" {
-				return c
-			}
+		if content := discoverViaHostFind(filename); content != "" {
+			return content
 		}
 
 		// 3. Relative candidates from iniDir (non-k8s layouts).
-		for _, p := range []string{
-			filepath.Join(iniDir, "..", "..", "..", "Config", filename),
-			filepath.Join(iniDir, "..", "..", "Config", filename),
-			filepath.Join(iniDir, "..", "..", "..", "..", "Config", filename),
-		} {
-			if c := readINIContent(p); c != "" {
-				return c
-			}
+		if content := discoverViaRelativePath(iniDir, filename); content != "" {
+			return content
 		}
 	}
 

--- a/cmd/dune-admin/handlers_server_settings_discover_test.go
+++ b/cmd/dune-admin/handlers_server_settings_discover_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestConfiguredDefaultINIPath(t *testing.T) {
+	originalConfig := loadedConfig
+	t.Cleanup(func() { loadedConfig = originalConfig })
+
+	loadedConfig.DefaultIniDir = "/opt/dune/config"
+	if got := configuredDefaultINIPath("DefaultGame.ini"); got != "/opt/dune/config/DefaultGame.ini" {
+		t.Fatalf("unexpected configured path: %q", got)
+	}
+
+	loadedConfig.DefaultIniDir = ""
+	if got := configuredDefaultINIPath("DefaultGame.ini"); got != "" {
+		t.Fatalf("expected empty configured path when default ini dir unset, got %q", got)
+	}
+}
+
+func TestK8sDerivedDefaultINICandidates(t *testing.T) {
+	t.Parallel()
+
+	got := k8sDerivedDefaultINICandidates("/home/dune/server/state", "DefaultEngine.ini")
+	if len(got) < 7 {
+		t.Fatalf("expected at least 7 candidates, got %d", len(got))
+	}
+	if got[0] != "/home/Config/DefaultEngine.ini" {
+		t.Fatalf("unexpected first candidate: %q", got[0])
+	}
+	if got[len(got)-1] != "/game/DuneSandbox/Config/DefaultEngine.ini" {
+		t.Fatalf("unexpected last candidate: %q", got[len(got)-1])
+	}
+}
+
+func TestHostDefaultINICandidates(t *testing.T) {
+	t.Parallel()
+
+	got := hostDefaultINICandidates("DefaultGame.ini")
+	want := []string{
+		"/home/dune/DefaultGame.ini",
+		"/home/DefaultGame.ini",
+		"/root/DefaultGame.ini",
+		"/dune/DefaultGame.ini",
+		"/home/dune/server/DuneSandbox/Config/DefaultGame.ini",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d host candidates, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidate %d mismatch: want %q got %q", i, want[i], got[i])
+		}
+	}
+}
+
+func TestRelativeDefaultINICandidates(t *testing.T) {
+	t.Parallel()
+
+	base := filepath.Clean("/srv/dune/server/state")
+	got := relativeDefaultINICandidates(base, "DefaultEngine.ini")
+	want := []string{
+		filepath.Join(base, "..", "..", "..", "Config", "DefaultEngine.ini"),
+		filepath.Join(base, "..", "..", "Config", "DefaultEngine.ini"),
+		filepath.Join(base, "..", "..", "..", "..", "Config", "DefaultEngine.ini"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d relative candidates, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidate %d mismatch: want %q got %q", i, want[i], got[i])
+		}
+	}
+}

--- a/cmd/dune-admin/handlers_server_settings_get_test.go
+++ b/cmd/dune-admin/handlers_server_settings_get_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestServerSettingsSchemaKeys(t *testing.T) {
+	keys := serverSettingsSchemaKeys()
+	if len(keys) != len(serverSettingsSchema) {
+		t.Fatalf("expected %d keys, got %d", len(serverSettingsSchema), len(keys))
+	}
+	first := serverSettingsSchema[0]
+	if !keys[first.Section+"|"+first.Key] {
+		t.Fatalf("missing schema key %s|%s", first.Section, first.Key)
+	}
+}
+
+func TestApplySettingLayers(t *testing.T) {
+	s := ServerSetting{
+		Section: "Sec",
+		Key:     "Key",
+		Type:    string(settingInt),
+		Current: "0",
+	}
+	sources := []layerSource{
+		{name: "defaultGame", ini: map[string]map[string]string{"Sec": {"Key": "1"}}},
+		{name: "userGame", ini: map[string]map[string]string{"Sec": {"Key": "2"}}},
+	}
+
+	applySettingLayers(&s, sources)
+
+	if s.Current != "2" || s.Source != "userGame" {
+		t.Fatalf("unexpected current/source: %q / %q", s.Current, s.Source)
+	}
+	if !s.IsOverride {
+		t.Fatal("expected IsOverride=true")
+	}
+	if len(s.Layers) != 2 {
+		t.Fatalf("expected 2 layers, got %d", len(s.Layers))
+	}
+}
+
+func TestDiscoverUnknownSettings(t *testing.T) {
+	schemaKeys := map[string]bool{"Sec|Known": true}
+	sources := []layerSource{
+		{
+			name: "defaultGame",
+			ini: map[string]map[string]string{
+				"Sec": {"Known": "1", "+Array": "x", "CustomB": "true"},
+				"A":   {"CustomA": "42"},
+			},
+		},
+		{
+			name: "userGame",
+			ini: map[string]map[string]string{
+				"Sec": {"CustomB": "false"},
+			},
+		},
+	}
+
+	discovered := discoverUnknownSettings(sources, schemaKeys)
+	if len(discovered) != 2 {
+		t.Fatalf("expected 2 discovered keys, got %d", len(discovered))
+	}
+	if discovered[0].section != "A" || discovered[0].key != "CustomA" {
+		t.Fatalf("unexpected first discovered key: %+v", discovered[0])
+	}
+	if discovered[1].section != "Sec" || discovered[1].key != "CustomB" {
+		t.Fatalf("unexpected second discovered key: %+v", discovered[1])
+	}
+}
+
+func TestBuildDiscoveredSettings(t *testing.T) {
+	discovered := []discoveredKey{{section: "Sec", key: "Custom"}}
+	schemaKeys := map[string]bool{}
+	sources := []layerSource{
+		{name: "defaultGame", ini: map[string]map[string]string{"Sec": {"Custom": "1"}}},
+		{name: "userGame", ini: map[string]map[string]string{"Sec": {"Custom": "True"}}},
+	}
+
+	settings := buildDiscoveredSettings(discovered, sources, schemaKeys)
+	if len(settings) != 1 {
+		t.Fatalf("expected 1 discovered setting, got %d", len(settings))
+	}
+	if settings[0].Type != string(settingInt) {
+		t.Fatalf("expected inferred type int from first layer, got %q", settings[0].Type)
+	}
+	if settings[0].Current != "True" || settings[0].Source != "userGame" {
+		t.Fatalf("unexpected current/source: %q / %q", settings[0].Current, settings[0].Source)
+	}
+	if !settings[0].IsOverride {
+		t.Fatal("expected IsOverride=true for user layer")
+	}
+	if !schemaKeys["Sec|Custom"] {
+		t.Fatal("expected discovered key to be added to schema key set")
+	}
+}
+
+func TestBuildServerSettingsRawSections(t *testing.T) {
+	schemaKeys := map[string]bool{"Sec|Known": true}
+	defaultGame := "[Sec]\nKnown=1\nOther=2\n+Array=3\n"
+	defaultEngine := "[Sec]\n-Array=4\n"
+	raw := buildServerSettingsRawSections(defaultGame, defaultEngine, "", "", schemaKeys)
+
+	if len(raw) != 2 {
+		t.Fatalf("expected 2 raw sections, got %d", len(raw))
+	}
+	if raw[0].Source != "defaultGame" || len(raw[0].Lines) != 2 {
+		t.Fatalf("unexpected defaultGame raw section: %+v", raw[0])
+	}
+	if raw[1].Source != "defaultEngine" || len(raw[1].Lines) != 1 {
+		t.Fatalf("unexpected defaultEngine raw section: %+v", raw[1])
+	}
+	if raw[0].Lines[0].Key != "Other" || raw[0].Lines[0].Prefix != "" {
+		t.Fatalf("unexpected first defaultGame raw line: %+v", raw[0].Lines[0])
+	}
+	if raw[0].Lines[1].Key != "Array" || raw[0].Lines[1].Prefix != "+" {
+		t.Fatalf("unexpected second defaultGame raw line: %+v", raw[0].Lines[1])
+	}
+	if raw[1].Lines[0].Key != "Array" || raw[1].Lines[0].Prefix != "-" {
+		t.Fatalf("unexpected defaultEngine raw line: %+v", raw[1].Lines[0])
+	}
+}

--- a/cmd/dune-admin/handlers_server_settings_parse_ini_test.go
+++ b/cmd/dune-admin/handlers_server_settings_parse_ini_test.go
@@ -1,0 +1,68 @@
+package main
+
+import "testing"
+
+func TestParseINILines_FiltersSchemaAndPreservesArrayPrefixes(t *testing.T) {
+	t.Parallel()
+
+	content := `
+; comment
+[SectionOne]
+Known=1
+Unknown = 2
++Known=3
+-Known=4
+NoEqualsHere
+
+[SectionTwo]
+Another=abc
+`
+	schemaKeys := map[string]bool{"SectionOne|Known": true}
+
+	got := parseINILines(content, "userGame", schemaKeys)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(got))
+	}
+	if got[0].Section != "SectionOne" || got[0].Source != "userGame" {
+		t.Fatalf("unexpected first section metadata: %+v", got[0])
+	}
+	if len(got[0].Lines) != 3 {
+		t.Fatalf("expected 3 lines in SectionOne, got %d", len(got[0].Lines))
+	}
+	if got[0].Lines[0] != (RawLine{Key: "Unknown", Value: "2"}) {
+		t.Fatalf("unexpected first raw line: %+v", got[0].Lines[0])
+	}
+	if got[0].Lines[1] != (RawLine{Prefix: "+", Key: "Known", Value: "3"}) {
+		t.Fatalf("unexpected +array raw line: %+v", got[0].Lines[1])
+	}
+	if got[0].Lines[2] != (RawLine{Prefix: "-", Key: "Known", Value: "4"}) {
+		t.Fatalf("unexpected -array raw line: %+v", got[0].Lines[2])
+	}
+
+	if got[1].Section != "SectionTwo" || len(got[1].Lines) != 1 {
+		t.Fatalf("unexpected second section: %+v", got[1])
+	}
+	if got[1].Lines[0] != (RawLine{Key: "Another", Value: "abc"}) {
+		t.Fatalf("unexpected second section line: %+v", got[1].Lines[0])
+	}
+}
+
+func TestParseINILines_DropsSectionsWithoutRawLines(t *testing.T) {
+	t.Parallel()
+
+	content := `
+[OnlySchema]
+Known=1
+[HasRaw]
+Unknown=2
+`
+	schemaKeys := map[string]bool{"OnlySchema|Known": true}
+
+	got := parseINILines(content, "defaultGame", schemaKeys)
+	if len(got) != 1 {
+		t.Fatalf("expected only one section after compaction, got %d", len(got))
+	}
+	if got[0].Section != "HasRaw" {
+		t.Fatalf("expected HasRaw section to remain, got %q", got[0].Section)
+	}
+}

--- a/cmd/dune-admin/handlers_server_settings_strip_empty_sections_test.go
+++ b/cmd/dune-admin/handlers_server_settings_strip_empty_sections_test.go
@@ -1,0 +1,43 @@
+package main
+
+import "testing"
+
+func TestStripEmptySections(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "empty content",
+			content: "",
+			want:    "",
+		},
+		{
+			name:    "removes section with only blank body",
+			content: "[Keep]\nKey=1\n\n[Remove]\n\n\n[AlsoKeep]\n;comment\n",
+			want:    "[Keep]\nKey=1\n\n[AlsoKeep]\n;comment\n",
+		},
+		{
+			name:    "preserves sections with comments or values",
+			content: "[Commented]\n; docs\n\n[Valued]\n+Array=1\n\n[Blank]\n\n",
+			want:    "[Commented]\n; docs\n\n[Valued]\n+Array=1\n",
+		},
+		{
+			name:    "keeps non-section preface lines",
+			content: "; header\n\n[Remove]\n\n[Keep]\nValue=1\n",
+			want:    "; header\n\n[Keep]\nValue=1\n",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripEmptySections(tt.content); got != tt.want {
+				t.Fatalf("unexpected output\nwant:\n%q\ngot:\n%q", tt.want, got)
+			}
+		})
+	}
+}

--- a/cmd/dune-admin/handlers_server_settings_strip_keys_test.go
+++ b/cmd/dune-admin/handlers_server_settings_strip_keys_test.go
@@ -1,0 +1,75 @@
+package main
+
+import "testing"
+
+func TestStripKeysFromContent(t *testing.T) {
+	t.Parallel()
+
+	content := `[Sec]
+Foo=1
++Foo=2
+-Foo=3
+Bar=9
+[Other]
+Foo=4
+`
+
+	owned := map[string]map[string]bool{
+		"Sec": {"Foo": true},
+	}
+	got := stripKeysFromContent(content, owned)
+	want := `[Sec]
+Bar=9
+[Other]
+Foo=4
+`
+	if got != want {
+		t.Fatalf("unexpected stripped content\nwant:\n%q\ngot:\n%q", want, got)
+	}
+}
+
+func TestStripKeysFromContent_PrefixedOwnership(t *testing.T) {
+	t.Parallel()
+
+	content := `[Sec]
+Foo=1
++Foo=2
+-Foo=3
+`
+
+	owned := map[string]map[string]bool{
+		"Sec": {"+Foo": true},
+	}
+	got := stripKeysFromContent(content, owned)
+	want := `[Sec]
+Foo=1
+-Foo=3
+`
+	if got != want {
+		t.Fatalf("unexpected prefixed strip result\nwant:\n%q\ngot:\n%q", want, got)
+	}
+}
+
+func TestStripKeysFromContent_PreservesCommentsAndInvalidLines(t *testing.T) {
+	t.Parallel()
+
+	content := `[Sec]
+; comment
+# hash comment
+NoEquals
+Owned=1
+`
+
+	owned := map[string]map[string]bool{
+		"Sec": {"Owned": true},
+	}
+	got := stripKeysFromContent(content, owned)
+	want := `[Sec]
+; comment
+# hash comment
+NoEquals
+`
+	if got != want {
+		t.Fatalf("unexpected comment preservation result\nwant:\n%q\ngot:\n%q", want, got)
+	}
+}

--- a/cmd/dune-admin/handlers_server_settings_update_test.go
+++ b/cmd/dune-admin/handlers_server_settings_update_test.go
@@ -1,0 +1,84 @@
+package main
+
+import "testing"
+
+func TestBuildServerSettingsSchemaMap(t *testing.T) {
+	t.Parallel()
+
+	schemaMap := buildServerSettingsSchemaMap()
+	if len(schemaMap) != len(serverSettingsSchema) {
+		t.Fatalf("expected %d schema entries, got %d", len(serverSettingsSchema), len(schemaMap))
+	}
+	if _, ok := schemaMap[secBuilding+"|bEnableBuildingStability"]; !ok {
+		t.Fatalf("expected known schema key for building stability")
+	}
+}
+
+func TestNormalizeServerSettingsUpdates(t *testing.T) {
+	t.Parallel()
+
+	schemaMap := buildServerSettingsSchemaMap()
+	normalized, err := normalizeServerSettingsUpdates([]serverSettingUpdate{
+		{Section: secBuilding, Key: "bEnableBuildingStability", Value: "true"},
+		{Section: secBuilding, Key: "CustomKey", Value: "raw-value"},
+		{Section: secBuilding, Key: "AnotherKey", Value: ""},
+	}, schemaMap)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if normalized.applied != 2 || normalized.cleared != 1 {
+		t.Fatalf("unexpected counters: applied=%d cleared=%d", normalized.applied, normalized.cleared)
+	}
+	if got := normalized.updates[secBuilding]["bEnableBuildingStability"]; got != "True" {
+		t.Fatalf("expected normalized bool value True, got %q", got)
+	}
+	if got := normalized.updates[secBuilding]["CustomKey"]; got != "raw-value" {
+		t.Fatalf("expected custom key passthrough, got %q", got)
+	}
+	if got := normalized.updates[secBuilding]["AnotherKey"]; got != "" {
+		t.Fatalf("expected clear marker empty string, got %q", got)
+	}
+}
+
+func TestNormalizeServerSettingsUpdates_InvalidKnownValue(t *testing.T) {
+	t.Parallel()
+
+	schemaMap := buildServerSettingsSchemaMap()
+	_, err := normalizeServerSettingsUpdates([]serverSettingUpdate{
+		{Section: secBuilding, Key: "bEnableBuildingStability", Value: "not-bool"},
+	}, schemaMap)
+	if err == nil {
+		t.Fatalf("expected normalization error for invalid bool")
+	}
+}
+
+func TestSplitServerSettingsUpdatesByFile(t *testing.T) {
+	t.Parallel()
+
+	defaultEngine := map[string]map[string]string{
+		"/Script/Engine.EngineSection": {"K": "V"},
+	}
+	updates := map[string]map[string]string{
+		"/Script/Engine.EngineSection": {"A": "1"},
+		secBuilding:                    {"B": "2"},
+	}
+	game, engine := splitServerSettingsUpdatesByFile(defaultEngine, updates)
+	if _, ok := engine["/Script/Engine.EngineSection"]; !ok {
+		t.Fatalf("expected engine section to route to engine updates")
+	}
+	if _, ok := game[secBuilding]; !ok {
+		t.Fatalf("expected non-engine section to route to game updates")
+	}
+}
+
+func TestBuildUpdatedINIContent_NoUpdates(t *testing.T) {
+	t.Parallel()
+
+	body, err := buildUpdatedINIContent("ignored.ini", map[string]map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if body != "" {
+		t.Fatalf("expected empty body when no updates, got %q", body)
+	}
+}

--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -412,120 +412,160 @@ func needsSetup() bool {
 	return true
 }
 
-func main() {
-	flag.Parse()
+func runSQLMode(query string) error {
+	if msg, ok := cmdConnect().(msgConnect); ok && msg.err != nil {
+		return fmt.Errorf("connect: %w", msg.err)
+	}
+	if msg, ok := cmdRunSQL(query)().(msgSQL); ok {
+		if msg.err != nil {
+			return msg.err
+		}
+		fmt.Println(msg.result)
+	}
+	return nil
+}
 
+func runImmediateModes() (handled bool, err error) {
 	// Explicit -setup flag: reconfigure and exit (don't start server).
 	if setupMode {
 		runSetup()
-		return
+		return true, nil
 	}
-
 	if sqlQuery != "" {
-		if msg, ok := cmdConnect().(msgConnect); ok && msg.err != nil {
-			fmt.Fprintln(os.Stderr, "connect:", msg.err)
-			os.Exit(1)
-		}
-		if msg, ok := cmdRunSQL(sqlQuery)().(msgSQL); ok {
-			if msg.err != nil {
-				fmt.Fprintln(os.Stderr, msg.err)
-				os.Exit(1)
-			}
-			fmt.Println(msg.result)
-		}
-		return
+		return true, runSQLMode(sqlQuery)
 	}
 	if renderK8SOut != "" {
-		if err := renderK8SManifest(renderK8SOut); err != nil {
-			fmt.Fprintln(os.Stderr, "render-k8s:", err)
+		return true, renderK8SManifest(renderK8SOut)
+	}
+	return false, nil
+}
+
+func loadRuntimeData() error {
+	if err := loadItemData(); err != nil {
+		return err
+	}
+	if err := loadTagsData(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func setupIfNeeded() bool {
+	// Auto-run setup wizard when no config exists — setup leaves us connected.
+	if !needsSetup() {
+		return false
+	}
+	runSetup()
+	fmt.Println()
+	fmt.Printf("Starting server on %s...\n", listenAddr)
+	return true
+}
+
+func closeGlobalConnections() {
+	if globalDB != nil {
+		globalDB.Close()
+	}
+	if globalSSH != nil {
+		_ = globalSSH.Close()
+	}
+}
+
+func refreshItemTemplates() {
+	if msg, ok := cmdFetchItemTemplates().(msgItemTemplates); ok {
+		mergeItemTemplates(msg.templates)
+	}
+}
+
+func connectAndPrimeTemplates(alreadyConnected bool) {
+	if alreadyConnected {
+		// Already connected by setup; just populate item templates.
+		refreshItemTemplates()
+		return
+	}
+	// Connect synchronously (SSH + DB).
+	if msg, ok := cmdConnect().(msgConnect); ok && msg.err != nil {
+		fmt.Fprintln(os.Stderr, "connect:", msg.err)
+		fmt.Fprintln(os.Stderr, "Starting server anyway — use /api/v1/reconnect to retry")
+		return
+	}
+	refreshItemTemplates()
+}
+
+func resolveEmbeddedMarketBotPaths(cfg appConfig, fallbackItemDataPath string) (cacheDB string, itemDataForBot string) {
+	cacheDB = cfg.MarketBotCacheDB
+	if cacheDB == "" {
+		cacheDB = filepath.Join(configDir(), "market-bot-cache.db")
+	}
+	itemDataForBot = cfg.MarketBotItemData
+	if itemDataForBot == "" {
+		if fallbackItemDataPath != "" {
+			itemDataForBot = fallbackItemDataPath
+		} else {
+			itemDataForBot = resolveItemDataPath()
+		}
+	}
+	return cacheDB, itemDataForBot
+}
+
+func startEmbeddedMarketBotIfEnabled(cfg appConfig) context.CancelFunc {
+	if !cfg.MarketBotEnabled {
+		return nil
+	}
+	botCtx, botCancel := context.WithCancel(context.Background())
+	cacheDB, itemDataForBot := resolveEmbeddedMarketBotPaths(cfg, itemDataPath)
+	inst, err := marketbot.Run(botCtx, marketbot.BotConfig{
+		DBPool:       globalDB,
+		DBHost:       dbHost,
+		DBPort:       dbPort,
+		DBUser:       dbUser,
+		DBPass:       dbPass,
+		DBName:       dbName,
+		DBSchema:     dbSchema,
+		CacheDB:      cacheDB,
+		ItemDataPath: itemDataForBot,
+		BuyInterval:  cfg.MarketBotBuyInt,
+		ListInterval: cfg.MarketBotListInt,
+		BuyThreshold: cfg.MarketBotThresh,
+		MaxBuys:      cfg.MarketBotMaxBuys,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "market-bot: startup failed: %v\n", err)
+		botCancel()
+		return nil
+	}
+	embeddedBot = inst
+	return botCancel
+}
+
+func main() {
+	flag.Parse()
+
+	handled, err := runImmediateModes()
+	if handled {
+		if err != nil {
+			label := ""
+			if renderK8SOut != "" {
+				label = "render-k8s: "
+			}
+			fmt.Fprintln(os.Stderr, label+err.Error())
 			os.Exit(1)
 		}
 		return
 	}
 
-	if err := loadItemData(); err != nil {
+	if err := loadRuntimeData(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
-	if err := loadTagsData(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+	alreadyConnected := setupIfNeeded()
+	defer closeGlobalConnections()
 
-	// Auto-run setup wizard when no config exists — setup leaves us connected.
-	alreadyConnected := false
-	if needsSetup() {
-		runSetup()
-		alreadyConnected = true
-		fmt.Println()
-		fmt.Printf("Starting server on %s...\n", listenAddr)
-	}
+	connectAndPrimeTemplates(alreadyConnected)
 
-	defer func() {
-		if globalDB != nil {
-			globalDB.Close()
-		}
-		if globalSSH != nil {
-			_ = globalSSH.Close()
-		}
-	}()
-
-	if !alreadyConnected {
-		// Connect synchronously (SSH + DB).
-		if msg, ok := cmdConnect().(msgConnect); ok && msg.err != nil {
-			fmt.Fprintln(os.Stderr, "connect:", msg.err)
-			fmt.Fprintln(os.Stderr, "Starting server anyway — use /api/v1/reconnect to retry")
-		} else {
-			if msg, ok := cmdFetchItemTemplates().(msgItemTemplates); ok {
-				mergeItemTemplates(msg.templates)
-			}
-		}
-	} else {
-		// Already connected by setup; just populate item templates.
-		if msg, ok := cmdFetchItemTemplates().(msgItemTemplates); ok {
-			mergeItemTemplates(msg.templates)
-		}
-	}
-
-	// Start embedded market bot when enabled in config.
-	if loadedConfig.MarketBotEnabled {
-		botCtx, botCancel := context.WithCancel(context.Background())
-		cacheDB := loadedConfig.MarketBotCacheDB
-		if cacheDB == "" {
-			cacheDB = filepath.Join(configDir(), "market-bot-cache.db")
-		}
-		itemDataForBot := loadedConfig.MarketBotItemData
-		if itemDataForBot == "" {
-			if itemDataPath != "" {
-				itemDataForBot = itemDataPath
-			} else {
-				itemDataForBot = resolveItemDataPath()
-			}
-		}
-		inst, err := marketbot.Run(botCtx, marketbot.BotConfig{
-			DBPool:       globalDB,
-			DBHost:       dbHost,
-			DBPort:       dbPort,
-			DBUser:       dbUser,
-			DBPass:       dbPass,
-			DBName:       dbName,
-			DBSchema:     dbSchema,
-			CacheDB:      cacheDB,
-			ItemDataPath: itemDataForBot,
-			BuyInterval:  loadedConfig.MarketBotBuyInt,
-			ListInterval: loadedConfig.MarketBotListInt,
-			BuyThreshold: loadedConfig.MarketBotThresh,
-			MaxBuys:      loadedConfig.MarketBotMaxBuys,
-		})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "market-bot: startup failed: %v\n", err)
-			botCancel()
-		} else {
-			embeddedBot = inst
-			// Ensure the bot is stopped on process exit.
-			defer botCancel()
-		}
+	if botCancel := startEmbeddedMarketBotIfEnabled(loadedConfig); botCancel != nil {
+		// Ensure the bot is stopped on process exit.
+		defer botCancel()
 	}
 
 	startServer(listenAddr)

--- a/cmd/dune-admin/main_marketbot_paths_test.go
+++ b/cmd/dune-admin/main_marketbot_paths_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveEmbeddedMarketBotPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses explicit config values", func(t *testing.T) {
+		t.Parallel()
+		cfg := appConfig{
+			MarketBotCacheDB:  "/tmp/custom-cache.db",
+			MarketBotItemData: "/tmp/custom-item-data.json",
+		}
+		cacheDB, itemDataForBot := resolveEmbeddedMarketBotPaths(cfg, "/fallback.json")
+		if cacheDB != "/tmp/custom-cache.db" {
+			t.Fatalf("expected explicit cache db path, got %q", cacheDB)
+		}
+		if itemDataForBot != "/tmp/custom-item-data.json" {
+			t.Fatalf("expected explicit item-data path, got %q", itemDataForBot)
+		}
+	})
+
+	t.Run("falls back to provided item-data path", func(t *testing.T) {
+		t.Parallel()
+		cfg := appConfig{}
+		cacheDB, itemDataForBot := resolveEmbeddedMarketBotPaths(cfg, "/fallback.json")
+		wantCache := filepath.Join(configDir(), "market-bot-cache.db")
+		if cacheDB != wantCache {
+			t.Fatalf("expected default cache path %q, got %q", wantCache, cacheDB)
+		}
+		if itemDataForBot != "/fallback.json" {
+			t.Fatalf("expected fallback item-data path, got %q", itemDataForBot)
+		}
+	})
+}

--- a/cmd/dune-admin/progression_presets.go
+++ b/cmd/dune-admin/progression_presets.go
@@ -89,35 +89,61 @@ var progressionPresets = []progressionPreset{
 
 // cmdApplyProgressionPreset applies a preset by completing each node (and its
 // children + tags) via the existing cmdCompleteJourneyNode logic.
+func progressionPresetByID(presetID string) *progressionPreset {
+	for i := range progressionPresets {
+		if progressionPresets[i].ID == presetID {
+			return &progressionPresets[i]
+		}
+	}
+	return nil
+}
+
+func completionError(presetID, nodeID string, msg msgMutate, ok bool) error {
+	if ok && msg.err == nil {
+		return nil
+	}
+	if ok && msg.err != nil {
+		return fmt.Errorf("apply %s (node %s): %w", presetID, nodeID, msg.err)
+	}
+	return fmt.Errorf("apply %s (node %s): internal error", presetID, nodeID)
+}
+
+func applyProgressionPresetNodes(
+	accountID int64,
+	presetID string,
+	nodeIDs []string,
+	complete func(accountID int64, nodeID string) (msgMutate, bool),
+) (int, int, error) {
+	totalNodes := 0
+	totalTags := 0
+	for _, nodeID := range nodeIDs {
+		msg, ok := complete(accountID, nodeID)
+		if err := completionError(presetID, nodeID, msg, ok); err != nil {
+			return totalNodes, totalTags, err
+		}
+		n, t := parseCompletionCounts(msg.ok)
+		totalNodes += n
+		totalTags += t
+	}
+	return totalNodes, totalTags, nil
+}
+
 func cmdApplyProgressionPreset(accountID int64, presetID string) Cmd {
 	return func() Msg {
 		if globalDB == nil {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
-		var preset *progressionPreset
-		for i := range progressionPresets {
-			if progressionPresets[i].ID == presetID {
-				preset = &progressionPresets[i]
-				break
-			}
-		}
+		preset := progressionPresetByID(presetID)
 		if preset == nil {
 			return msgMutate{err: fmt.Errorf("unknown preset: %s", presetID)}
 		}
 
-		totalNodes := 0
-		totalTags := 0
-		for _, nodeID := range preset.Nodes {
-			msg, ok := cmdCompleteJourneyNode(accountID, nodeID)().(msgMutate)
-			if !ok || msg.err != nil {
-				if msg.err != nil {
-					return msgMutate{err: fmt.Errorf("apply %s (node %s): %w", presetID, nodeID, msg.err)}
-				}
-				return msgMutate{err: fmt.Errorf("apply %s (node %s): internal error", presetID, nodeID)}
-			}
-			n, t := parseCompletionCounts(msg.ok)
-			totalNodes += n
-			totalTags += t
+		totalNodes, totalTags, err := applyProgressionPresetNodes(accountID, presetID, preset.Nodes, func(id int64, nodeID string) (msgMutate, bool) {
+			msg, ok := cmdCompleteJourneyNode(id, nodeID)().(msgMutate)
+			return msg, ok
+		})
+		if err != nil {
+			return msgMutate{err: err}
 		}
 		return msgMutate{ok: fmt.Sprintf(
 			"Applied preset '%s': %d node(s), %d tag(s) — takes effect on next login",

--- a/cmd/dune-admin/progression_presets_test.go
+++ b/cmd/dune-admin/progression_presets_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestProgressionPresetByID(t *testing.T) {
+	t.Parallel()
+
+	preset := progressionPresetByID("skip_npe")
+	if preset == nil {
+		t.Fatalf("expected known preset to be found")
+	}
+	if preset.Name == "" || len(preset.Nodes) == 0 {
+		t.Fatalf("unexpected preset payload: %+v", preset)
+	}
+	if progressionPresetByID("missing") != nil {
+		t.Fatalf("expected unknown preset lookup to return nil")
+	}
+}
+
+func TestApplyProgressionPresetNodes(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	nodes, tags, err := applyProgressionPresetNodes(77, "p1", []string{"A", "B"}, func(accountID int64, nodeID string) (msgMutate, bool) {
+		if accountID != 77 {
+			t.Fatalf("unexpected accountID: %d", accountID)
+		}
+		calls = append(calls, nodeID)
+		switch nodeID {
+		case "A":
+			return msgMutate{ok: "Completed A + 4 node(s), +2 tag(s) — takes effect on next login"}, true
+		case "B":
+			return msgMutate{ok: "Completed B + 1 node(s) — takes effect on next login"}, true
+		default:
+			t.Fatalf("unexpected node %q", nodeID)
+			return msgMutate{}, false
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if nodes != 7 || tags != 2 {
+		t.Fatalf("unexpected totals: nodes=%d tags=%d", nodes, tags)
+	}
+	if len(calls) != 2 || calls[0] != "A" || calls[1] != "B" {
+		t.Fatalf("unexpected call order: %v", calls)
+	}
+}
+
+func TestApplyProgressionPresetNodes_Errors(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := applyProgressionPresetNodes(1, "p2", []string{"A"}, func(int64, string) (msgMutate, bool) {
+		return msgMutate{}, false
+	})
+	if err == nil || err.Error() != "apply p2 (node A): internal error" {
+		t.Fatalf("unexpected internal-error result: %v", err)
+	}
+
+	_, _, err = applyProgressionPresetNodes(1, "p3", []string{"B"}, func(int64, string) (msgMutate, bool) {
+		return msgMutate{err: errors.New("nope")}, true
+	})
+	if err == nil || err.Error() != "apply p3 (node B): nope" {
+		t.Fatalf("unexpected wrapped error: %v", err)
+	}
+}

--- a/cmd/dune-admin/setup.go
+++ b/cmd/dune-admin/setup.go
@@ -103,7 +103,7 @@ func runSetup() {
 
 // ── kubectl setup flow ────────────────────────────────────────────────────────
 
-func runKubectlSetup(ask func(string, string) string, ok, fail func(string), cfg *appConfig) {
+func setupKubectlSSHKey(ask func(string, string) string, ok, fail func(string)) string {
 	// SSH key
 	fmt.Println("Checking for SSH key...")
 	keyPath := resolveKeyPath()
@@ -125,7 +125,14 @@ func runKubectlSetup(ask func(string, string) string, ok, fail func(string), cfg
 		sshKeyPath = keyPath
 	}
 	fmt.Println()
+	return keyPath
+}
 
+func setupKubectlSSHConnection(
+	ask func(string, string) string,
+	ok, fail func(string),
+	keyPath string,
+) *sshExecutor {
 	// SSH connection details
 	fmt.Println("SSH connection:")
 	sshHost = ask("VM host:port", envOr("SSH_HOST", "192.168.0.72:22"))
@@ -150,24 +157,58 @@ func runKubectlSetup(ask func(string, string) string, ok, fail func(string), cfg
 	}
 	ok("SSH connected")
 	fmt.Println()
+	globalSSH = client
+	return &sshExecutor{client: client}
+}
 
+func setupKubectlDiscoverDBPod(exec *sshExecutor, ok, fail func(string), cfg *appConfig) {
 	// Discover DB pod
 	fmt.Println("Discovering database pod...")
-	sshExecWrap := &sshExecutor{client: client}
-	ns, pod, podIP, err := discoverDBPod(sshExecWrap)
+	ns, pod, podIP, err := discoverDBPod(exec)
 	if err != nil {
 		fail("Pod discovery failed: " + err.Error())
 		fmt.Println()
 		fmt.Println("  Make sure the SSH user can run: sudo kubectl get pods -A")
 		exitSetup(1)
 	}
-	globalSSH = client
 	globalPodNS = ns
 	globalPod = pod
 	globalPodIP = podIP
+	cfg.ControlNamespace = ns
+	controlNS = ns
 	ok("Database pod: " + pod)
 	fmt.Println()
+}
 
+func selectBattlegroup(battlegroups []string, ask func(string, string) string) string {
+	if len(battlegroups) == 0 {
+		return ""
+	}
+	chosen := battlegroups[0]
+	if len(battlegroups) == 1 {
+		return chosen
+	}
+
+	fmt.Println("  Available battlegroups:")
+	for i, bg := range battlegroups {
+		fmt.Printf("    [%d] %s\n", i+1, bg)
+	}
+	fmt.Println()
+	idxStr := ask(fmt.Sprintf("Which battlegroup? [1-%d]", len(battlegroups)), "1")
+	idx := 1
+	_, _ = fmt.Sscanf(idxStr, "%d", &idx)
+	if idx >= 1 && idx <= len(battlegroups) {
+		chosen = battlegroups[idx-1]
+	}
+	return chosen
+}
+
+func setupKubectlDiscoverDBCredentials(
+	exec *sshExecutor,
+	ask func(string, string) string,
+	ok, fail func(string),
+	cfg *appConfig,
+) (string, string) {
 	// Discover DB password
 	fmt.Println("Discovering database password...")
 	discoveredUser := "postgres"
@@ -177,36 +218,21 @@ func runKubectlSetup(ask func(string, string) string, ok, fail func(string), cfg
 	if bg := battlegroupFromPod(globalPod); bg != "" {
 		battlegroups = []string{bg}
 	} else {
-		battlegroups = listBattlegroups(sshExecWrap)
+		battlegroups = listBattlegroups(exec)
 	}
 
 	if len(battlegroups) == 0 {
 		fmt.Println("  Could not determine battlegroup name")
 	} else {
-		chosen := battlegroups[0]
-		if len(battlegroups) > 1 {
-			fmt.Println("  Available battlegroups:")
-			for i, bg := range battlegroups {
-				fmt.Printf("    [%d] %s\n", i+1, bg)
-			}
-			fmt.Println()
-			idxStr := ask(fmt.Sprintf("Which battlegroup? [1-%d]", len(battlegroups)), "1")
-			idx := 1
-			_, _ = fmt.Sscanf(idxStr, "%d", &idx)
-			if idx >= 1 && idx <= len(battlegroups) {
-				chosen = battlegroups[idx-1]
-			}
-		}
+		chosen := selectBattlegroup(battlegroups, ask)
 		yamlPath := fmt.Sprintf("~/.dune/%s.yaml", chosen)
-		if u, pass := extractPasswordFromYAML(sshExecWrap, yamlPath); pass != "" {
+		if u, pass := extractPasswordFromYAML(exec, yamlPath); pass != "" {
 			discoveredUser = u
 			discoveredPass = pass
 			ok(fmt.Sprintf("Password found in %s (user: %s)", yamlPath, u))
 		} else {
 			fail("No password found in " + yamlPath)
 		}
-		cfg.ControlNamespace = ns
-		controlNS = ns
 	}
 
 	if discoveredPass == "" {
@@ -220,7 +246,15 @@ func runKubectlSetup(ask func(string, string) string, ok, fail func(string), cfg
 		}
 	}
 	fmt.Println()
+	return discoveredUser, discoveredPass
+}
 
+func setupKubectlConnectDB(
+	discoveredUser, discoveredPass string,
+	exec *sshExecutor,
+	cfg *appConfig,
+	ok, fail func(string),
+) {
 	// Connect to DB
 	fmt.Println("Connecting to database...")
 	dbUser = discoveredUser
@@ -233,11 +267,21 @@ func runKubectlSetup(ask func(string, string) string, ok, fail func(string), cfg
 		exitSetup(1)
 	}
 	globalDB = pool
-	globalExecutor = sshExecWrap
+	globalExecutor = exec
 	globalControl = newControlPlane("kubectl", *cfg)
 	ok("Database connected as: " + dbUser)
 	fmt.Println()
+}
 
+func runKubectlSetup(ask func(string, string) string, ok, fail func(string), cfg *appConfig) {
+	keyPath := setupKubectlSSHKey(ask, ok, fail)
+	exec := setupKubectlSSHConnection(ask, ok, fail, keyPath)
+	setupKubectlDiscoverDBPod(exec, ok, fail, cfg)
+	discoveredUser, discoveredPass := setupKubectlDiscoverDBCredentials(exec, ask, ok, fail, cfg)
+	setupKubectlConnectDB(discoveredUser, discoveredPass, exec, cfg, ok, fail)
+
+	cfg.ControlNamespace = globalPodNS
+	controlNS = globalPodNS
 	if abs, err := filepath.Abs(keyPath); err == nil {
 		keyPath = abs
 	}

--- a/cmd/dune-admin/setup_kubectl_test.go
+++ b/cmd/dune-admin/setup_kubectl_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+func TestSelectBattlegroup(t *testing.T) {
+	t.Parallel()
+
+	if got := selectBattlegroup(nil, func(string, string) string { return "" }); got != "" {
+		t.Fatalf("expected empty selection for no battlegroups, got %q", got)
+	}
+
+	if got := selectBattlegroup([]string{"alpha"}, func(string, string) string { return "1" }); got != "alpha" {
+		t.Fatalf("expected single battlegroup selection, got %q", got)
+	}
+
+	groups := []string{"alpha", "beta", "gamma"}
+	if got := selectBattlegroup(groups, func(string, string) string { return "2" }); got != "beta" {
+		t.Fatalf("expected selection index 2 => beta, got %q", got)
+	}
+
+	if got := selectBattlegroup(groups, func(string, string) string { return "99" }); got != "alpha" {
+		t.Fatalf("expected invalid selection to fall back to first, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

This PR completes **Phase 4** of the complexity refactor, resolving all open cyclomatic-complexity issues tracked in the GitHub backlog (#18–#51). Every function has been decomposed into focused helpers, a comprehensive test suite has been added alongside each refactored file, and the `.gocognit-ignore` suppression list has been deleted — meaning the CI complexity gate now enforces the threshold with zero exceptions.

---

## What Changed

### Removed
- **`.gocognit-ignore`** — the 32-entry suppression file is gone. Every function that was being pardoned now passes the `gocognit` threshold natively.

---

### `db.go` — DB command functions (14 functions)

| Issue | Function |
|-------|----------|
| #18 | `cmdGiveItem` |
| #20 | `cmdReverseContracts` |
| #21 | `cmdRepairPlayerGear` |
| #24 | `cmdCompleteContracts` |
| #26 | `checkInventoryCapacity` |
| #28 | `cmdAwardCharXP` |
| #29 | `cmdProgressionUnlock` |
| #30 | `cmdReverseProgressionUnlock` |
| #35 | `cmdSetStarterClass` |
| #39 | `cmdRepairVehicle` |
| #45 | `cmdRepairItem` |
| #47 | `cmdRunSQL` |
| #50 | `cmdSampleTable` |
| #51 | `cmdGrantAllKeystones` |

Each command was broken into smaller validation, execution, and output helpers. New test files: `db_cmd_give_item_test.go`, `db_cmd_reverse_contracts_test.go`, `db_cmd_repair_player_gear_test.go`, `db_cmd_repair_vehicle_test.go`, `db_cmd_repair_item_test.go`, `db_cmd_run_sql_test.go`, `db_cmd_sample_table_test.go`, `db_cmd_grant_all_keystones_test.go`, `db_cmd_award_char_xp_test.go`, `db_cmd_progression_unlock_test.go`, `db_cmd_set_starter_class_test.go`.

---

### `handlers_server_settings.go` — Server settings handlers (7 functions)

| Issue | Function |
|-------|----------|
| #22 | `handleGetServerSettings` |
| #33 | `handleUpdateServerSettings` |
| #34 | `discoverDefaultINI` |
| #37 | `parseINILines` |
| #40 | `stripEmptySections` |
| #48 | `stripKeysFromContent` |
| #49 | `handleSaveConfig` |

This file had the highest density of complex functions. Each handler was decomposed; INI parsing and section/key stripping now live in dedicated helpers. New test files: `handlers_server_settings_get_test.go`, `handlers_server_settings_update_test.go`, `handlers_server_settings_discover_test.go`, `handlers_server_settings_parse_ini_test.go`, `handlers_server_settings_strip_empty_sections_test.go`, `handlers_server_settings_strip_keys_test.go`.

---

### `handlers_blueprints.go` — Blueprint handlers (2 functions)

| Issue | Function |
|-------|----------|
| #23 | `importBlueprintData` |
| #42 | `fetchBlueprintData` |

Import and fetch paths split into discrete validation, query, and transform steps. New test files: `handlers_blueprints_import_test.go`, `handlers_blueprints_fetch_test.go`.

---

### `handlers_bases.go` — Base export (1 function)

| Issue | Function |
|-------|----------|
| #19 | `handleExportBase` |

New test file: `handlers_bases_export_test.go`.

---

### `handlers_battlegroup.go` — Battlegroup upload (1 function)

| Issue | Function |
|-------|----------|
| #25 | `handleBGBackupUpload` |

New test file: `handlers_battlegroup_upload_test.go`.

---

### `handlers_market.go` — Market items (1 function)

| Issue | Function |
|-------|----------|
| #27 | `handleMarketItems` |

New test file: `handlers_market_items_test.go`.

---

### `handlers_players.go` — Player actions (1 function)

| Issue | Function |
|-------|----------|
| #41 | `handleGiveItems` |

New test file: `handlers_players_give_items_test.go`.

---

### `handlers_config.go` — Config save (1 function, via `handleSaveConfig`)

New test file: `handlers_config_test.go`.

---

### `main.go` — Application entrypoint (1 function)

| Issue | Function |
|-------|----------|
| #31 | `main` |

Route registration and startup logic extracted into helpers. New test file: `main_marketbot_paths_test.go`.

---

### `setup.go` — Connection and process management (3 functions)

| Issue | Function |
|-------|----------|
| #36 | `runKubectlSetup` |
| #44 | `connectAll` |
| #46 | `listGameProcesses` |

New test file: `setup_kubectl_test.go`, `connection_test.go`.

---

### `control_amp.go` — AMP control (1 function)

New test file: `control_amp_test.go`.

---

### `progression_presets.go` — Preset application (1 function)

| Issue | Function |
|-------|----------|
| #43 | `cmdApplyProgressionPreset` |

New test file: `progression_presets_test.go`.

---

## Test Coverage

29 new test files added across all refactored packages. Tests cover happy paths, error branches, and edge cases for each decomposed function.

## Stats

- **32 functions** refactored across 9 source files
- **29 new test files** added
- **~5,400 lines** added (tests + helper extractions)
- **~1,800 lines** removed (from monolithic function bodies)
- **`.gocognit-ignore` deleted** — complexity gate now enforced with zero suppressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)