### PR TITLE
chore(verify): refactor 8 functions to pass gocognit complexity gate

### DIFF
--- a/cmd/dune-admin/control_kubectl.go
+++ b/cmd/dune-admin/control_kubectl.go
@@ -250,6 +250,39 @@ func extractPasswordFromYAML(exec Executor, filePath string) (user, pass string)
 	return parseDeploymentCredentials([]byte(out))
 }
 
+// tryReadINIFromPod attempts to read filename from a specific pod by trying
+// well-known Config paths first, then falling back to a find-based search.
+func tryReadINIFromPod(exec Executor, kctl, namespace, pod, filename string) string {
+	candidates := []string{
+		"/DuneSandbox/Config/" + filename,
+		"/home/dune/server/DuneSandbox/Config/" + filename,
+		"/home/dune/DuneSandbox/Config/" + filename,
+		"/game/DuneSandbox/Config/" + filename,
+	}
+	for _, p := range candidates {
+		content, err := exec.Exec(fmt.Sprintf(
+			"%s exec -n %s %s -- cat %s 2>/dev/null",
+			kctl, namespace, pod, shellQuote(p)))
+		if err == nil && len(strings.TrimSpace(content)) > 0 {
+			log.Printf("[default-ini] kubectl: read %s (%d bytes) from pod %s", p, len(content), pod)
+			return content
+		}
+	}
+	pathOut, _ := exec.Exec(fmt.Sprintf(
+		"%s exec -n %s %s -- find -L /DuneSandbox /home /app /game -name %s -not -path '*/Saved/*' 2>/dev/null | head -1",
+		kctl, namespace, pod, shellQuote(filename)))
+	if p := strings.TrimSpace(pathOut); p != "" {
+		content, err := exec.Exec(fmt.Sprintf(
+			"%s exec -n %s %s -- cat %s 2>/dev/null",
+			kctl, namespace, pod, shellQuote(p)))
+		if err == nil && len(strings.TrimSpace(content)) > 0 {
+			log.Printf("[default-ini] kubectl: read %s (%d bytes) from pod %s", p, len(content), pod)
+			return content
+		}
+	}
+	return ""
+}
+
 func (c *kubectlControl) ReadDefaultINI(_ context.Context, exec Executor, filename string) string {
 	if c.namespace == "" {
 		return ""
@@ -286,37 +319,9 @@ func (c *kubectlControl) ReadDefaultINI(_ context.Context, exec Executor, filena
 		return ""
 	}
 
-	// Try well-known Config directories directly. find / misses paths that are
-	// only accessible via bind-mount roots or require following symlinks.
-	candidates := []string{
-		"/DuneSandbox/Config/" + filename,
-		"/home/dune/server/DuneSandbox/Config/" + filename,
-		"/home/dune/DuneSandbox/Config/" + filename,
-		"/game/DuneSandbox/Config/" + filename,
-	}
 	for _, pod := range pods {
-		for _, p := range candidates {
-			content, err := exec.Exec(fmt.Sprintf(
-				"%s exec -n %s %s -- cat %s 2>/dev/null",
-				kctl, c.namespace, pod, shellQuote(p)))
-			if err == nil && len(strings.TrimSpace(content)) > 0 {
-				log.Printf("[default-ini] kubectl: read %s (%d bytes) from pod %s", p, len(content), pod)
-				return content
-			}
-		}
-
-		// Fall back: find with symlink-following under game-relevant roots.
-		pathOut, _ := exec.Exec(fmt.Sprintf(
-			"%s exec -n %s %s -- find -L /DuneSandbox /home /app /game -name %s -not -path '*/Saved/*' 2>/dev/null | head -1",
-			kctl, c.namespace, pod, shellQuote(filename)))
-		if p := strings.TrimSpace(pathOut); p != "" {
-			content, err := exec.Exec(fmt.Sprintf(
-				"%s exec -n %s %s -- cat %s 2>/dev/null",
-				kctl, c.namespace, pod, shellQuote(p)))
-			if err == nil && len(strings.TrimSpace(content)) > 0 {
-				log.Printf("[default-ini] kubectl: read %s (%d bytes) from pod %s", p, len(content), pod)
-				return content
-			}
+		if content := tryReadINIFromPod(exec, kctl, c.namespace, pod, filename); content != "" {
+			return content
 		}
 	}
 

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -476,6 +476,26 @@ func ensureGiveItemVolumeCapacity(
 	return nil
 }
 
+func fillExistingStacks(sorted []giveItemStackSlot, remaining, stackMax int64) ([]giveItemStackUpdate, int64) {
+	updates := make([]giveItemStackUpdate, 0, len(sorted))
+	for _, st := range sorted {
+		if remaining == 0 {
+			break
+		}
+		space := stackMax - st.size
+		if space <= 0 {
+			continue
+		}
+		add := space
+		if add > remaining {
+			add = remaining
+		}
+		updates = append(updates, giveItemStackUpdate{id: st.id, add: add})
+		remaining -= add
+	}
+	return updates, remaining
+}
+
 func planGiveItemStacks(qty, stackMax int64, stacks []giveItemStackSlot) ([]giveItemStackUpdate, []int64) {
 	sorted := make([]giveItemStackSlot, len(stacks))
 	copy(sorted, stacks)
@@ -483,23 +503,11 @@ func planGiveItemStacks(qty, stackMax int64, stacks []giveItemStackSlot) ([]give
 		return sorted[i].size > sorted[j].size
 	})
 	remaining := qty
-	updates := make([]giveItemStackUpdate, 0, len(sorted))
+	var updates []giveItemStackUpdate
 	if stackMax > 1 {
-		for _, st := range sorted {
-			if remaining == 0 {
-				break
-			}
-			space := stackMax - st.size
-			if space <= 0 {
-				continue
-			}
-			add := space
-			if add > remaining {
-				add = remaining
-			}
-			updates = append(updates, giveItemStackUpdate{id: st.id, add: add})
-			remaining -= add
-		}
+		updates, remaining = fillExistingStacks(sorted, remaining, stackMax)
+	} else {
+		updates = make([]giveItemStackUpdate, 0)
 	}
 	newStackCap := 0
 	if stackMax > 0 {

--- a/cmd/dune-admin/handlers_players.go
+++ b/cmd/dune-admin/handlers_players.go
@@ -266,6 +266,27 @@ func resolveGiveItemsOnlinePath(
 	return true, flsID
 }
 
+func processOneGiveItem(ctx context.Context, playerID int64, item giveItemInput, online bool, flsID string, deps giveItemsDeps) (string, *skippedItem) {
+	if online && item.Quality == 0 {
+		if err := deps.checkCapacity(ctx, playerID, item.Template, item.Qty); err != nil {
+			return "", &skippedItem{Template: item.Template, Reason: err.Error()}
+		}
+		if err := deps.rmqAdd(flsID, item.Template, int(item.Qty), 1.0); err != nil {
+			return "", &skippedItem{Template: item.Template, Reason: err.Error()}
+		}
+		return item.Template, nil
+	}
+	msg, ok := deps.dbGive(playerID, item.Template, item.Qty, item.Quality)
+	if !ok || msg.err != nil {
+		reason := "internal error"
+		if ok && msg.err != nil {
+			reason = msg.err.Error()
+		}
+		return "", &skippedItem{Template: item.Template, Reason: reason}
+	}
+	return item.Template, nil
+}
+
 func processGiveItems(
 	ctx context.Context,
 	req giveItemsRequest,
@@ -276,28 +297,12 @@ func processGiveItems(
 	given := make([]string, 0, len(req.Items))
 	skipped := make([]skippedItem, 0)
 	for _, item := range req.Items {
-		if online && item.Quality == 0 {
-			if err := deps.checkCapacity(ctx, req.PlayerID, item.Template, item.Qty); err != nil {
-				skipped = append(skipped, skippedItem{Template: item.Template, Reason: err.Error()})
-				continue
-			}
-			if err := deps.rmqAdd(flsID, item.Template, int(item.Qty), 1.0); err != nil {
-				skipped = append(skipped, skippedItem{Template: item.Template, Reason: err.Error()})
-				continue
-			}
-			given = append(given, item.Template)
+		g, s := processOneGiveItem(ctx, req.PlayerID, item, online, flsID, deps)
+		if s != nil {
+			skipped = append(skipped, *s)
 			continue
 		}
-		msg, ok := deps.dbGive(req.PlayerID, item.Template, item.Qty, item.Quality)
-		if !ok || msg.err != nil {
-			reason := "internal error"
-			if ok && msg.err != nil {
-				reason = msg.err.Error()
-			}
-			skipped = append(skipped, skippedItem{Template: item.Template, Reason: reason})
-			continue
-		}
-		given = append(given, item.Template)
+		given = append(given, g)
 	}
 	return given, skipped
 }

--- a/cmd/dune-admin/handlers_server_settings.go
+++ b/cmd/dune-admin/handlers_server_settings.go
@@ -283,6 +283,47 @@ func compactRawSections(result []RawSection) []RawSection {
 	return out
 }
 
+func storeINIEntry(line, cur string, sections map[string]map[string]string, counts map[string]map[string]int) {
+	rest := line
+	prefix := ""
+	if len(line) > 0 && (line[0] == '+' || line[0] == '-') {
+		prefix = string(line[0])
+		rest = line[1:]
+	}
+	eq := strings.Index(rest, "=")
+	if eq <= 0 {
+		return
+	}
+	baseKey := prefix + strings.TrimSpace(rest[:eq])
+	val := strings.TrimSpace(rest[eq+1:])
+	n := counts[cur][baseKey]
+	counts[cur][baseKey] = n + 1
+	storeKey := baseKey
+	if n > 0 {
+		storeKey = fmt.Sprintf("%s\x00%d", baseKey, n)
+	}
+	sections[cur][storeKey] = val
+}
+
+func applyINILine(line, cur string, sections map[string]map[string]string, counts map[string]map[string]int) string {
+	if line == "" || strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#") {
+		return cur
+	}
+	if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+		cur = line[1 : len(line)-1]
+		if sections[cur] == nil {
+			sections[cur] = map[string]string{}
+			counts[cur] = map[string]int{}
+		}
+		return cur
+	}
+	if cur == "" {
+		return cur
+	}
+	storeINIEntry(line, cur, sections, counts)
+	return cur
+}
+
 // parseINIRaw parses raw INI lines preserving +/- prefixes as part of the key
 // (e.g. "+ActiveMod=SomeMod" is stored as key "+ActiveMod"). Duplicate keys
 // (common for UE array entries like multiple "+ActiveMod=" lines) are stored
@@ -290,42 +331,10 @@ func compactRawSections(result []RawSection) []RawSection {
 // renderDuneAdminBlock strips the suffix when writing the file.
 func parseINIRaw(content string) map[string]map[string]string {
 	sections := map[string]map[string]string{}
-	counts := map[string]map[string]int{} // section → key → occurrence count
+	counts := map[string]map[string]int{}
 	var cur string
 	for _, raw := range strings.Split(content, "\n") {
-		line := strings.TrimSpace(raw)
-		if line == "" || strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#") {
-			continue
-		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			cur = line[1 : len(line)-1]
-			if sections[cur] == nil {
-				sections[cur] = map[string]string{}
-				counts[cur] = map[string]int{}
-			}
-			continue
-		}
-		if cur == "" {
-			continue
-		}
-		rest := line
-		prefix := ""
-		if len(line) > 0 && (line[0] == '+' || line[0] == '-') {
-			prefix = string(line[0])
-			rest = line[1:]
-		}
-		if eq := strings.Index(rest, "="); eq > 0 {
-			baseKey := prefix + strings.TrimSpace(rest[:eq])
-			val := strings.TrimSpace(rest[eq+1:])
-			n := counts[cur][baseKey]
-			counts[cur][baseKey] = n + 1
-			// First occurrence uses the plain key; subsequent ones get "\x00N" suffix.
-			storeKey := baseKey
-			if n > 0 {
-				storeKey = fmt.Sprintf("%s\x00%d", baseKey, n)
-			}
-			sections[cur][storeKey] = val
-		}
+		cur = applyINILine(strings.TrimSpace(raw), cur, sections, counts)
 	}
 	return sections
 }
@@ -653,27 +662,29 @@ func buildSchemaSettings(layerSources []layerSource) []ServerSetting {
 	return settings
 }
 
+func discoverSectionKeys(section string, keys map[string]string, seenKeys map[string]bool, out *[]discoveredKey) {
+	for key := range keys {
+		if strings.HasPrefix(key, "+") || strings.HasPrefix(key, "-") {
+			continue
+		}
+		composite := section + "|" + key
+		if seenKeys[composite] {
+			continue
+		}
+		seenKeys[composite] = true
+		*out = append(*out, discoveredKey{section: section, key: key})
+	}
+}
+
 func discoverUnknownSettings(layerSources []layerSource, schemaKeys map[string]bool) []discoveredKey {
 	seenKeys := make(map[string]bool, len(schemaKeys))
 	for k := range schemaKeys {
 		seenKeys[k] = true
 	}
-
 	discovered := make([]discoveredKey, 0, 32)
 	for _, src := range layerSources {
 		for section, keys := range src.ini {
-			for key := range keys {
-				// Skip array-prefix lines (+/-); they belong in raw sections.
-				if strings.HasPrefix(key, "+") || strings.HasPrefix(key, "-") {
-					continue
-				}
-				composite := section + "|" + key
-				if seenKeys[composite] {
-					continue
-				}
-				seenKeys[composite] = true
-				discovered = append(discovered, discoveredKey{section: section, key: key})
-			}
+			discoverSectionKeys(section, keys, seenKeys, &discovered)
 		}
 	}
 	sort.Slice(discovered, func(i, j int) bool {
@@ -880,37 +891,43 @@ func renderDuneAdminBlock(managed map[string]map[string]string) string {
 	}
 	sort.Strings(secs)
 	for _, sec := range secs {
-		b.WriteString("\n[" + sec + "]\n")
-		keys := make([]string, 0, len(managed[sec]))
-		for k := range managed[sec] {
-			keys = append(keys, k)
-		}
-		sort.Slice(keys, func(i, j int) bool {
-			baseI, idxI, dupI := managedKeyParts(keys[i])
-			baseJ, idxJ, dupJ := managedKeyParts(keys[j])
-			if baseI != baseJ {
-				return baseI < baseJ
-			}
-			if dupI != dupJ {
-				// The unsuffixed key sorts before duplicates.
-				return !dupI
-			}
-			if dupI && idxI != idxJ {
-				return idxI < idxJ
-			}
-			return keys[i] < keys[j]
-		})
-		for _, k := range keys {
-			// Strip the \x00N dedup suffix before writing — it is internal only.
-			displayKey := k
-			if idx := strings.IndexByte(k, '\x00'); idx >= 0 {
-				displayKey = k[:idx]
-			}
-			b.WriteString(displayKey + "=" + managed[sec][k] + "\n")
-		}
+		renderManagedSection(&b, sec, managed[sec])
 	}
 	b.WriteString("\n" + duneAdminEndMarker + "\n")
 	return b.String()
+}
+
+func sortedManagedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		baseI, idxI, dupI := managedKeyParts(keys[i])
+		baseJ, idxJ, dupJ := managedKeyParts(keys[j])
+		if baseI != baseJ {
+			return baseI < baseJ
+		}
+		if dupI != dupJ {
+			return !dupI
+		}
+		if dupI && idxI != idxJ {
+			return idxI < idxJ
+		}
+		return keys[i] < keys[j]
+	})
+	return keys
+}
+
+func renderManagedSection(b *strings.Builder, sec string, m map[string]string) {
+	b.WriteString("\n[" + sec + "]\n")
+	for _, k := range sortedManagedKeys(m) {
+		displayKey := k
+		if idx := strings.IndexByte(k, '\x00'); idx >= 0 {
+			displayKey = k[:idx]
+		}
+		b.WriteString(displayKey + "=" + m[k] + "\n")
+	}
 }
 
 // legacyHeaderSentinel matches the comment block emitted by the brief

--- a/cmd/dune-admin/render_k8s.go
+++ b/cmd/dune-admin/render_k8s.go
@@ -43,6 +43,27 @@ func indentLines(s, prefix string) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
+func addIfNonEmpty(m map[string]any, key, val string) {
+	if val != "" {
+		m[key] = val
+	}
+}
+
+func addAmpManifestFields(m map[string]any, cfg *appConfig, control string) {
+	if cfg.Control != "amp" && control != "amp" {
+		return
+	}
+	addIfNonEmpty(m, "amp_instance", cfg.AmpInstance)
+	addIfNonEmpty(m, "amp_container", cfg.AmpContainer)
+	addIfNonEmpty(m, "amp_user", cfg.AmpUser)
+	addIfNonEmpty(m, "amp_log_path", cfg.AmpLogPath)
+	if cfg.AmpUseContainer != nil {
+		m["amp_use_container"] = *cfg.AmpUseContainer
+	}
+	addIfNonEmpty(m, "amp_data_root", cfg.AmpDataRoot)
+	addIfNonEmpty(m, "director_url", cfg.DirectorURL)
+}
+
 func renderK8SManifest(outPath string) error {
 	control := firstNonEmpty(controlPlane, loadedConfig.Control)
 	if control == "" {
@@ -56,11 +77,10 @@ func renderK8SManifest(outPath string) error {
 	dbHostVal := firstNonEmpty(dbHost, loadedConfig.DBHost, "postgres.default.svc.cluster.local")
 	dbPortVal := dbPort
 	if dbPortVal == 0 {
-		if loadedConfig.DBPort != 0 {
-			dbPortVal = loadedConfig.DBPort
-		} else {
-			dbPortVal = 15432
-		}
+		dbPortVal = loadedConfig.DBPort
+	}
+	if dbPortVal == 0 {
+		dbPortVal = 15432
 	}
 	dbUserVal := firstNonEmpty(dbUser, loadedConfig.DBUser, "dune")
 	dbNameVal := firstNonEmpty(dbName, loadedConfig.DBName, "dune")
@@ -96,59 +116,19 @@ func renderK8SManifest(outPath string) error {
 		"market_bot_buy_threshold": buyThreshold,
 		"market_bot_max_buys":      maxBuys,
 	}
-	if loadedConfig.SSHHost != "" {
-		manifestCfg["ssh_host"] = loadedConfig.SSHHost
-	}
-	if loadedConfig.SSHUser != "" {
-		manifestCfg["ssh_user"] = loadedConfig.SSHUser
-	}
-	if loadedConfig.SSHKey != "" {
-		manifestCfg["ssh_key"] = loadedConfig.SSHKey
-	}
-	if loadedConfig.ControlNamespace != "" {
-		manifestCfg["control_namespace"] = loadedConfig.ControlNamespace
-	}
-	if loadedConfig.BrokerGameAddr != "" {
-		manifestCfg["broker_game_addr"] = loadedConfig.BrokerGameAddr
-	}
-	if loadedConfig.BrokerAdminAddr != "" {
-		manifestCfg["broker_admin_addr"] = loadedConfig.BrokerAdminAddr
-	}
+	addIfNonEmpty(manifestCfg, "ssh_host", loadedConfig.SSHHost)
+	addIfNonEmpty(manifestCfg, "ssh_user", loadedConfig.SSHUser)
+	addIfNonEmpty(manifestCfg, "ssh_key", loadedConfig.SSHKey)
+	addIfNonEmpty(manifestCfg, "control_namespace", loadedConfig.ControlNamespace)
+	addIfNonEmpty(manifestCfg, "broker_game_addr", loadedConfig.BrokerGameAddr)
+	addIfNonEmpty(manifestCfg, "broker_admin_addr", loadedConfig.BrokerAdminAddr)
 	if loadedConfig.BrokerTLS {
 		manifestCfg["broker_tls"] = true
 	}
-	if loadedConfig.ServerIniDir != "" {
-		manifestCfg["server_ini_dir"] = loadedConfig.ServerIniDir
-	}
-	if loadedConfig.DefaultIniDir != "" {
-		manifestCfg["default_ini_dir"] = loadedConfig.DefaultIniDir
-	}
-	if loadedConfig.BackupDir != "" {
-		manifestCfg["backup_dir"] = loadedConfig.BackupDir
-	}
-	if loadedConfig.Control == "amp" || control == "amp" {
-		if loadedConfig.AmpInstance != "" {
-			manifestCfg["amp_instance"] = loadedConfig.AmpInstance
-		}
-		if loadedConfig.AmpContainer != "" {
-			manifestCfg["amp_container"] = loadedConfig.AmpContainer
-		}
-		if loadedConfig.AmpUser != "" {
-			manifestCfg["amp_user"] = loadedConfig.AmpUser
-		}
-		if loadedConfig.AmpLogPath != "" {
-			manifestCfg["amp_log_path"] = loadedConfig.AmpLogPath
-		}
-		if loadedConfig.AmpUseContainer != nil {
-			manifestCfg["amp_use_container"] = *loadedConfig.AmpUseContainer
-		}
-		if loadedConfig.AmpDataRoot != "" {
-			manifestCfg["amp_data_root"] = loadedConfig.AmpDataRoot
-		}
-		if loadedConfig.DirectorURL != "" {
-			manifestCfg["director_url"] = loadedConfig.DirectorURL
-		}
-	}
+	addIfNonEmpty(manifestCfg, "server_ini_dir", loadedConfig.ServerIniDir)
+	addIfNonEmpty(manifestCfg, "default_ini_dir", loadedConfig.DefaultIniDir)
+	addIfNonEmpty(manifestCfg, "backup_dir", loadedConfig.BackupDir)
+	addAmpManifestFields(manifestCfg, &loadedConfig, control)
 
 	cfgYAMLBytes, err := yaml.Marshal(manifestCfg)
 	if err != nil {

--- a/cmd/dune-admin/setup.go
+++ b/cmd/dune-admin/setup.go
@@ -403,6 +403,44 @@ func runLocalSetup(ask func(string, string) string, ok, fail func(string), cfg *
 
 // ── amp setup flow ────────────────────────────────────────────────────────────
 
+type ampSetupDefaults struct {
+	instance string
+	user     string
+	topology string
+	selected *ampInstance
+}
+
+func detectAmpSetupDefaults(ask func(string, string) string) ampSetupDefaults {
+	d := ampSetupDefaults{instance: "DuneAwakening01", user: "amp", topology: "container"}
+	instances, detectedUser, _ := detectAmpInstances()
+	if len(instances) == 0 {
+		return d
+	}
+	fmt.Printf("Detected %d AMP instance(s):\n", len(instances))
+	for i, inst := range instances {
+		fmt.Printf("  %d) %s\n", i+1, summarizeInstance(inst))
+	}
+	choice := 1
+	if len(instances) > 1 {
+		pickStr := ask("Pick instance [1]", "1")
+		if n, err := strconv.Atoi(strings.TrimSpace(pickStr)); err == nil && n >= 1 && n <= len(instances) {
+			choice = n
+		}
+	}
+	d.selected = &instances[choice-1]
+	d.instance = d.selected.Name
+	if d.selected.InContainer {
+		d.topology = "container"
+	} else {
+		d.topology = "native"
+	}
+	if detectedUser != "" {
+		d.user = detectedUser
+	}
+	fmt.Println()
+	return d
+}
+
 // runAmpSetup configures the AMP control plane (CubeCoders AMP). AMP supports
 // two deployment topologies — game server in a podman container, or running
 // natively on the host as the AMP user. All paths/names are configurable.
@@ -412,38 +450,11 @@ func runLocalSetup(ask func(string, string) string, ok, fail func(string), cfg *
 // hardcoded defaults (DuneAwakening01, /AMP/duneawakening/...) when
 // detection isn't possible — every prompt is still overridable.
 func runAmpSetup(ask func(string, string) string, ok, fail func(string), cfg *appConfig) {
-	// ── Auto-detect AMP instances ─────────────────────────────────────────────
-	instances, detectedUser, _ := detectAmpInstances()
-
-	defaultInstance := "DuneAwakening01"
-	defaultUser := "amp"
-	defaultTopology := "container"
-	var selected *ampInstance
-
-	if len(instances) > 0 {
-		fmt.Printf("Detected %d AMP instance(s):\n", len(instances))
-		for i, inst := range instances {
-			fmt.Printf("  %d) %s\n", i+1, summarizeInstance(inst))
-		}
-		choice := 1
-		if len(instances) > 1 {
-			pickStr := ask("Pick instance [1]", "1")
-			if n, err := strconv.Atoi(strings.TrimSpace(pickStr)); err == nil && n >= 1 && n <= len(instances) {
-				choice = n
-			}
-		}
-		selected = &instances[choice-1]
-		defaultInstance = selected.Name
-		if selected.InContainer {
-			defaultTopology = "container"
-		} else {
-			defaultTopology = "native"
-		}
-		if detectedUser != "" {
-			defaultUser = detectedUser
-		}
-		fmt.Println()
-	}
+	d := detectAmpSetupDefaults(ask)
+	defaultInstance := d.instance
+	defaultUser := d.user
+	defaultTopology := d.topology
+	selected := d.selected
 
 	fmt.Println("AMP instance:")
 	cfg.AmpInstance = ask("Instance name (ampinstmgr instance)", defaultInstance)


### PR DESCRIPTION
## Summary

- All 8 functions exceeding the `gocognit` score-15 threshold are resolved by extracting focused helper functions — no `.gocognit-ignore` suppressions needed
- `make verify` now passes cleanly end-to-end

## Functions refactored

| Function | Before | After | Helper(s) extracted |
|---|---|---|---|
| `renderK8SManifest` | 38 | ~10 | `addIfNonEmpty`, `addAmpManifestFields` |
| `runAmpSetup` | 24 | ~9 | `detectAmpSetupDefaults` + `ampSetupDefaults` struct |
| `ReadDefaultINI` | 21 | ~12 | `tryReadINIFromPod` |
| `parseINIRaw` | 21 | ~2 | `applyINILine`, `storeINIEntry` |
| `renderDuneAdminBlock` | 20 | ~3 | `renderManagedSection`, `sortedManagedKeys` |
| `discoverUnknownSettings` | 18 | ~6 | `discoverSectionKeys` |
| `processGiveItems` | 17 | ~4 | `processOneGiveItem` |
| `planGiveItemStacks` | 16 | ~8 | `fillExistingStacks` |

## Root cause

These functions were never below the threshold after the Phase 1 layout refactor (`b2f89db`). They were not caught at the time because CI does not run the `gocognit` target — only `make verify` does locally. The individual `[REFACTOR]` commits resolved the Phase 0 tracked functions but these Phase 1 additions were missed.

## Test plan

- [x] `make verify` passes (go vet, golangci-lint, govulncheck, markdownlint, gocognit)
- [x] `go test -race ./...` passes
- [x] Pre-push hook passes all 7 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)