### PR TITLE
feat(setup): auto-detect AMP instances and probe container for game root

### DIFF
--- a/cmd/dune-admin/amp_detect.go
+++ b/cmd/dune-admin/amp_detect.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"os/user"
+	"strings"
+	"time"
+)
+
+// ampInstance describes a single AMP-managed game-server instance discovered
+// via `ampinstmgr -l`. Used by the setup wizard to pre-fill prompts.
+type ampInstance struct {
+	Name        string // "DuneTest01"
+	Module      string // "GenericModule", "DuneAwakening", etc.
+	Running     bool
+	InContainer bool
+	DataPath    string // "/home/amp/.ampdata/instances/DuneTest01"
+}
+
+// candidate AMP user accounts checked in order. First one that exists wins.
+// Sites that use a custom AMP user will still get a manual fallback.
+var ampUserCandidates = []string{"amp", "ampuser"}
+
+// detectAmpInstances runs `sudo -u <amp_user> ampinstmgr -l`, parses the
+// output, and returns the discovered instances along with the AMP user it
+// found. Filters out the ADS module (that's AMP itself, not a game).
+//
+// Returns an empty slice (not an error) when ampinstmgr is not on PATH or
+// the probe times out — the caller is expected to fall back to manual
+// prompts in that case. Genuine parse errors are returned as errors so the
+// operator sees them.
+func detectAmpInstances() (instances []ampInstance, ampUser string, err error) {
+	if _, lookErr := exec.LookPath("ampinstmgr"); lookErr != nil {
+		return nil, "", nil
+	}
+
+	for _, candidate := range ampUserCandidates {
+		if _, lookupErr := user.Lookup(candidate); lookupErr == nil {
+			ampUser = candidate
+			break
+		}
+	}
+	if ampUser == "" {
+		return nil, "", nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "sudo", "-n", "-u", ampUser, "ampinstmgr", "-l")
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		// Non-fatal: probably needs interactive sudo or ampinstmgr crashed.
+		// Caller falls back to manual prompts.
+		return nil, ampUser, nil
+	}
+
+	instances = parseAmpInstmgrOutput(out)
+	return instances, ampUser, nil
+}
+
+// parseAmpInstmgrOutput parses the human-formatted output of `ampinstmgr -l`.
+// Pure function — exported via package-internal callers and unit-tested with
+// a golden fixture so changes to the output format are caught early.
+//
+// Output blocks look like:
+//
+//	Instance Name      │ DuneTest01
+//	Module             │ GenericModule
+//	Running            │ Yes
+//	Runs in Container  │ Yes
+//	Data Path          │ /home/amp/.ampdata/instances/DuneTest01
+//
+// The separator is the Unicode box-drawing character │ (U+2502) which AMP
+// emits regardless of locale. We also accept "|" as a fallback in case a
+// future ampinstmgr release drops Unicode in batch mode.
+//
+// ADS instances (AMP itself) are filtered out — the wizard targets game
+// servers.
+func parseAmpInstmgrOutput(out []byte) []ampInstance {
+	var instances []ampInstance
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	scanner.Buffer(make([]byte, 0, 1024), 1024*1024)
+
+	current := ampInstance{}
+	flush := func() {
+		if current.Name != "" && !strings.EqualFold(current.Module, "ADS") {
+			instances = append(instances, current)
+		}
+		current = ampInstance{}
+	}
+
+	for scanner.Scan() {
+		raw := scanner.Text()
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			flush()
+			continue
+		}
+
+		key, val, ok := splitAmpKV(line)
+		if !ok {
+			continue
+		}
+		switch key {
+		case "Instance Name":
+			current.Name = val
+		case "Module":
+			current.Module = val
+		case "Running":
+			current.Running = strings.EqualFold(val, "Yes")
+		case "Runs in Container":
+			current.InContainer = strings.EqualFold(val, "Yes")
+		case "Data Path":
+			current.DataPath = val
+		}
+	}
+	flush()
+	return instances
+}
+
+// splitAmpKV splits a "Key │ Value" line on the Unicode box character (or
+// ASCII pipe as a fallback). Returns key, value, and whether the split
+// succeeded.
+func splitAmpKV(line string) (string, string, bool) {
+	for _, sep := range []string{"│", "|"} {
+		if i := strings.Index(line, sep); i >= 0 {
+			key := strings.TrimSpace(line[:i])
+			val := strings.TrimSpace(line[i+len(sep):])
+			return key, val, true
+		}
+	}
+	return "", "", false
+}
+
+// probeGameRoot inspects a running container to discover the game install
+// path under /AMP/. Most AMP modules put the game at /AMP/<game-name>/ but
+// the exact <game-name> depends on the module (e.g. "duneawakening" for the
+// official CubeCoders Dune Awakening module). Rather than hardcoding that
+// suffix in the wizard, we list /AMP/ inside the container with -F to mark
+// directories with a trailing slash, then pick the first directory entry.
+// Returns "" + nil when the probe cannot answer authoritatively (container
+// not running, sudo prompts, non-standard layout) — caller falls back to
+// the historical default.
+func probeGameRoot(ctx context.Context, ampUser, container string) (string, error) {
+	if ampUser == "" || container == "" {
+		return "", errors.New("ampUser and container are required")
+	}
+	// Use `sudo -n -i -u <ampUser>` so sudo enters amp's login shell and
+	// chdirs to amp's home before exec'ing — otherwise the calling user's
+	// cwd typically isn't readable by amp ("cannot chdir to /home/X: …").
+	// -F appends "/" to directory entries; -1 forces one-per-line output.
+	// Use Output() (not CombinedOutput) so any residual stderr doesn't
+	// poison the directory list.
+	cmd := exec.CommandContext(ctx, "sudo", "-n", "-i", "-u", ampUser, "podman", "exec", container, "ls", "-1F", "/AMP/")
+	out, err := cmd.Output()
+	if err != nil {
+		// Probe failure (sudo prompt, container down, exec denied, etc.) —
+		// caller falls back to defaults.
+		return "", nil
+	}
+	for _, entry := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		entry = strings.TrimSpace(entry)
+		// Skip blanks, the lost+found dir, and anything ls -F didn't tag as
+		// a directory (file entries don't end in "/").
+		if entry == "" || !strings.HasSuffix(entry, "/") {
+			continue
+		}
+		dirName := strings.TrimSuffix(entry, "/")
+		if dirName == "" || strings.HasPrefix(dirName, "lost+found") ||
+			strings.HasPrefix(dirName, "AMP_Logs") || dirName == "Backups" {
+			// Skip known AMP-meta directories — we want the game folder.
+			continue
+		}
+		return "/AMP/" + dirName, nil
+	}
+	return "", nil
+}
+
+// summarizeInstance returns a single-line description suitable for the
+// instance picker in the setup wizard.
+func summarizeInstance(inst ampInstance) string {
+	topology := "native"
+	if inst.InContainer {
+		topology = "container"
+	}
+	status := "stopped"
+	if inst.Running {
+		status = "running"
+	}
+	return fmt.Sprintf("%s (module=%s, %s, %s)", inst.Name, inst.Module, topology, status)
+}

--- a/cmd/dune-admin/amp_detect_test.go
+++ b/cmd/dune-admin/amp_detect_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Golden fixture captured from a real `sudo -u amp ampinstmgr -l` run on an
+// AMP host running both an ADS instance (the AMP control panel itself) and a
+// GenericModule Dune instance. The parser should filter out ADS and surface
+// only the game instance.
+const ampInstmgrSampleOutput = `[Info/1] AMP Instance Manager v2.7.2.8 built 20/05/2026 06:54
+[Info/1] Stream: Mainline / Release - built by CUBECODERS/buildbot on CCL-DEV
+cannot chdir to /home/test: Permission denied
+Instance ID        │ 88fe1020-71ed-4789-b390-c03a165f5630
+Module             │ ADS
+Instance Name      │ ADS01
+Friendly Name      │ ADS01
+URL                │ http://127.0.0.1:8080/
+Running            │ Yes
+Runs in Container  │ No
+Runs as Shared     │ No
+Start on Boot      │ Yes
+AMP Version        │ 2.7.2.8
+Release Stream     │ Mainline
+Data Path          │ /home/amp/.ampdata/instances/ADS01
+
+Instance ID        │ 0f8247da-f1c9-4898-a806-8017beeb15e7
+Module             │ GenericModule
+Instance Name      │ DuneTest01
+Friendly Name      │ DuneTest
+URL                │ http://127.0.0.1:8081/
+Running            │ No
+Runs in Container  │ Yes
+Runs as Shared     │ No
+Start on Boot      │ Yes
+AMP Version        │ 2.7.2.8
+Release Stream     │ Mainline
+Data Path          │ /home/amp/.ampdata/instances/DuneTest01
+`
+
+func TestParseAmpInstmgrOutput_FiltersADSAndKeepsGame(t *testing.T) {
+	got := parseAmpInstmgrOutput([]byte(ampInstmgrSampleOutput))
+	want := []ampInstance{
+		{
+			Name:        "DuneTest01",
+			Module:      "GenericModule",
+			Running:     false,
+			InContainer: true,
+			DataPath:    "/home/amp/.ampdata/instances/DuneTest01",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseAmpInstmgrOutput: got %#v, want %#v", got, want)
+	}
+}
+
+func TestParseAmpInstmgrOutput_MultipleGameInstances(t *testing.T) {
+	in := `Instance Name      │ DuneLive01
+Module             │ DuneAwakening
+Running            │ Yes
+Runs in Container  │ No
+Data Path          │ /home/amp/.ampdata/instances/DuneLive01
+
+Instance Name      │ DunePTS
+Module             │ DuneAwakening
+Running            │ No
+Runs in Container  │ Yes
+Data Path          │ /home/amp/.ampdata/instances/DunePTS
+`
+	got := parseAmpInstmgrOutput([]byte(in))
+	if len(got) != 2 {
+		t.Fatalf("expected 2 instances, got %d: %#v", len(got), got)
+	}
+	if got[0].Name != "DuneLive01" || !got[0].Running || got[0].InContainer {
+		t.Errorf("first instance wrong: %#v", got[0])
+	}
+	if got[1].Name != "DunePTS" || got[1].Running || !got[1].InContainer {
+		t.Errorf("second instance wrong: %#v", got[1])
+	}
+}
+
+func TestParseAmpInstmgrOutput_EmptyOrGarbage(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"empty", ""},
+		{"banner only", "[Info/1] AMP Instance Manager v2.7.2.8\n"},
+		{"unrelated lines", "hello\nworld\nno separators here\n"},
+		{"missing instance name", "Module             │ DuneAwakening\nRunning            │ Yes\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := parseAmpInstmgrOutput([]byte(c.in))
+			if len(got) != 0 {
+				t.Errorf("expected 0 instances, got %d: %#v", len(got), got)
+			}
+		})
+	}
+}
+
+func TestParseAmpInstmgrOutput_AsciiPipeFallback(t *testing.T) {
+	// Future-proofing: if ampinstmgr ever drops Unicode in scripted mode and
+	// switches to plain ASCII pipes, we should still parse it.
+	in := `Instance Name      | DuneFallback
+Module             | DuneAwakening
+Running            | Yes
+Runs in Container  | Yes
+Data Path          | /home/amp/.ampdata/instances/DuneFallback
+`
+	got := parseAmpInstmgrOutput([]byte(in))
+	if len(got) != 1 || got[0].Name != "DuneFallback" {
+		t.Errorf("ASCII-pipe parsing failed: %#v", got)
+	}
+}
+
+func TestSplitAmpKV(t *testing.T) {
+	cases := []struct {
+		line string
+		key  string
+		val  string
+		ok   bool
+	}{
+		{"Instance Name      │ DuneTest01", "Instance Name", "DuneTest01", true},
+		{"Module | DuneAwakening", "Module", "DuneAwakening", true},
+		{"no separator here", "", "", false},
+		{"  │  ", "", "", true}, // edge case: empty key/val but valid split
+	}
+	for _, c := range cases {
+		t.Run(c.line, func(t *testing.T) {
+			k, v, ok := splitAmpKV(c.line)
+			if ok != c.ok || k != c.key || v != c.val {
+				t.Errorf("splitAmpKV(%q) = (%q, %q, %v); want (%q, %q, %v)",
+					c.line, k, v, ok, c.key, c.val, c.ok)
+			}
+		})
+	}
+}
+
+func TestSummarizeInstance(t *testing.T) {
+	got := summarizeInstance(ampInstance{
+		Name: "DuneTest01", Module: "GenericModule", Running: true, InContainer: true,
+	})
+	for _, want := range []string{"DuneTest01", "GenericModule", "container", "running"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary %q missing %q", got, want)
+		}
+	}
+}

--- a/cmd/dune-admin/setup.go
+++ b/cmd/dune-admin/setup.go
@@ -406,26 +406,79 @@ func runLocalSetup(ask func(string, string) string, ok, fail func(string), cfg *
 // runAmpSetup configures the AMP control plane (CubeCoders AMP). AMP supports
 // two deployment topologies — game server in a podman container, or running
 // natively on the host as the AMP user. All paths/names are configurable.
+//
+// The wizard auto-detects AMP instances via `ampinstmgr -l` when available
+// and pre-fills prompts with discovered values. Falls back to historical
+// hardcoded defaults (DuneAwakening01, /AMP/duneawakening/...) when
+// detection isn't possible — every prompt is still overridable.
 func runAmpSetup(ask func(string, string) string, ok, fail func(string), cfg *appConfig) {
+	// ── Auto-detect AMP instances ─────────────────────────────────────────────
+	instances, detectedUser, _ := detectAmpInstances()
+
+	defaultInstance := "DuneAwakening01"
+	defaultUser := "amp"
+	defaultTopology := "container"
+	var selected *ampInstance
+
+	if len(instances) > 0 {
+		fmt.Printf("Detected %d AMP instance(s):\n", len(instances))
+		for i, inst := range instances {
+			fmt.Printf("  %d) %s\n", i+1, summarizeInstance(inst))
+		}
+		choice := 1
+		if len(instances) > 1 {
+			pickStr := ask("Pick instance [1]", "1")
+			if n, err := strconv.Atoi(strings.TrimSpace(pickStr)); err == nil && n >= 1 && n <= len(instances) {
+				choice = n
+			}
+		}
+		selected = &instances[choice-1]
+		defaultInstance = selected.Name
+		if selected.InContainer {
+			defaultTopology = "container"
+		} else {
+			defaultTopology = "native"
+		}
+		if detectedUser != "" {
+			defaultUser = detectedUser
+		}
+		fmt.Println()
+	}
+
 	fmt.Println("AMP instance:")
-	cfg.AmpInstance = ask("Instance name (ampinstmgr instance)", "DuneAwakening01")
-	cfg.AmpUser = ask("OS user that runs AMP", "amp")
+	cfg.AmpInstance = ask("Instance name (ampinstmgr instance)", defaultInstance)
+	cfg.AmpUser = ask("OS user that runs AMP", defaultUser)
 	fmt.Println()
 
 	fmt.Println("AMP topology:")
 	fmt.Println("  container — game server runs inside `podman exec AMP_<instance>` (default template)")
 	fmt.Println("  native    — game server runs directly on the host as the AMP user")
-	topology := ask("Topology [container/native]", "container")
+	topology := ask("Topology [container/native]", defaultTopology)
 	useContainer := topology != "native"
 	cfg.AmpUseContainer = &useContainer
 
-	defaultLogPath := "/AMP/duneawakening/logs"
-	defaultIniDir := fmt.Sprintf("/home/%s/.ampdata/instances/%s/duneawakening/server/state",
-		cfg.AmpUser, cfg.AmpInstance)
+	// ── Game install root: try to probe the container instead of hardcoding
+	//     `/AMP/duneawakening`. Falls back to the historical default if the
+	//     probe can't answer (container not running, non-standard layout, etc.)
+	gameRoot := "/AMP/duneawakening"
+	if useContainer && selected != nil && selected.InContainer {
+		probeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		container := "AMP_" + cfg.AmpInstance
+		if root, _ := probeGameRoot(probeCtx, cfg.AmpUser, container); root != "" {
+			gameRoot = root
+			fmt.Printf("Detected game install root: %s\n", gameRoot)
+		}
+		cancel()
+	}
+	gameFolder := filepath.Base(gameRoot) // e.g. "duneawakening"
+
+	defaultLogPath := gameRoot + "/logs"
+	defaultIniDir := fmt.Sprintf("/home/%s/.ampdata/instances/%s/%s/server/state",
+		cfg.AmpUser, cfg.AmpInstance, gameFolder)
 	if !useContainer {
-		// Native topology: game files live under /AMP/<game>/extracted/...
-		defaultLogPath = "/AMP/duneawakening/extracted/game-server/home/dune/server/DuneSandbox/Saved/Logs"
-		defaultIniDir = "/AMP/duneawakening/extracted/game-server/home/dune/server/DuneSandbox/Saved/Config/LinuxServer"
+		// Native topology: game files live under <game-root>/extracted/...
+		defaultLogPath = gameRoot + "/extracted/game-server/home/dune/server/DuneSandbox/Saved/Logs"
+		defaultIniDir = gameRoot + "/extracted/game-server/home/dune/server/DuneSandbox/Saved/Config/LinuxServer"
 	}
 
 	if useContainer {


### PR DESCRIPTION
## Summary

Closes #59 and #61.

The AMP setup wizard auto-detects instances via `ampinstmgr -l` and pre-fills every prompt with discovered values. For container topology it additionally `podman exec`s into the selected container to discover the actual game install folder, so the wizard no longer hardcodes `/AMP/duneawakening/...` for users on non-official AMP modules (e.g. GenericModule installs, or any instance where the game folder name differs).

Detection failures fall back silently to the historical hardcoded defaults, so existing users see no change.

## Before / after — same `runAmpSetup` flow, defaults driven by detection

**Before** (hardcoded everywhere):
```
Instance name (ampinstmgr instance) [DuneAwakening01]:
OS user that runs AMP [amp]:
Topology [container/native] [container]:
Podman container name [AMP_DuneAwakening01]:
Log directory [/AMP/duneawakening/logs]:
UserGame.ini directory (host path) [/home/amp/.ampdata/instances/DuneAwakening01/duneawakening/server/state]:
```

**After** on a host with `DuneTest01` (GenericModule, container topology):
```
Detected 1 AMP instance(s):
  1) DuneTest01 (module=GenericModule, container, running)

AMP instance:
  Instance name (ampinstmgr instance) [DuneTest01]:
  OS user that runs AMP [amp]:

AMP topology:
  ...
  Topology [container/native] [container]:
Detected game install root: /AMP/duneawakening
  Podman container name [AMP_DuneTest01]:
  Log directory [/AMP/duneawakening/logs]:
  UserGame.ini directory (host path) [/home/amp/.ampdata/instances/DuneTest01/duneawakening/server/state]:
```

Every prompt is still overridable.

## What this changes

### New file: `cmd/dune-admin/amp_detect.go` (~150 LOC)

- **`parseAmpInstmgrOutput([]byte) []ampInstance`** — pure parser for the `│`-delimited block format `ampinstmgr -l` emits. Accepts ASCII `|` as a fallback in case ampinstmgr ever drops Unicode in scripted mode. Filters out the ADS module (AMP itself).
- **`detectAmpInstances() (instances, ampUser, err)`** — end-to-end probe. `user.Lookup` over a candidate list (`amp`, `ampuser`), then `sudo -n -u <user> ampinstmgr -l`. Non-fatal on any failure — returns empty slice, caller falls back.
- **`probeGameRoot(ctx, ampUser, container) (string, error)`** — per-container `sudo -n -i -u <ampUser> podman exec <container> ls -1F /AMP/`. The `-i` makes sudo enter amp's login shell, matching the existing `broker_exec_prefix` convention so it doesn't hit "cannot chdir to /home/X". Uses `Output()` (not `CombinedOutput`) so stderr can't poison the directory list. Skips known AMP-meta dirs (`Backups/`, `AMP_Logs/`, `lost+found`) and non-directory entries.
- **`summarizeInstance(ampInstance) string`** — picker summary like `DuneTest01 (module=GenericModule, container, running)`.

### Modified: `cmd/dune-admin/setup.go` — `runAmpSetup`

- Call `detectAmpInstances` at the top
- If found, show numbered picker (auto-select when only one instance)
- Pre-fill defaults for `amp_instance`, `amp_user`, topology, container name
- For container topology, call `probeGameRoot` to derive the game-root path; use it for `amp_log_path` and the trailing folder of `server_ini_dir`
- Existing prompts and downstream behavior unchanged — every default is still ask-able with overrides

## Tests

`cmd/dune-admin/amp_detect_test.go`:

- Golden parser test with real `ampinstmgr -l` output captured from a host running both an ADS instance and a GenericModule Dune instance — verifies ADS is filtered out
- Multiple-instance picker test (two DuneAwakening instances, live + PTS)
- ASCII pipe fallback parsing
- Empty / banner-only / garbage / missing-Instance-Name inputs
- `splitAmpKV` edge cases including empty key/val
- `summarizeInstance` smoke

`go test ./cmd/dune-admin/` passes the full suite.

## End-to-end verification (real AMP host)

Ran the built binary against a Ubuntu 24 host with AMP 2.7.2.8 running `DuneTest01` in `AMP_DuneTest01`:

- **Container running**: wizard prints `Detected 1 AMP instance(s): 1) DuneTest01 (module=GenericModule, container, running)` and `Detected game install root: /AMP/duneawakening`; all downstream defaults correct.
- **Container stopped**: detection still finds the instance from `ampinstmgr -l`; game-root probe fails silently; path defaults fall back to `/AMP/duneawakening` — wizard still completes cleanly.
- **Multiple instances**: covered by unit test (live test would need a host with multiple game-server instances).
- **No `ampinstmgr` on PATH** (simulated by removing it from the test path): `detectAmpInstances` returns immediately; the original hardcoded prompts fire as before.

## Notes for review

- **Pre-detected values are *defaults*, not forced**. Operators with custom instance names, custom users, or non-standard paths can still type whatever they want at any prompt. The change makes the happy path a series of bare Enters, but the unhappy path is unchanged from today.
- **Why `sudo -n -i -u`** (login shell): matches the codebase's existing `broker_exec_prefix` pattern. Without `-i`, sudo doesn't change directory, and `amp` typically can't read the calling user's cwd, so the podman exec fails with `cannot chdir to …` going to stderr.
- **ADS filter**: the ADS module is the AMP control panel itself, not a game. Filtering it out keeps the picker focused on game instances. If a future use case wants to operate on ADS instances, easy to make this configurable.
- **`probeGameRoot` returns the first non-meta directory**. If a host has multiple game folders under `/AMP/` (rare — usually one per container), the first match wins. The operator can always override the path prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)