### PR TITLE
fix(server): restore spaHandler for single-binary deploys

### DIFF
--- a/cmd/dune-admin/server.go
+++ b/cmd/dune-admin/server.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -236,6 +238,17 @@ func startServer(addr string) {
 		}
 	}
 
+	// SPA frontend (local restoration: phase-0 removed this for the
+	// Cloudflare Pages deploy path; AMP / single-binary deploys still
+	// need it). Pending upstream issue + PR.
+	for _, dir := range []string{"./dist", "./web/dist"} {
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			log.Printf("Serving frontend from %s", dir)
+			mux.Handle("/", spaHandler(dir))
+			break
+		}
+	}
+
 	srv := &http.Server{
 		Addr:              addr,
 		Handler:           corsMiddleware(mux),
@@ -246,6 +259,26 @@ func startServer(addr string) {
 	}
 	log.Printf("dune-admin listening on %s", addr)
 	log.Fatal(srv.ListenAndServe())
+}
+
+// spaHandler serves static files from distDir, falling back to index.html
+// for any path that does not match a real file (client-side routing).
+func spaHandler(distDir string) http.Handler {
+	fileServer := http.FileServer(http.Dir(distDir))
+	cleanDist := filepath.Clean(distDir)
+	sep := string(filepath.Separator)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := filepath.Join(cleanDist, filepath.FromSlash(r.URL.Path))
+		if p != cleanDist && !strings.HasPrefix(p, cleanDist+sep) {
+			http.NotFound(w, r)
+			return
+		}
+		if _, err := os.Stat(p); err == nil { // #nosec G703 -- path validated against cleanDist prefix above
+			fileServer.ServeHTTP(w, r)
+			return
+		}
+		http.ServeFile(w, r, filepath.Join(cleanDist, "index.html"))
+	})
 }
 
 // ── JSON helpers ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Restores `spaHandler` and its registration block in `cmd/dune-admin/server.go`, ported verbatim from `upstream/main`. Fixes #58.

## Why

`chore/phase-0-bug-fixes` removed `spaHandler` along with the API-only refactor for the Cloudflare Pages deploy path. Single-binary deploys (AMP-native, local `make linux` + systemd, k8s `port-forward`) still need the binary to serve the SPA from `./dist` at `/`, otherwise `GET /` returns 404 while `web/src/api/client.ts` is still pinned to the same-origin assumption for these deploy modes.

## What changed

- 33 lines added to `cmd/dune-admin/server.go`
- Adds `os` + `path/filepath` to the import block
- Registers the SPA handler at the end of `startServer` (after API routes and `/director/` so it only catches unhandled paths) — only when `./dist` or `./web/dist` exists on disk; no-op when neither is present
- Restores the path-traversal-safe `spaHandler` function (`filepath.Clean` + `HasPrefix` check, real files via `http.FileServer`, index.html fallback for client-side routes)

No new config keys. No behavior change for users who don't ship a `dist/` directory next to the binary. CDN-deploy mode is unaffected (`VITE_CDN_BASE_URL`-built SPA continues to talk to the API cross-origin).

## Test plan

- [x] Built `make linux` from this branch and deployed onto an AMP-mode test VM (`/opt/dune-admin/dune-admin` + `/opt/dune-admin/dist/`, systemd service, no other changes)
- [x] `GET http://vm:9090/` → `HTTP 200`, returns SPA HTML
- [x] `GET http://vm:9090/api/v1/market-bot/status` → embedded bot endpoint unaffected, returns JSON
- [x] `GET http://vm:9090/some-deep-react-route` → falls back to `index.html` so client-side routing keeps working
- [x] Started binary in a working dir with no `dist/` → handler is not registered, `GET /` returns 404 (same as before the patch)
- [x] `journalctl` shows `Serving frontend from ./dist` log line as expected

## Notes for review

If you'd rather wire this through a config flag (e.g. `serve_spa: true` in `appConfig` or a `--serve-spa` flag) instead of filesystem-detection, I'm happy to revise. The filesystem-detection shape matches what `main` did and feels right for the "drop a binary + dist dir, run it" use case — but flag your preference.

Once this lands, my local `scripts/patches/0001-spa-handler-restore.patch` (used by an install script I'd like to PR separately) can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)