### PR TITLE
fix(make): apply LDFLAGS + trimpath to the linux target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ install: go
 	install -m 0755 $(BIN) $(DESTDIR)$(PREFIX)/bin/dune-admin
 
 linux:
-	GOOS=linux GOARCH=amd64 go build -o dune-admin-linux $(CMD)
+	GOOS=linux GOARCH=amd64 $(GO) build -trimpath $(LDFLAGS) -o dune-admin-linux $(CMD)
 
 dev-server:
 	go run $(CMD)


### PR DESCRIPTION
## Summary

One-line Makefile fix. The `linux` cross-compile target was missing the `LDFLAGS` (and `-trimpath`) that every other build target uses, so binaries built with `make linux` don't get `AppVersion` / `GitCommit` / `BuildTime` populated.

## Symptom

After redeploying a test VM to `v0.13.0` (commit `b87243c`) via `scripts/install.sh`:

```bash
$ curl -s http://vm:9090/api/v1/status | jq '{version, commit, build_time}'
{
  "version": "dev",
  "commit": "unknown",
  "build_time": "unknown"
}
```

The binary runs fine — but the status endpoint can't tell operators which build is actually live, which makes "did the upgrade land?" / "is this the binary I think it is?" harder than it should be on hosts that run multiple deploys.

## Fix

```diff
 linux:
-	GOOS=linux GOARCH=amd64 go build -o dune-admin-linux $(CMD)
+	GOOS=linux GOARCH=amd64 $(GO) build -trimpath $(LDFLAGS) -o dune-admin-linux $(CMD)
```

Matches the existing convention in the `go` target:

```makefile
go:
	@mkdir -p bin
	$(GO) build -trimpath $(LDFLAGS) -o $(BIN) $(CMD)
	install -m 0755 $(BIN) ./dune-admin
```

Same `$(LDFLAGS)` already defined at the top of the Makefile:

```makefile
LDFLAGS := -ldflags "-s -w -X main.AppVersion=$(VERSION) -X main.GitCommit=$(GIT_COMMIT) -X main.BuildTime=$(BUILD_TIME)"
```

## Verification

Build invocation now expands to:

```
GOOS=linux GOARCH=amd64 go build -trimpath   -ldflags "-s -w -X main.AppVersion=0.13.0             -X main.GitCommit=b87243c             -X main.BuildTime=2026-05-28T03:32:59Z"   -o dune-admin-linux ./cmd/dune-admin
```

Same flags that `make build` (host OS) already applied — this is just plumbing them through the cross-compile target.

## Notes

`-trimpath` is the right default for shipped binaries (strips absolute paths from stack traces and the binary's symbol table — reproducible-build friendly). Same reason it's already on the `go` target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)