### PR TITLE
chore: add .gitattributes to force LF line endings for source files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Force LF line endings for files where line endings matter at runtime or for
+# tooling correctness. Without this, contributors who clone on Windows with
+# the default `core.autocrlf=true` get CRLF in the working tree, which makes
+# `gofmt -l .` (and therefore `make fmt-check` / the pre-commit hook) report
+# every Go file as unformatted on first checkout.
+
+*.go        text eol=lf
+*.sh        text eol=lf
+*.bash      text eol=lf
+Makefile    text eol=lf
+.githooks/* text eol=lf
+
+# Treat lockfiles as binary so diffs don't churn on encoding changes.
+go.sum             -text
+web/pnpm-lock.yaml -text


### PR DESCRIPTION
## Summary

Adds a 15-line `.gitattributes` that forces LF line endings for Go, shell, Makefile, and `.githooks/*` files. No behavior change for Linux/macOS — already LF by default. Big quality-of-life win for Windows contributors.

## The problem

Without an explicit policy, anyone cloning on Windows with the default `core.autocrlf=true` gets CRLF in the working tree at checkout. `gofmt -l .` then reports every Go file as unformatted, and the pre-commit hook + `make fmt-check` + `make verify` all fail on first run. The blobs in the repo are LF, the working tree is CRLF, gofmt sees CRLF as wrong.

I tripped on this minutes ago setting up the pre-commit hooks per `make hooks` on a Windows host:

```
$ make verify
Code is not formatted. Run 'make fmt'
$ gofmt -l . | head
cmd\dune-admin\amp_detect.go
cmd\dune-admin\broker.go
cmd\dune-admin\compat.go
...
```

The workaround is per-clone:
```bash
git config core.autocrlf false
git rm --cached -r .
git reset --hard
```

But every new Windows contributor has to discover and apply this. `.gitattributes` makes it automatic.

## What changed

```
*.go        text eol=lf
*.sh        text eol=lf
*.bash      text eol=lf
Makefile    text eol=lf
.githooks/* text eol=lf

go.sum             -text
web/pnpm-lock.yaml -text
```

- Source files that tools care about: forced LF
- Lockfiles: marked binary so diffs don't churn if someone's editor flips encodings

## Why these specific files

- **`*.go`** — gofmt is line-ending-strict
- **`*.sh` / `*.bash` / `.githooks/*`** — bash on Linux refuses to run scripts with CRLF (`bad interpreter: /bin/bash^M: no such file or directory`)
- **`Makefile`** — GNU make's recipe parsing breaks on CRLF (tab + CR is not tab)
- **`go.sum` / `pnpm-lock.yaml`** — auto-generated, no value being treated as text-with-line-endings

## Test plan

- [x] Apply `.gitattributes` on a Windows clone with `core.autocrlf=true`
- [x] Re-checkout (`git rm --cached -r . && git reset --hard`)
- [x] `make fmt-check` passes
- [x] Pre-commit hook (which calls `make fmt`) runs cleanly
- No-op for existing Linux/macOS contributors (their working trees were already LF)

## Notes

Related to the verification tooling setup work I just did — `make hooks` + `make tools` on Windows worked perfectly once the CRLF mismatch was resolved, so this puts that on a permanent footing for the next Windows contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)