### PR TITLE
feat: add bot listing cleanup — UI button + -clean-market CLI flag

### DIFF
--- a/cmd/dune-admin/handlers_market_bot.go
+++ b/cmd/dune-admin/handlers_market_bot.go
@@ -117,6 +117,27 @@ func handleMarketBotExec(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"output": output})
 }
 
+// ── cleanup ───────────────────────────────────────────────────────────────────
+
+// handleMarketBotCleanup deletes every active bot-owned listing. The tick loop
+// is paused for the duration and resumed if it was running. Player listings
+// and fulfilled-order history are untouched.
+func handleMarketBotCleanup(w http.ResponseWriter, r *http.Request) {
+	if embeddedBot == nil {
+		jsonErr(w, fmt.Errorf("embedded market bot is disabled"), http.StatusServiceUnavailable)
+		return
+	}
+	orders, items, err := embeddedBot.CleanupListings(r.Context())
+	if err != nil {
+		jsonErr(w, err, 500)
+		return
+	}
+	jsonOK(w, map[string]int64{
+		"orders_deleted": orders,
+		"items_deleted":  items,
+	})
+}
+
 // ── log streaming ─────────────────────────────────────────────────────────────
 
 func handleMarketBotLogsReady(w http.ResponseWriter, r *http.Request) {

--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -32,6 +32,7 @@ var BuildTime = "unknown"
 
 var (
 	setupMode       bool
+	cleanMarketMode bool
 	sqlQuery        string
 	renderK8SOut    string
 	sshHost         string
@@ -285,6 +286,7 @@ func init() {
 	flag.StringVar(&backupDir, "backup-dir", envOr("BACKUP_DIR", ""), "Backup directory path")
 	flag.StringVar(&serverIniDir, "ini-dir", envOr("SERVER_INI_DIR", ""), "Directory containing UserGame.ini / UserOverrides.ini")
 	flag.BoolVar(&setupMode, "setup", false, "Interactive setup wizard — writes ~/.dune-admin/config.yaml")
+	flag.BoolVar(&cleanMarketMode, "clean-market", false, "Delete all bot listings (Revy), then exit")
 	flag.StringVar(&sqlQuery, "sql", "", "Run a SQL query and print results to stdout, then exit")
 	flag.StringVar(&renderK8SOut, "render-k8s", "", "Render k8s manifest with values from loaded config (path or '-' for stdout)")
 }
@@ -425,6 +427,48 @@ func runSQLMode(query string) error {
 	return nil
 }
 
+// runCleanMarketMode wipes every active Revy listing then exits. Useful as a
+// one-shot operation from cron, AMP, or an admin laptop without having to
+// spin up the full HTTP server.
+func runCleanMarketMode() error {
+	if err := loadItemData(); err != nil {
+		return fmt.Errorf("load item data: %w", err)
+	}
+	if msg, ok := cmdConnect().(msgConnect); ok && msg.err != nil {
+		return fmt.Errorf("connect: %w", msg.err)
+	}
+	defer closeGlobalConnections()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cacheDB, itemDataForBot := resolveEmbeddedMarketBotPaths(loadedConfig, itemDataPath)
+	inst, err := marketbot.Run(ctx, marketbot.BotConfig{
+		DBPool:       globalDB,
+		DBHost:       dbHost,
+		DBPort:       dbPort,
+		DBUser:       dbUser,
+		DBPass:       dbPass,
+		DBName:       dbName,
+		DBSchema:     dbSchema,
+		CacheDB:      cacheDB,
+		ItemDataPath: itemDataForBot,
+	})
+	if err != nil {
+		return fmt.Errorf("init market bot: %w", err)
+	}
+	// Pause immediately so the tick loop spawned by Run does not race the
+	// cleanup we are about to perform.
+	inst.Pause()
+
+	orders, items, err := inst.CleanupListings(ctx)
+	if err != nil {
+		return fmt.Errorf("cleanup: %w", err)
+	}
+	fmt.Printf("market cleanup: deleted %d orders, %d items\n", orders, items)
+	return nil
+}
+
 func runImmediateModes() (handled bool, err error) {
 	// Explicit -setup flag: reconfigure and exit (don't start server).
 	if setupMode {
@@ -433,6 +477,9 @@ func runImmediateModes() (handled bool, err error) {
 	}
 	if sqlQuery != "" {
 		return true, runSQLMode(sqlQuery)
+	}
+	if cleanMarketMode {
+		return true, runCleanMarketMode()
 	}
 	if renderK8SOut != "" {
 		return true, renderK8SManifest(renderK8SOut)
@@ -546,6 +593,9 @@ func main() {
 			label := ""
 			if renderK8SOut != "" {
 				label = "render-k8s: "
+			}
+			if cleanMarketMode {
+				label = "clean-market: "
 			}
 			fmt.Fprintln(os.Stderr, label+err.Error())
 			os.Exit(1)

--- a/cmd/dune-admin/server.go
+++ b/cmd/dune-admin/server.go
@@ -219,6 +219,7 @@ func startServer(addr string) {
 	mux.HandleFunc("GET /api/v1/market-bot/config", handleMarketBotConfig)
 	mux.HandleFunc("PUT /api/v1/market-bot/config", handleMarketBotConfig)
 	mux.HandleFunc("POST /api/v1/market-bot/exec", handleMarketBotExec)
+	mux.HandleFunc("POST /api/v1/market-bot/cleanup", handleMarketBotCleanup)
 	mux.HandleFunc("GET /api/v1/market-bot/logs-ready", handleMarketBotLogsReady)
 	mux.HandleFunc("GET /api/v1/market-bot/logs", handleMarketBotLogs)
 

--- a/internal/marketbot/bot.go
+++ b/internal/marketbot/bot.go
@@ -81,6 +81,21 @@ func (i *Instance) Enabled() bool {
 	return i.cfg.Snapshot().Enabled
 }
 
+// CleanupListings deletes every active bot-owned listing. The tick loop is
+// paused for the duration and resumed only if it was running before. The next
+// list tick will rebuild listings from the catalog.
+func (i *Instance) CleanupListings(ctx context.Context) (orders int64, items int64, err error) {
+	wasEnabled := i.Enabled()
+	if wasEnabled {
+		i.Pause()
+	}
+	orders, items, err = i.ex.CleanupListings(ctx)
+	if wasEnabled {
+		i.Resume()
+	}
+	return orders, items, err
+}
+
 // Run starts the market bot. It blocks until ctx is cancelled.
 // The returned *Instance is valid as soon as Run returns a non-nil value
 // in the first return position; callers should check err for startup errors.

--- a/internal/marketbot/exchange.go
+++ b/internal/marketbot/exchange.go
@@ -779,6 +779,56 @@ func (e *Exchange) ListTick(ctx context.Context, catalog []CatalogItem) {
 	e.listingCount.Store(count)
 }
 
+// CleanupListings deletes every active bot-owned listing (and the backing
+// item rows) for Revy. Player listings, fulfilled order history, and the bot's
+// Solari balance are left untouched. Returns the number of orders and items
+// removed.
+func (e *Exchange) CleanupListings(ctx context.Context) (orders int64, items int64, err error) {
+	if e.ownerID == 0 {
+		return 0, 0, fmt.Errorf("bot owner id not initialised")
+	}
+	tx, err := e.db.Begin(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	itemRes, err := tx.Exec(ctx, `
+		DELETE FROM dune.items
+		WHERE id IN (
+			SELECT item_id FROM dune.dune_exchange_orders
+			WHERE owner_id = $1 AND is_npc_order = TRUE AND item_id IS NOT NULL
+		)`, e.ownerID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("delete items: %w", err)
+	}
+	items = itemRes.RowsAffected()
+
+	// dune_exchange_sell_orders rows cascade via FK; if not, delete them too.
+	if _, err = tx.Exec(ctx, `
+		DELETE FROM dune.dune_exchange_sell_orders
+		WHERE order_id IN (
+			SELECT id FROM dune.dune_exchange_orders
+			WHERE owner_id = $1 AND is_npc_order = TRUE
+		)`, e.ownerID); err != nil {
+		return 0, 0, fmt.Errorf("delete sell orders: %w", err)
+	}
+
+	orderRes, err := tx.Exec(ctx, `
+		DELETE FROM dune.dune_exchange_orders
+		WHERE owner_id = $1 AND is_npc_order = TRUE`, e.ownerID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("delete orders: %w", err)
+	}
+	orders = orderRes.RowsAffected()
+
+	if err = tx.Commit(ctx); err != nil {
+		return 0, 0, fmt.Errorf("commit: %w", err)
+	}
+	e.listingCount.Store(0)
+	return orders, items, nil
+}
+
 // Tick runs both BuyTick and ListTick. Used for the initial run on startup.
 func (e *Exchange) Tick(ctx context.Context, catalog []CatalogItem) {
 	e.BuyTick(ctx)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -549,6 +549,7 @@ export const api = {
     config: async () => normalizeBotConfig(await req<unknown>('GET', '/market-bot/config')),
     saveConfig: async (cfg: BotConfig) => normalizeBotConfig(await req<unknown>('PUT', '/market-bot/config', cfg)),
     lifecycle: (cmd: 'start' | 'stop' | 'restart') => req<{ output: string }>('POST', '/market-bot/exec', { cmd }),
+    cleanup: () => req<{ orders_deleted: number; items_deleted: number }>('POST', '/market-bot/cleanup'),
     logsReady: () => req<{ ready: boolean; reason?: string; namespace?: string; name?: string }>('GET', '/market-bot/logs-ready'),
   },
 }

--- a/web/src/tabs/MarketTab/bot/BotActions.tsx
+++ b/web/src/tabs/MarketTab/bot/BotActions.tsx
@@ -2,15 +2,18 @@ import { useState } from 'react'
 import { Button, Spinner, toast } from '@heroui/react'
 import { api } from '../../../api/client'
 import type { BotStatus } from '../../../api/client'
-import { Icon } from '../../../dune-ui'
+import { Icon, ConfirmDialog } from '../../../dune-ui'
 
 type Props = {
   status: BotStatus | null
   onRefresh: () => void
 }
 
+type BusyOp = 'start' | 'stop' | 'restart' | 'cleanup'
+
 export default function BotActions({ status, onRefresh }: Props) {
-  const [busy, setBusy] = useState<'start' | 'stop' | 'restart' | null>(null)
+  const [busy, setBusy] = useState<BusyOp | null>(null)
+  const [confirmOpen, setConfirmOpen] = useState(false)
 
   const run = async (cmd: 'start' | 'stop' | 'restart') => {
     setBusy(cmd)
@@ -27,37 +30,71 @@ export default function BotActions({ status, onRefresh }: Props) {
     }
   }
 
+  const runCleanup = async () => {
+    setConfirmOpen(false)
+    setBusy('cleanup')
+    try {
+      const res = await api.marketBot.cleanup()
+      toast.success(`Wiped ${res.orders_deleted} listings (${res.items_deleted} items)`)
+      setTimeout(onRefresh, 1500)
+    } catch (e: unknown) {
+      toast.danger(`Cleanup failed: ${e instanceof Error ? e.message : String(e)}`)
+    } finally {
+      setBusy(null)
+    }
+  }
+
   const running = status?.running ?? false
 
   return (
-    <div className="flex items-center gap-2">
-      <Button
-        size="sm"
-        variant="outline"
-        isDisabled={running || busy !== null}
-        onPress={() => run('start')}
-      >
-        {busy === 'start' ? <Spinner size="sm" color="current" /> : <Icon name="play" />}
-        Resume
-      </Button>
-      <Button
-        size="sm"
-        variant="danger-soft"
-        isDisabled={!running || busy !== null}
-        onPress={() => run('stop')}
-      >
-        {busy === 'stop' ? <Spinner size="sm" color="current" /> : <Icon name="square" />}
-        Pause
-      </Button>
-      <Button
-        size="sm"
-        variant="ghost"
-        isDisabled={busy !== null}
-        onPress={() => run('restart')}
-      >
-        {busy === 'restart' ? <Spinner size="sm" color="current" /> : <Icon name="refresh-cw" />}
-        Reinitialize
-      </Button>
-    </div>
+    <>
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          isDisabled={running || busy !== null}
+          onPress={() => run('start')}
+        >
+          {busy === 'start' ? <Spinner size="sm" color="current" /> : <Icon name="play" />}
+          Resume
+        </Button>
+        <Button
+          size="sm"
+          variant="danger-soft"
+          isDisabled={!running || busy !== null}
+          onPress={() => run('stop')}
+        >
+          {busy === 'stop' ? <Spinner size="sm" color="current" /> : <Icon name="square" />}
+          Pause
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          isDisabled={busy !== null}
+          onPress={() => run('restart')}
+        >
+          {busy === 'restart' ? <Spinner size="sm" color="current" /> : <Icon name="refresh-cw" />}
+          Reinitialize
+        </Button>
+        <Button
+          size="sm"
+          variant="danger-soft"
+          isDisabled={busy !== null}
+          onPress={() => setConfirmOpen(true)}
+        >
+          {busy === 'cleanup' ? <Spinner size="sm" color="current" /> : <Icon name="trash-2" />}
+          Wipe Listings
+        </Button>
+      </div>
+
+      <ConfirmDialog
+        open={confirmOpen}
+        title="Wipe all bot listings?"
+        description="This deletes every active Revy listing on the exchange. Player listings, fulfilled-order history, and Revy's Solari balance are untouched. The next list tick will repopulate listings from the catalog."
+        confirmLabel="Wipe Listings"
+        onConfirm={runCleanup}
+        onCancel={() => setConfirmOpen(false)}
+      />
+    </>
   )
 }


### PR DESCRIPTION
## Summary

Adds a way to wipe all active Revy (bot) listings from the exchange — both from the UI and as a one-shot CLI operation.

## Changes

### Backend
- **`Exchange.CleanupListings(ctx)`** — transactional DELETE scoped to `owner_id = Revy AND is_npc_order = TRUE`: removes `items`, `dune_exchange_sell_orders`, then `dune_exchange_orders`. Resets the in-memory listing count.
- **`Instance.CleanupListings(ctx)`** — pauses the tick loop, calls `Exchange.CleanupListings`, resumes if it was running. Next list tick repopulates from catalog.
- **`POST /api/v1/market-bot/cleanup`** — new HTTP handler; returns `{orders_deleted, items_deleted}`. 503 if bot is disabled.
- **`-clean-market` CLI flag** — connects to DB, initialises the bot (resolves Revy's actor ID), wipes listings, prints result, exits. Useful from cron/AMP without starting the server.

### Frontend
- **`api.marketBot.cleanup()`** — typed API client method.
- **"Wipe Listings" button** in Market → Bot Control → actions bar. Opens a `ConfirmDialog` describing the operation, toasts the deleted count, and triggers a status refresh.

## Scope
Player listings, fulfilled-order history, and Revy's Solari balance are untouched.