### PR TITLE
update market stuff

### DIFF
--- a/cmd/dune-admin/handlers_market_bot.go
+++ b/cmd/dune-admin/handlers_market_bot.go
@@ -1,47 +1,153 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
 )
 
+// ── remote bot proxy ─────────────────────────────────────────────────────────
+
+// remoteBotClient proxies /api/v1/market-bot/* calls to a standalone market
+// bot's HTTP API (internal/marketbot.APIServer). Used when market_bot_enabled
+// is false but market_bot_remote_url is set.
+type remoteBotClient struct {
+	baseURL string // trailing slash stripped
+	token   string
+	client  *http.Client
+}
+
+func newRemoteBotClient(rawURL, token string) *remoteBotClient {
+	return &remoteBotClient{
+		baseURL: strings.TrimRight(rawURL, "/"),
+		token:   token,
+		client: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+	}
+}
+
+// do executes a request against the remote bot, copies the response status and
+// body back to w, and returns true on success.
+func (r *remoteBotClient) do(w http.ResponseWriter, method, path string, body io.Reader) bool {
+	u := r.baseURL + path
+	req, err := http.NewRequest(method, u, body)
+	if err != nil {
+		jsonErr(w, fmt.Errorf("remote bot: build request: %w", err), http.StatusInternalServerError)
+		return false
+	}
+	if r.token != "" {
+		req.Header.Set("Authorization", "Bearer "+r.token)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		jsonErr(w, fmt.Errorf("remote bot unreachable: %w", err), http.StatusBadGateway)
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+	return resp.StatusCode < 300
+}
+
+// wsURL converts the base HTTP URL to a WebSocket URL.
+func (r *remoteBotClient) wsURL(path string) string {
+	return strings.NewReplacer("https://", "wss://", "http://", "ws://").
+		Replace(r.baseURL) + path
+}
+
 // ── status ────────────────────────────────────────────────────────────────────
 
 func handleMarketBotStatus(w http.ResponseWriter, r *http.Request) {
-	if embeddedBot == nil {
-		jsonOK(w, map[string]any{
-			"running": false,
-			"enabled": false,
-			"mode":    "embedded",
-			"error":   "embedded market bot is disabled; set market_bot_enabled: true and restart dune-admin",
-		})
+	if embeddedBot != nil {
+		snap := embeddedBot.StatusSnapshot()
+		m, _ := json.Marshal(snap)
+		var out map[string]any
+		_ = json.Unmarshal(m, &out)
+		if out == nil {
+			out = map[string]any{}
+		}
+		running := embeddedBot.Enabled()
+		out["running"] = running
+		out["enabled"] = running
+		out["mode"] = "embedded"
+		jsonOK(w, out)
 		return
 	}
-	snap := embeddedBot.StatusSnapshot()
-	m, _ := json.Marshal(snap)
-	var out map[string]any
-	_ = json.Unmarshal(m, &out)
-	if out == nil {
-		out = map[string]any{}
+	if remoteBotProxy != nil {
+		// Fetch status from remote and augment with mode field.
+		u := remoteBotProxy.baseURL + "/status"
+		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, u, nil)
+		if err != nil {
+			jsonErr(w, fmt.Errorf("remote bot: %w", err), http.StatusInternalServerError)
+			return
+		}
+		if remoteBotProxy.token != "" {
+			req.Header.Set("Authorization", "Bearer "+remoteBotProxy.token)
+		}
+		resp, err := remoteBotProxy.client.Do(req)
+		if err != nil {
+			jsonErr(w, fmt.Errorf("remote bot unreachable: %w", err), http.StatusBadGateway)
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+		var out map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			jsonErr(w, fmt.Errorf("remote bot: decode: %w", err), http.StatusBadGateway)
+			return
+		}
+		if out == nil {
+			out = map[string]any{}
+		}
+		out["mode"] = "remote"
+		out["running"] = true
+		out["enabled"] = true
+		jsonOK(w, out)
+		return
 	}
-	running := embeddedBot.Enabled()
-	out["running"] = running
-	out["enabled"] = running
-	out["mode"] = "embedded"
-	jsonOK(w, out)
+	jsonOK(w, map[string]any{
+		"running": false,
+		"enabled": false,
+		"mode":    "none",
+		"error":   "market bot not configured; set market_bot_enabled: true or market_bot_remote_url",
+	})
 }
 
 // ── config ────────────────────────────────────────────────────────────────────
 
 func handleMarketBotConfig(w http.ResponseWriter, r *http.Request) {
-	if embeddedBot == nil {
-		jsonErr(w, fmt.Errorf("embedded market bot is disabled"), http.StatusServiceUnavailable)
+	if embeddedBot != nil {
+		handleEmbeddedBotConfig(w, r)
 		return
 	}
+	if remoteBotProxy != nil {
+		switch r.Method {
+		case http.MethodGet:
+			remoteBotProxy.do(w, http.MethodGet, "/config", nil)
+		case http.MethodPut:
+			remoteBotProxy.do(w, http.MethodPut, "/config", r.Body)
+		default:
+			jsonErr(w, fmt.Errorf("method not allowed"), http.StatusMethodNotAllowed)
+		}
+		return
+	}
+	jsonErr(w, fmt.Errorf("market bot not configured"), http.StatusServiceUnavailable)
+}
+
+func handleEmbeddedBotConfig(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		data, err := embeddedBot.ConfigJSON()
@@ -51,7 +157,6 @@ func handleMarketBotConfig(w http.ResponseWriter, r *http.Request) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(data) //nolint:errcheck
-		return
 	case http.MethodPut:
 		var patch map[string]json.RawMessage
 		if err := decode(r, &patch); err != nil {
@@ -69,10 +174,8 @@ func handleMarketBotConfig(w http.ResponseWriter, r *http.Request) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(data) //nolint:errcheck
-		return
 	default:
 		jsonErr(w, fmt.Errorf("method not allowed"), http.StatusMethodNotAllowed)
-		return
 	}
 }
 
@@ -95,64 +198,82 @@ func handleMarketBotExec(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if embeddedBot == nil {
-		jsonErr(w, fmt.Errorf("embedded market bot is disabled"), http.StatusServiceUnavailable)
+	if embeddedBot != nil {
+		output := "ok"
+		switch req.Cmd {
+		case "start":
+			embeddedBot.Resume()
+			output = "resumed"
+		case "stop":
+			embeddedBot.Pause()
+			output = "paused"
+		case "restart":
+			if err := embeddedBot.Restart(r.Context()); err != nil {
+				jsonErr(w, err, 500)
+				return
+			}
+			output = "restarted"
+		}
+		jsonOK(w, map[string]string{"output": output})
 		return
 	}
-	output := "ok"
-	switch req.Cmd {
-	case "start":
-		embeddedBot.Resume()
-		output = "resumed"
-	case "stop":
-		embeddedBot.Pause()
-		output = "paused"
-	case "restart":
-		if err := embeddedBot.Restart(r.Context()); err != nil {
-			jsonErr(w, err, 500)
-			return
-		}
-		output = "restarted"
+	if remoteBotProxy != nil {
+		body, _ := json.Marshal(map[string]string{"cmd": req.Cmd})
+		remoteBotProxy.do(w, http.MethodPost, "/exec", strings.NewReader(string(body)))
+		return
 	}
-	jsonOK(w, map[string]string{"output": output})
+	jsonErr(w, fmt.Errorf("market bot not configured"), http.StatusServiceUnavailable)
 }
 
 // ── cleanup ───────────────────────────────────────────────────────────────────
 
-// handleMarketBotCleanup deletes every active bot-owned listing. The tick loop
-// is paused for the duration and resumed if it was running. Player listings
-// and fulfilled-order history are untouched.
 func handleMarketBotCleanup(w http.ResponseWriter, r *http.Request) {
-	if embeddedBot == nil {
-		jsonErr(w, fmt.Errorf("embedded market bot is disabled"), http.StatusServiceUnavailable)
+	if embeddedBot != nil {
+		orders, items, err := embeddedBot.CleanupListings(r.Context())
+		if err != nil {
+			jsonErr(w, err, 500)
+			return
+		}
+		jsonOK(w, map[string]int64{
+			"orders_deleted": orders,
+			"items_deleted":  items,
+		})
 		return
 	}
-	orders, items, err := embeddedBot.CleanupListings(r.Context())
-	if err != nil {
-		jsonErr(w, err, 500)
+	if remoteBotProxy != nil {
+		remoteBotProxy.do(w, http.MethodPost, "/cleanup", nil)
 		return
 	}
-	jsonOK(w, map[string]int64{
-		"orders_deleted": orders,
-		"items_deleted":  items,
-	})
+	jsonErr(w, fmt.Errorf("market bot not configured"), http.StatusServiceUnavailable)
 }
 
 // ── log streaming ─────────────────────────────────────────────────────────────
 
-func handleMarketBotLogsReady(w http.ResponseWriter, r *http.Request) {
-	if embeddedBot == nil {
-		jsonOK(w, map[string]any{"ready": false, "mode": "embedded", "reason": "embedded market bot is disabled"})
+func handleMarketBotLogsReady(w http.ResponseWriter, _ *http.Request) {
+	if embeddedBot != nil {
+		jsonOK(w, map[string]any{"ready": true, "mode": "embedded"})
 		return
 	}
-	jsonOK(w, map[string]any{"ready": true, "mode": "embedded"})
+	if remoteBotProxy != nil {
+		jsonOK(w, map[string]any{"ready": true, "mode": "remote"})
+		return
+	}
+	jsonOK(w, map[string]any{"ready": false, "mode": "none", "reason": "market bot not configured"})
 }
 
 func handleMarketBotLogs(w http.ResponseWriter, r *http.Request) {
-	if embeddedBot == nil {
-		http.Error(w, "embedded market bot is disabled", http.StatusServiceUnavailable)
+	if embeddedBot != nil {
+		streamEmbeddedBotLogs(w, r)
 		return
 	}
+	if remoteBotProxy != nil {
+		proxyBotLogsWS(w, r, remoteBotProxy)
+		return
+	}
+	http.Error(w, "market bot not configured", http.StatusServiceUnavailable)
+}
+
+func streamEmbeddedBotLogs(w http.ResponseWriter, r *http.Request) {
 	conn, err := wsUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return
@@ -174,5 +295,54 @@ func handleMarketBotLogs(w http.ResponseWriter, r *http.Request) {
 		case <-r.Context().Done():
 			return
 		}
+	}
+}
+
+// proxyBotLogsWS bridges the client WebSocket connection to the remote bot's
+// /logs WebSocket endpoint, relaying text frames in both directions.
+func proxyBotLogsWS(w http.ResponseWriter, r *http.Request, proxy *remoteBotClient) {
+	clientConn, err := wsUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer func() { _ = clientConn.Close() }()
+
+	hdr := http.Header{}
+	if proxy.token != "" {
+		hdr.Set("Authorization", "Bearer "+proxy.token)
+	}
+	remoteConn, _, err := websocket.DefaultDialer.DialContext(r.Context(), proxy.wsURL("/logs"), hdr)
+	if err != nil {
+		log.Printf("remote bot ws dial: %v", err)
+		_ = clientConn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, "remote unavailable"))
+		return
+	}
+	defer func() { _ = remoteConn.Close() }()
+
+	bridgeWSConns(r.Context(), clientConn, remoteConn)
+}
+
+// bridgeWSConns relays frames between two WebSocket connections until either
+// closes or the context is cancelled.
+func bridgeWSConns(ctx context.Context, a, b *websocket.Conn) {
+	done := make(chan struct{}, 2)
+	relay := func(src, dst *websocket.Conn) {
+		defer func() { done <- struct{}{} }()
+		for {
+			mt, msg, err := src.ReadMessage()
+			if err != nil {
+				return
+			}
+			if err := dst.WriteMessage(mt, msg); err != nil {
+				return
+			}
+		}
+	}
+	go relay(b, a) // remote → client
+	go relay(a, b) // client → remote
+	select {
+	case <-done:
+	case <-ctx.Done():
 	}
 }

--- a/cmd/dune-admin/handlers_market_bot_test.go
+++ b/cmd/dune-admin/handlers_market_bot_test.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newRemoteFakeServer creates a fake remote bot HTTP server and returns a
+// remoteBotClient pointed at it, plus a cleanup function.
+func newRemoteFakeServer(t *testing.T, mux *http.ServeMux) (*remoteBotClient, func()) {
+	t.Helper()
+	ts := httptest.NewServer(mux)
+	client := newRemoteBotClient(ts.URL, "fake-token")
+	// Override the HTTP client to use the test server's client so redirects work.
+	client.client = ts.Client()
+	return client, ts.Close
+}
+
+func TestHandleMarketBotStatus_NeitherConfigured(t *testing.T) {
+	origBot := embeddedBot
+	origProxy := remoteBotProxy
+	embeddedBot = nil
+	remoteBotProxy = nil
+	defer func() { embeddedBot = origBot; remoteBotProxy = origProxy }()
+
+	req := httptest.NewRequest("GET", "/api/v1/market-bot/status", nil)
+	w := httptest.NewRecorder()
+	handleMarketBotStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200 got %d", w.Code)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["running"] != false {
+		t.Errorf("running should be false, got %v", body["running"])
+	}
+	if body["mode"] != "none" {
+		t.Errorf("mode should be 'none', got %v", body["mode"])
+	}
+}
+
+func TestHandleMarketBotStatus_RemoteProxy(t *testing.T) {
+	origBot := embeddedBot
+	origProxy := remoteBotProxy
+	embeddedBot = nil
+	defer func() { embeddedBot = origBot; remoteBotProxy = origProxy }()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer fake-token" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"uptime":"1m","listing_count":42}`)
+	})
+
+	proxy, cleanup := newRemoteFakeServer(t, mux)
+	defer cleanup()
+	remoteBotProxy = proxy
+
+	req := httptest.NewRequest("GET", "/api/v1/market-bot/status", nil)
+	w := httptest.NewRecorder()
+	handleMarketBotStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200 got %d: %s", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["mode"] != "remote" {
+		t.Errorf("mode should be 'remote', got %v", body["mode"])
+	}
+	if body["running"] != true {
+		t.Errorf("running should be true for reachable remote, got %v", body["running"])
+	}
+	if body["listing_count"].(float64) != 42 {
+		t.Errorf("listing_count should be 42, got %v", body["listing_count"])
+	}
+}
+
+func TestHandleMarketBotConfig_RemoteGet(t *testing.T) {
+	origBot := embeddedBot
+	origProxy := remoteBotProxy
+	embeddedBot = nil
+	defer func() { embeddedBot = origBot; remoteBotProxy = origProxy }()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /config", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"max_buys":99,"enabled":true}`)
+	})
+
+	proxy, cleanup := newRemoteFakeServer(t, mux)
+	defer cleanup()
+	remoteBotProxy = proxy
+
+	req := httptest.NewRequest("GET", "/api/v1/market-bot/config", nil)
+	w := httptest.NewRecorder()
+	handleMarketBotConfig(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200 got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"max_buys":99`) {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestHandleMarketBotConfig_RemotePut(t *testing.T) {
+	origBot := embeddedBot
+	origProxy := remoteBotProxy
+	embeddedBot = nil
+	defer func() { embeddedBot = origBot; remoteBotProxy = origProxy }()
+
+	var receivedBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /config", func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		receivedBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":"ok"}`)
+	})
+
+	proxy, cleanup := newRemoteFakeServer(t, mux)
+	defer cleanup()
+	remoteBotProxy = proxy
+
+	req := httptest.NewRequest("PUT", "/api/v1/market-bot/config",
+		strings.NewReader(`{"max_buys":7}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handleMarketBotConfig(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200 got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(receivedBody, `"max_buys":7`) {
+		t.Errorf("remote did not receive correct body: %s", receivedBody)
+	}
+}
+
+func TestHandleMarketBotConfig_NeitherConfigured(t *testing.T) {
+	origBot := embeddedBot
+	origProxy := remoteBotProxy
+	embeddedBot = nil
+	remoteBotProxy = nil
+	defer func() { embeddedBot = origBot; remoteBotProxy = origProxy }()
+
+	req := httptest.NewRequest("GET", "/api/v1/market-bot/config", nil)
+	w := httptest.NewRecorder()
+	handleMarketBotConfig(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("want 503 got %d", w.Code)
+	}
+}
+
+func TestHandleMarketBotExec_Remote(t *testing.T) {
+	origBot := embeddedBot
+	origProxy := remoteBotProxy
+	embeddedBot = nil
+	defer func() { embeddedBot = origBot; remoteBotProxy = origProxy }()
+
+	var receivedCmd string
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /exec", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		receivedCmd = body["cmd"]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"output":"resumed"}`)
+	})
+
+	proxy, cleanup := newRemoteFakeServer(t, mux)
+	defer cleanup()
+	remoteBotProxy = proxy
+
+	req := httptest.NewRequest("POST", "/api/v1/market-bot/exec",
+		strings.NewReader(`{"cmd":"start"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handleMarketBotExec(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200 got %d: %s", w.Code, w.Body.String())
+	}
+	if receivedCmd != "start" {
+		t.Errorf("remote received cmd=%q want 'start'", receivedCmd)
+	}
+}
+
+func TestHandleMarketBotExec_UnknownCmd(t *testing.T) {
+	origBot := embeddedBot
+	origProxy := remoteBotProxy
+	embeddedBot = nil
+	remoteBotProxy = nil
+	defer func() { embeddedBot = origBot; remoteBotProxy = origProxy }()
+
+	req := httptest.NewRequest("POST", "/api/v1/market-bot/exec",
+		strings.NewReader(`{"cmd":"nuke"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handleMarketBotExec(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("unknown cmd: want 400 got %d", w.Code)
+	}
+}
+
+func TestHandleMarketBotCleanup_Remote(t *testing.T) {
+	origBot := embeddedBot
+	origProxy := remoteBotProxy
+	embeddedBot = nil
+	defer func() { embeddedBot = origBot; remoteBotProxy = origProxy }()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /cleanup", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"orders_deleted":5,"items_deleted":10}`)
+	})
+
+	proxy, cleanup := newRemoteFakeServer(t, mux)
+	defer cleanup()
+	remoteBotProxy = proxy
+
+	req := httptest.NewRequest("POST", "/api/v1/market-bot/cleanup", nil)
+	w := httptest.NewRecorder()
+	handleMarketBotCleanup(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200 got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"orders_deleted":5`) {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestHandleMarketBotLogsReady_Remote(t *testing.T) {
+	origBot := embeddedBot
+	origProxy := remoteBotProxy
+	embeddedBot = nil
+	defer func() { embeddedBot = origBot; remoteBotProxy = origProxy }()
+
+	remoteBotProxy = newRemoteBotClient("http://irrelevant", "tok")
+
+	req := httptest.NewRequest("GET", "/api/v1/market-bot/logs-ready", nil)
+	w := httptest.NewRecorder()
+	handleMarketBotLogsReady(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200 got %d", w.Code)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["ready"] != true {
+		t.Errorf("ready should be true, got %v", body["ready"])
+	}
+	if body["mode"] != "remote" {
+		t.Errorf("mode should be 'remote', got %v", body["mode"])
+	}
+}
+
+func TestHandleMarketBotLogsReady_NeitherConfigured(t *testing.T) {
+	origBot := embeddedBot
+	origProxy := remoteBotProxy
+	embeddedBot = nil
+	remoteBotProxy = nil
+	defer func() { embeddedBot = origBot; remoteBotProxy = origProxy }()
+
+	req := httptest.NewRequest("GET", "/api/v1/market-bot/logs-ready", nil)
+	w := httptest.NewRecorder()
+	handleMarketBotLogsReady(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200 got %d", w.Code)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["ready"] != false {
+		t.Errorf("ready should be false when nothing configured, got %v", body["ready"])
+	}
+}
+
+func TestHandleMarketBotStatus_RemoteUnreachable(t *testing.T) {
+	origBot := embeddedBot
+	origProxy := remoteBotProxy
+	embeddedBot = nil
+	defer func() { embeddedBot = origBot; remoteBotProxy = origProxy }()
+
+	remoteBotProxy = newRemoteBotClient("http://127.0.0.1:19999", "tok")
+
+	req := httptest.NewRequest("GET", "/api/v1/market-bot/status", nil)
+	w := httptest.NewRecorder()
+	handleMarketBotStatus(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("unreachable remote: want 502 got %d", w.Code)
+	}
+}

--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -151,13 +151,30 @@ type appConfig struct {
 
 	// ── Embedded market bot ────────────────────────────────────────────────
 	// MarketBotEnabled starts the market bot as an in-process goroutine.
-	MarketBotEnabled  bool          `yaml:"market_bot_enabled"`
+	// Pointer so we can distinguish "unset" (default-on for backward compat
+	// with upgrades that pre-date this key) from "explicitly false".
+	MarketBotEnabled  *bool         `yaml:"market_bot_enabled"`
 	MarketBotCacheDB  string        `yaml:"market_bot_cache_db"`
 	MarketBotItemData string        `yaml:"market_bot_item_data"`
+	MarketBotState    string        `yaml:"market_bot_state"` // path to persisted runtime state JSON
 	MarketBotBuyInt   time.Duration `yaml:"market_bot_buy_interval"`
 	MarketBotListInt  time.Duration `yaml:"market_bot_list_interval"`
 	MarketBotThresh   float64       `yaml:"market_bot_buy_threshold"`
 	MarketBotMaxBuys  int           `yaml:"market_bot_max_buys"`
+	// Remote market bot proxy: when set, dune-admin forwards /api/v1/market-bot/*
+	// to the given URL instead of running an embedded bot.
+	// Set market_bot_enabled: false alongside this.
+	MarketBotRemoteURL   string `yaml:"market_bot_remote_url"`
+	MarketBotRemoteToken string `yaml:"market_bot_remote_token"`
+}
+
+// marketBotEnabled returns the effective bot-enabled flag. Missing yaml key →
+// default on (so upgrades enable the feature). Explicit false → off.
+func marketBotEnabled(cfg appConfig) bool {
+	if cfg.MarketBotEnabled == nil {
+		return true
+	}
+	return *cfg.MarketBotEnabled
 }
 
 func configDir() string {
@@ -442,7 +459,7 @@ func runCleanMarketMode() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cacheDB, itemDataForBot := resolveEmbeddedMarketBotPaths(loadedConfig, itemDataPath)
+	cacheDB, itemDataForBot, _ := resolveEmbeddedMarketBotPaths(loadedConfig, itemDataPath)
 	inst, err := marketbot.Run(ctx, marketbot.BotConfig{
 		DBPool:       globalDB,
 		DBHost:       dbHost,
@@ -538,7 +555,7 @@ func connectAndPrimeTemplates(alreadyConnected bool) {
 	refreshItemTemplates()
 }
 
-func resolveEmbeddedMarketBotPaths(cfg appConfig, fallbackItemDataPath string) (cacheDB string, itemDataForBot string) {
+func resolveEmbeddedMarketBotPaths(cfg appConfig, fallbackItemDataPath string) (cacheDB string, itemDataForBot string, statePath string) {
 	cacheDB = cfg.MarketBotCacheDB
 	if cacheDB == "" {
 		cacheDB = filepath.Join(configDir(), "market-bot-cache.db")
@@ -551,15 +568,19 @@ func resolveEmbeddedMarketBotPaths(cfg appConfig, fallbackItemDataPath string) (
 			itemDataForBot = resolveItemDataPath()
 		}
 	}
-	return cacheDB, itemDataForBot
+	statePath = cfg.MarketBotState
+	if statePath == "" {
+		statePath = filepath.Join(configDir(), "market-bot-state.json")
+	}
+	return cacheDB, itemDataForBot, statePath
 }
 
 func startEmbeddedMarketBotIfEnabled(cfg appConfig) context.CancelFunc {
-	if !cfg.MarketBotEnabled {
+	if !marketBotEnabled(cfg) {
 		return nil
 	}
 	botCtx, botCancel := context.WithCancel(context.Background())
-	cacheDB, itemDataForBot := resolveEmbeddedMarketBotPaths(cfg, itemDataPath)
+	cacheDB, itemDataForBot, statePath := resolveEmbeddedMarketBotPaths(cfg, itemDataPath)
 	inst, err := marketbot.Run(botCtx, marketbot.BotConfig{
 		DBPool:       globalDB,
 		DBHost:       dbHost,
@@ -569,6 +590,7 @@ func startEmbeddedMarketBotIfEnabled(cfg appConfig) context.CancelFunc {
 		DBName:       dbName,
 		DBSchema:     dbSchema,
 		CacheDB:      cacheDB,
+		StatePath:    statePath,
 		ItemDataPath: itemDataForBot,
 		BuyInterval:  cfg.MarketBotBuyInt,
 		ListInterval: cfg.MarketBotListInt,
@@ -614,8 +636,11 @@ func main() {
 	connectAndPrimeTemplates(alreadyConnected)
 
 	if botCancel := startEmbeddedMarketBotIfEnabled(loadedConfig); botCancel != nil {
-		// Ensure the bot is stopped on process exit.
 		defer botCancel()
+	}
+
+	if loadedConfig.MarketBotRemoteURL != "" {
+		remoteBotProxy = newRemoteBotClient(loadedConfig.MarketBotRemoteURL, loadedConfig.MarketBotRemoteToken)
 	}
 
 	startServer(listenAddr)
@@ -624,3 +649,7 @@ func main() {
 // embeddedBot holds the live market bot instance when market_bot_enabled=true.
 // Nil when bot is disabled.
 var embeddedBot *marketbot.Instance
+
+// remoteBotProxy forwards /api/v1/market-bot/* to a remote bot when set.
+// Takes precedence when embeddedBot is nil.
+var remoteBotProxy *remoteBotClient

--- a/cmd/dune-admin/main_marketbot_paths_test.go
+++ b/cmd/dune-admin/main_marketbot_paths_test.go
@@ -13,26 +13,51 @@ func TestResolveEmbeddedMarketBotPaths(t *testing.T) {
 		cfg := appConfig{
 			MarketBotCacheDB:  "/tmp/custom-cache.db",
 			MarketBotItemData: "/tmp/custom-item-data.json",
+			MarketBotState:    "/tmp/custom-state.json",
 		}
-		cacheDB, itemDataForBot := resolveEmbeddedMarketBotPaths(cfg, "/fallback.json")
+		cacheDB, itemDataForBot, statePath := resolveEmbeddedMarketBotPaths(cfg, "/fallback.json")
 		if cacheDB != "/tmp/custom-cache.db" {
 			t.Fatalf("expected explicit cache db path, got %q", cacheDB)
 		}
 		if itemDataForBot != "/tmp/custom-item-data.json" {
 			t.Fatalf("expected explicit item-data path, got %q", itemDataForBot)
 		}
+		if statePath != "/tmp/custom-state.json" {
+			t.Fatalf("expected explicit state path, got %q", statePath)
+		}
 	})
 
 	t.Run("falls back to provided item-data path", func(t *testing.T) {
 		t.Parallel()
 		cfg := appConfig{}
-		cacheDB, itemDataForBot := resolveEmbeddedMarketBotPaths(cfg, "/fallback.json")
+		cacheDB, itemDataForBot, statePath := resolveEmbeddedMarketBotPaths(cfg, "/fallback.json")
 		wantCache := filepath.Join(configDir(), "market-bot-cache.db")
 		if cacheDB != wantCache {
 			t.Fatalf("expected default cache path %q, got %q", wantCache, cacheDB)
 		}
 		if itemDataForBot != "/fallback.json" {
 			t.Fatalf("expected fallback item-data path, got %q", itemDataForBot)
+		}
+		wantState := filepath.Join(configDir(), "market-bot-state.json")
+		if statePath != wantState {
+			t.Fatalf("expected default state path %q, got %q", wantState, statePath)
+		}
+	})
+
+	t.Run("marketBotEnabled defaults to true when nil", func(t *testing.T) {
+		t.Parallel()
+		cfg := appConfig{} // MarketBotEnabled is nil
+		if !marketBotEnabled(cfg) {
+			t.Error("marketBotEnabled should default to true when field is nil")
+		}
+	})
+
+	t.Run("marketBotEnabled respects explicit false", func(t *testing.T) {
+		t.Parallel()
+		f := false
+		cfg := appConfig{MarketBotEnabled: &f}
+		if marketBotEnabled(cfg) {
+			t.Error("marketBotEnabled should return false when explicitly set to false")
 		}
 	})
 }

--- a/cmd/dune-admin/render_k8s.go
+++ b/cmd/dune-admin/render_k8s.go
@@ -108,7 +108,7 @@ func renderK8SManifest(outPath string) error {
 		"db_user":                  dbUserVal,
 		"db_name":                  dbNameVal,
 		"db_schema":                dbSchemaVal,
-		"market_bot_enabled":       loadedConfig.MarketBotEnabled,
+		"market_bot_enabled":       marketBotEnabled(loadedConfig),
 		"market_bot_cache_db":      cacheDB,
 		"market_bot_item_data":     itemData,
 		"market_bot_buy_interval":  buyInt.String(),
@@ -116,6 +116,7 @@ func renderK8SManifest(outPath string) error {
 		"market_bot_buy_threshold": buyThreshold,
 		"market_bot_max_buys":      maxBuys,
 	}
+	addIfNonEmpty(manifestCfg, "market_bot_remote_url", loadedConfig.MarketBotRemoteURL)
 	addIfNonEmpty(manifestCfg, "ssh_host", loadedConfig.SSHHost)
 	addIfNonEmpty(manifestCfg, "ssh_user", loadedConfig.SSHUser)
 	addIfNonEmpty(manifestCfg, "ssh_key", loadedConfig.SSHKey)
@@ -150,7 +151,7 @@ func renderK8SManifest(outPath string) error {
 	out.WriteString("  DB_SCHEMA: " + yamlScalar(dbSchemaVal) + "\n")
 	out.WriteString("  LISTEN_ADDR: " + yamlScalar(listen) + "\n")
 	out.WriteString("  CONTROL: " + yamlScalar(control) + "\n")
-	out.WriteString("  MARKET_BOT_ENABLED: " + yamlScalar(strconv.FormatBool(loadedConfig.MarketBotEnabled)) + "\n")
+	out.WriteString("  MARKET_BOT_ENABLED: " + yamlScalar(strconv.FormatBool(marketBotEnabled(loadedConfig))) + "\n")
 	out.WriteString("  MARKET_BOT_BUY_INTERVAL: " + yamlScalar(buyInt.String()) + "\n")
 	out.WriteString("  MARKET_BOT_LIST_INTERVAL: " + yamlScalar(listInt.String()) + "\n")
 	out.WriteString("  config.yaml: |\n")
@@ -162,6 +163,9 @@ func renderK8SManifest(outPath string) error {
 	out.WriteString("  BROKER_USER: " + yamlScalar(brokerUserVal) + "\n")
 	out.WriteString("  BROKER_PASS: " + yamlScalar(brokerPassVal) + "\n")
 	out.WriteString("  BROKER_JWT_SECRET: " + yamlScalar(brokerJWTVal) + "\n")
+	if loadedConfig.MarketBotRemoteToken != "" {
+		out.WriteString("  MARKET_BOT_REMOTE_TOKEN: " + yamlScalar(loadedConfig.MarketBotRemoteToken) + "\n")
+	}
 
 	out.WriteString(`---
 apiVersion: v1
@@ -310,7 +314,7 @@ spec:
     - name: http
       port: 8080
       targetPort: http
-  type: ClusterIP
+  type: NodePort
 `)
 
 	if outPath == "-" {

--- a/cmd/dune-admin/setup.go
+++ b/cmd/dune-admin/setup.go
@@ -562,9 +562,18 @@ func runAmpSetup(ask func(string, string) string, ok, fail func(string), cfg *ap
 func runMarketBotSetup(ask func(string, string) string, ok func(string), cfg *appConfig) {
 	fmt.Println("Embedded market bot:")
 	enabled := strings.ToLower(strings.TrimSpace(ask("Enable embedded market bot [yes/no]", "yes")))
-	cfg.MarketBotEnabled = enabled != "n" && enabled != "no" && enabled != "false" && enabled != "0"
-	if !cfg.MarketBotEnabled {
+	enabledBool := enabled != "n" && enabled != "no" && enabled != "false" && enabled != "0"
+	cfg.MarketBotEnabled = &enabledBool
+	if !enabledBool {
 		ok("Embedded market bot disabled")
+
+		// Offer remote proxy config.
+		remoteURL := strings.TrimSpace(ask("Remote bot URL (leave blank to skip)", ""))
+		if remoteURL != "" {
+			cfg.MarketBotRemoteURL = remoteURL
+			cfg.MarketBotRemoteToken = strings.TrimSpace(ask("Remote bot API token", ""))
+			ok("Remote market bot proxy configured")
+		}
 		fmt.Println()
 		return
 	}

--- a/deploy.sh
+++ b/deploy.sh
@@ -298,5 +298,6 @@ if [[ "$NO_PORT_FORWARD" -eq 0 ]]; then
   echo "Opening API port-forward at http://127.0.0.1:8080 ..."
   kubectl -n "$NAMESPACE" port-forward svc/dune-admin 8080:8080
 else
-  echo "Deploy complete. Run ./listen.sh to open API port-forward."
+  NODE_PORT=$(kubectl get svc dune-admin -n "$NAMESPACE" -o jsonpath='{.spec.ports[0].nodePort}')
+  echo "Deploy complete. Access your dashboard at http://${VM_HOST}:${NODE_PORT} (or via API port-forward if enabled)."
 fi

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,6 +3,23 @@ ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
+# ── Frontend build ────────────────────────────────────────────────────────────
+FROM --platform=$BUILDPLATFORM node:22-slim AS web-builder
+
+WORKDIR /build/web
+
+# Install pnpm via corepack (matches packageManager field in package.json)
+RUN corepack enable && corepack prepare pnpm@10.28.1 --activate
+
+COPY web/package.json web/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY web/ ./
+# No VITE_CDN_BASE_URL → isCdnDeploy=false → SPA uses same-origin API base.
+# VITE_MARKET_BOT_ENABLED=true shows the Bot Control button in the UI.
+RUN VITE_MARKET_BOT_ENABLED=true pnpm build
+
+# ── Go build ──────────────────────────────────────────────────────────────────
 FROM --platform=$BUILDPLATFORM golang:1.26.3 AS go-builder
 
 WORKDIR /build
@@ -16,6 +33,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -ldflags="-s -w" -o dune-admin ./cmd/dune-admin
 
+# ── Runtime ───────────────────────────────────────────────────────────────────
 FROM --platform=$TARGETPLATFORM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates kubernetes-client postgresql-client && rm -rf /var/lib/apt/lists/*
@@ -24,6 +42,7 @@ WORKDIR /app
 
 COPY --from=go-builder /build/dune-admin .
 COPY --from=go-builder /build/tags-data.json /build/item-data.json ./
+COPY --from=web-builder /build/web/dist ./dist
 
 EXPOSE 8080
 

--- a/deploy/k8s/dune-admin.yaml
+++ b/deploy/k8s/dune-admin.yaml
@@ -44,6 +44,7 @@ stringData:
   BROKER_USER: ""
   BROKER_PASS: ""
   BROKER_JWT_SECRET: ""
+  MARKET_BOT_REMOTE_TOKEN: ""
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -150,6 +151,12 @@ spec:
                 secretKeyRef:
                   name: dune-admin-secrets
                   key: BROKER_JWT_SECRET
+            - name: MARKET_BOT_REMOTE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: dune-admin-secrets
+                  key: MARKET_BOT_REMOTE_TOKEN
+                  optional: true
           volumeMounts:
             - name: market-bot-cache
               mountPath: /data
@@ -191,4 +198,5 @@ spec:
     - name: http
       port: 8080
       targetPort: http
-  type: ClusterIP
+      nodePort: 30080
+  type: NodePort

--- a/internal/marketbot/api.go
+++ b/internal/marketbot/api.go
@@ -1,27 +1,36 @@
 package marketbot
 
 import (
+	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"log"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 // APIServer handles HTTP requests for bot status and config.
 type APIServer struct {
 	config    *Config
 	ex        *Exchange
+	inst      *Instance // optional; required for /exec, /cleanup, /logs
 	token     string
 	startTime time.Time
 	mux       *http.ServeMux
 }
 
-func newAPIServer(cfg *Config, ex *Exchange, token string) *APIServer {
+var wsUpgrader = websocket.Upgrader{
+	CheckOrigin: func(_ *http.Request) bool { return true },
+}
+
+func newAPIServer(cfg *Config, ex *Exchange, inst *Instance, token string) *APIServer {
 	s := &APIServer{
 		config:    cfg,
 		ex:        ex,
+		inst:      inst,
 		token:     token,
 		startTime: time.Now(),
 	}
@@ -32,6 +41,10 @@ func newAPIServer(cfg *Config, ex *Exchange, token string) *APIServer {
 	s.mux.HandleFunc("PUT /config", s.auth(s.handlePutConfig))
 	s.mux.HandleFunc("POST /config/reload", s.auth(s.handleConfigReload))
 	s.mux.HandleFunc("GET /report", s.auth(s.handleReport))
+	s.mux.HandleFunc("POST /exec", s.auth(s.handleExec))
+	s.mux.HandleFunc("POST /cleanup", s.auth(s.handleCleanup))
+	s.mux.HandleFunc("GET /logs-ready", s.auth(s.handleLogsReady))
+	s.mux.HandleFunc("GET /logs", s.auth(s.handleLogs))
 	return s
 }
 
@@ -63,15 +76,15 @@ func writeJSON(w http.ResponseWriter, code int, v any) {
 	}
 }
 
-func (s *APIServer) handleHealth(w http.ResponseWriter, r *http.Request) {
+func (s *APIServer) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }
 
-func (s *APIServer) handleStatus(w http.ResponseWriter, r *http.Request) {
+func (s *APIServer) handleStatus(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, s.ex.statusSnapshot(s.startTime))
 }
 
-func (s *APIServer) handleGetConfig(w http.ResponseWriter, r *http.Request) {
+func (s *APIServer) handleGetConfig(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, s.config)
 }
 
@@ -88,13 +101,114 @@ func (s *APIServer) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "note": "changes apply on next tick"})
 }
 
-func (s *APIServer) handleConfigReload(w http.ResponseWriter, r *http.Request) {
+func (s *APIServer) handleConfigReload(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "note": "no file config to reload"})
 }
 
 func (s *APIServer) handleReport(w http.ResponseWriter, r *http.Request) {
 	rows := s.ex.reportData(r.Context())
 	writeJSON(w, http.StatusOK, rows)
+}
+
+var execAllowlist = map[string]bool{
+	"start": true, "stop": true, "restart": true,
+}
+
+func (s *APIServer) handleExec(w http.ResponseWriter, r *http.Request) {
+	if s.inst == nil {
+		http.Error(w, "instance not available", http.StatusServiceUnavailable)
+		return
+	}
+	var req struct {
+		Cmd string `json:"cmd"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !execAllowlist[req.Cmd] {
+		http.Error(w, "unknown command", http.StatusBadRequest)
+		return
+	}
+	var output string
+	switch req.Cmd {
+	case "start":
+		s.inst.Resume()
+		output = "resumed"
+	case "stop":
+		s.inst.Pause()
+		output = "paused"
+	case "restart":
+		if err := s.inst.Restart(r.Context()); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		output = "restarted"
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"output": output})
+}
+
+func (s *APIServer) handleCleanup(w http.ResponseWriter, r *http.Request) {
+	if s.inst == nil {
+		http.Error(w, "instance not available", http.StatusServiceUnavailable)
+		return
+	}
+	orders, items, err := s.inst.CleanupListings(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]int64{
+		"orders_deleted": orders,
+		"items_deleted":  items,
+	})
+}
+
+func (s *APIServer) handleLogsReady(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{"ready": true, "mode": "remote"})
+}
+
+func (s *APIServer) handleLogs(w http.ResponseWriter, r *http.Request) {
+	if s.inst == nil {
+		http.Error(w, "instance not available", http.StatusServiceUnavailable)
+		return
+	}
+	conn, err := wsUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetWriteDeadline(time.Time{})
+
+	ch := s.inst.Sink.Subscribe()
+	defer s.inst.Sink.Unsubscribe(ch)
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	// Pump client pings so we detect disconnects.
+	go func() {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				cancel()
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case line, ok := <-ch:
+			if !ok {
+				return
+			}
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(line)); err != nil {
+				return
+			}
+		}
+	}
 }
 
 // ListenAndServe starts the HTTP server on addr. Blocks until the server stops.

--- a/internal/marketbot/api_test.go
+++ b/internal/marketbot/api_test.go
@@ -12,8 +12,7 @@ func newTestServer(t *testing.T) (*APIServer, *Config) {
 	t.Helper()
 	cfg := &Config{}
 	cfg.config = defaultConfig()
-	ex := &Exchange{}
-	srv := newAPIServer(cfg, ex, "test-token")
+	srv := newAPIServer(cfg, &Exchange{}, nil, "test-token")
 	return srv, cfg
 }
 
@@ -62,7 +61,6 @@ func TestGetConfig(t *testing.T) {
 	if _, ok := body["max_buys"]; !ok {
 		t.Error("expected max_buys in response")
 	}
-	// Verify durations are strings, not integers
 	if _, ok := body["buy_interval"].(string); !ok {
 		t.Errorf("expected buy_interval to be a string, got %T", body["buy_interval"])
 	}
@@ -122,7 +120,7 @@ func TestReport(t *testing.T) {
 func TestNoTokenRejectsAll(t *testing.T) {
 	cfg := &Config{}
 	cfg.config = defaultConfig()
-	srv := newAPIServer(cfg, &Exchange{}, "")
+	srv := newAPIServer(cfg, &Exchange{}, nil, "")
 	for _, path := range []string{"/status", "/config", "/report"} {
 		req := httptest.NewRequest("GET", path, nil)
 		w := httptest.NewRecorder()
@@ -130,5 +128,92 @@ func TestNoTokenRejectsAll(t *testing.T) {
 		if w.Code != http.StatusUnauthorized {
 			t.Errorf("%s with no token: want 401 got %d", path, w.Code)
 		}
+	}
+}
+
+func TestExecStart(t *testing.T) {
+	cfg := &Config{}
+	cfg.config = defaultConfig()
+	cfg.config.Enabled = false
+	inst := &Instance{cfg: cfg}
+	srv := newAPIServer(cfg, &Exchange{}, inst, "test-token")
+
+	req := httptest.NewRequest("POST", "/exec", strings.NewReader(`{"cmd":"start"}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("exec start: want 200 got %d: %s", w.Code, w.Body.String())
+	}
+	if !cfg.Snapshot().Enabled {
+		t.Error("exec start: bot should be enabled after start")
+	}
+}
+
+func TestExecStop(t *testing.T) {
+	cfg := &Config{}
+	cfg.config = defaultConfig()
+	cfg.config.Enabled = true
+	inst := &Instance{cfg: cfg}
+	srv := newAPIServer(cfg, &Exchange{}, inst, "test-token")
+
+	req := httptest.NewRequest("POST", "/exec", strings.NewReader(`{"cmd":"stop"}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("exec stop: want 200 got %d: %s", w.Code, w.Body.String())
+	}
+	if cfg.Snapshot().Enabled {
+		t.Error("exec stop: bot should be disabled after stop")
+	}
+}
+
+func TestExecUnknownCmd(t *testing.T) {
+	cfg := &Config{}
+	cfg.config = defaultConfig()
+	inst := &Instance{cfg: cfg}
+	srv := newAPIServer(cfg, &Exchange{}, inst, "test-token")
+
+	req := httptest.NewRequest("POST", "/exec", strings.NewReader(`{"cmd":"explode"}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("exec unknown: want 400 got %d", w.Code)
+	}
+}
+
+func TestExecRequiresInstance(t *testing.T) {
+	srv, _ := newTestServer(t) // no instance
+
+	req := httptest.NewRequest("POST", "/exec", strings.NewReader(`{"cmd":"start"}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("exec without instance: want 503 got %d", w.Code)
+	}
+}
+
+func TestLogsReady(t *testing.T) {
+	srv, _ := newTestServer(t)
+	req := httptest.NewRequest("GET", "/logs-ready", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("logs-ready: want 200 got %d", w.Code)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["ready"] != true {
+		t.Errorf("logs-ready: want ready=true got %v", body["ready"])
 	}
 }

--- a/internal/marketbot/bot.go
+++ b/internal/marketbot/bot.go
@@ -24,6 +24,7 @@ type BotConfig struct {
 	DBSchema     string
 	DBPool       *pgxpool.Pool // optional shared dune-admin pool (preserves SSH/tunnel routing)
 	CacheDB      string
+	StatePath    string // optional path for persisted runtime config (UI-tunable fields)
 	ItemDataPath string
 	BuyInterval  time.Duration
 	ListInterval time.Duration
@@ -165,10 +166,30 @@ func Run(ctx context.Context, cfg BotConfig) (*Instance, error) {
 	}
 
 	botCfg := &Config{config: defaultConfig()}
+	// Seed from BotConfig (CLI/yaml). These act as initial defaults; if a
+	// persisted state file exists, its values win below.
 	botCfg.config.BuyInterval = cfg.BuyInterval
 	botCfg.config.ListInterval = cfg.ListInterval
 	botCfg.config.BuyThreshold = cfg.BuyThreshold
 	botCfg.config.MaxBuys = cfg.MaxBuys
+
+	// Restore UI-tunable runtime config from disk if present.
+	if cfg.StatePath != "" {
+		if state, err := LoadState(cfg.StatePath); err != nil {
+			logger.Printf("warn: load persisted state %s: %v (using defaults)", cfg.StatePath, err)
+		} else if state.MaxBuys > 0 || len(state.DisabledItems) > 0 || state.BuyThreshold > 0 {
+			// Non-zero state indicates the file existed and had real content.
+			botCfg.config = state
+			logger.Printf("loaded persisted runtime state from %s (%d disabled items)", cfg.StatePath, len(state.DisabledItems))
+		}
+		// Register persistence hook so every successful Apply writes through.
+		statePath := cfg.StatePath
+		botCfg.OnChange(func(v configValues) {
+			if err := SaveState(statePath, v); err != nil {
+				logger.Printf("warn: persist state %s: %v", statePath, err)
+			}
+		})
+	}
 
 	logger.Println("loading catalog...")
 	catalog, err := loadCatalog(cfg.ItemDataPath)
@@ -199,8 +220,8 @@ func Run(ctx context.Context, cfg BotConfig) (*Instance, error) {
 
 	var api *APIServer
 	if cfg.APIAddr != "" {
-		api = newAPIServer(botCfg, ex, cfg.APIToken)
-		go api.ListenAndServe(cfg.APIAddr)
+		api = newAPIServer(botCfg, ex, nil, cfg.APIToken)
+		// inst is wired in below after construction.
 	}
 
 	inst := &Instance{
@@ -211,6 +232,11 @@ func Run(ctx context.Context, cfg BotConfig) (*Instance, error) {
 		ex:      ex,
 		pool:    pool,
 		started: started,
+	}
+
+	if api != nil {
+		api.inst = inst
+		go api.ListenAndServe(cfg.APIAddr)
 	}
 
 	go func() {

--- a/internal/marketbot/config.go
+++ b/internal/marketbot/config.go
@@ -2,7 +2,12 @@ package marketbot
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -24,8 +29,9 @@ type configValues struct {
 
 // Config is the thread-safe runtime config. Tickers call Snapshot() at tick start.
 type Config struct {
-	mu     sync.RWMutex
-	config configValues
+	mu       sync.RWMutex
+	config   configValues
+	onChange func(configValues) // optional persistence hook fired after a successful Apply
 }
 
 func defaultConfig() configValues {
@@ -49,6 +55,21 @@ func defaultConfig() configValues {
 		},
 		DisabledItems: nil,
 	}
+}
+
+// isDisabled reports whether templateID is in the operator-configured disabled
+// list. Matching is case-insensitive so "Item.Sword" and "item.sword" are equal.
+func (c configValues) isDisabled(templateID string) bool {
+	if len(c.DisabledItems) == 0 || templateID == "" {
+		return false
+	}
+	lower := strings.ToLower(templateID)
+	for _, d := range c.DisabledItems {
+		if strings.ToLower(d) == lower {
+			return true
+		}
+	}
+	return false
 }
 
 // Snapshot returns a copy of the current config values under read lock.
@@ -215,5 +236,106 @@ func (c *Config) Apply(patch map[string]json.RawMessage) error {
 	}
 
 	c.config = next
+	if c.onChange != nil {
+		// Pass a deep copy so the callback can't race with future Apply calls.
+		snap := next
+		snap.DisabledItems = append([]string(nil), next.DisabledItems...)
+		snap.RarityMultipliers = copyFloatMap(next.RarityMultipliers)
+		snap.VendorMultipliers = copyFloatMap(next.VendorMultipliers)
+		// Fire synchronously: callers (persistence) are expected to be cheap.
+		// Apply already holds the write lock so a slow callback blocks other
+		// Applies, which is the safer ordering for state-file writes.
+		c.onChange(snap)
+	}
+	return nil
+}
+
+// OnChange registers a callback invoked (in a goroutine) after every successful
+// Apply. Use it to persist config changes to disk. Passing nil clears the hook.
+func (c *Config) OnChange(fn func(configValues)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onChange = fn
+}
+
+func copyFloatMap(m map[string]float64) map[string]float64 {
+	out := make(map[string]float64, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// LoadState reads a persisted configValues from path. A missing file returns
+// the zero configValues with a nil error so callers can treat it as "no state,
+// use defaults". Other I/O or decode errors are returned verbatim.
+func LoadState(path string) (configValues, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path is operator-supplied
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return configValues{}, nil
+		}
+		return configValues{}, fmt.Errorf("read state %s: %w", path, err)
+	}
+	var wire configJSON
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return configValues{}, fmt.Errorf("parse state %s: %w", path, err)
+	}
+	out := configValues{
+		BuyThreshold:      wire.BuyThreshold,
+		MaxBuys:           wire.MaxBuys,
+		ListingsPerGrade:  wire.ListingsPerGrade,
+		Enabled:           wire.Enabled,
+		GradeMultipliers:  wire.GradeMultipliers,
+		RarityMultipliers: wire.RarityMultipliers,
+		VendorMultipliers: wire.VendorMultipliers,
+		DisabledItems:     wire.DisabledItems,
+	}
+	if wire.BuyInterval != "" {
+		if d, err := time.ParseDuration(wire.BuyInterval); err == nil {
+			out.BuyInterval = d
+		}
+	}
+	if wire.ListInterval != "" {
+		if d, err := time.ParseDuration(wire.ListInterval); err == nil {
+			out.ListInterval = d
+		}
+	}
+	return out, nil
+}
+
+// SaveState writes configValues to path atomically (tmp file + rename) so a
+// crash mid-write cannot corrupt the live state file.
+func SaveState(path string, v configValues) error {
+	wire := configJSON{
+		BuyInterval:       v.BuyInterval.String(),
+		ListInterval:      v.ListInterval.String(),
+		BuyThreshold:      v.BuyThreshold,
+		MaxBuys:           v.MaxBuys,
+		ListingsPerGrade:  v.ListingsPerGrade,
+		Enabled:           v.Enabled,
+		GradeMultipliers:  v.GradeMultipliers,
+		RarityMultipliers: v.RarityMultipliers,
+		VendorMultipliers: v.VendorMultipliers,
+		DisabledItems:     v.DisabledItems,
+	}
+	data, err := json.MarshalIndent(wire, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal state: %w", err)
+	}
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create state dir %s: %w", dir, err)
+		}
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write tmp state: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename state: %w", err)
+	}
 	return nil
 }

--- a/internal/marketbot/config_test.go
+++ b/internal/marketbot/config_test.go
@@ -3,6 +3,8 @@ package marketbot
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -122,5 +124,116 @@ func TestConfigValidationAtomicity(t *testing.T) {
 	// max_buys should NOT have been updated (atomicity)
 	if c.Snapshot().MaxBuys != 50 {
 		t.Errorf("Apply should be atomic: MaxBuys should still be 50, got %d", c.Snapshot().MaxBuys)
+	}
+}
+
+func TestConfigOnChangeFiresAfterApply(t *testing.T) {
+	c := &Config{}
+	c.config = defaultConfig()
+
+	var called int
+	var lastSeen configValues
+	c.OnChange(func(v configValues) {
+		called++
+		lastSeen = v
+	})
+
+	patch := map[string]json.RawMessage{"max_buys": json.RawMessage("17")}
+	if err := c.Apply(patch); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if called != 1 {
+		t.Errorf("onChange should fire once on successful Apply, got %d", called)
+	}
+	if lastSeen.MaxBuys != 17 {
+		t.Errorf("onChange got MaxBuys=%d want 17", lastSeen.MaxBuys)
+	}
+
+	// Failed validation must NOT fire the callback.
+	bad := map[string]json.RawMessage{"max_buys": json.RawMessage("-5")}
+	if err := c.Apply(bad); err == nil {
+		t.Fatal("expected Apply to fail")
+	}
+	if called != 1 {
+		t.Errorf("onChange should not fire on validation failure, got %d", called)
+	}
+}
+
+func TestSaveAndLoadStateRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "market-bot-state.json")
+
+	want := defaultConfig()
+	want.MaxBuys = 123
+	want.BuyThreshold = 0.42
+	want.Enabled = false
+	want.DisabledItems = []string{"item.a", "item.b"}
+	want.RarityMultipliers = map[string]float64{"common": 2.5, "unique": 4.0}
+	want.GradeMultipliers = [6]float64{1, 2, 3, 4, 5, 6}
+
+	if err := SaveState(path, want); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	got, err := LoadState(path)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got.MaxBuys != want.MaxBuys || got.BuyThreshold != want.BuyThreshold ||
+		got.Enabled != want.Enabled || got.GradeMultipliers != want.GradeMultipliers {
+		t.Errorf("round-trip mismatch:\n want=%+v\n got=%+v", want, got)
+	}
+	if len(got.DisabledItems) != len(want.DisabledItems) {
+		t.Errorf("DisabledItems len: got %d want %d", len(got.DisabledItems), len(want.DisabledItems))
+	}
+	if got.RarityMultipliers["common"] != 2.5 {
+		t.Errorf("RarityMultipliers not restored: %v", got.RarityMultipliers)
+	}
+	if got.BuyInterval != want.BuyInterval {
+		t.Errorf("BuyInterval: got %v want %v", got.BuyInterval, want.BuyInterval)
+	}
+}
+
+func TestLoadStateMissingFile(t *testing.T) {
+	got, err := LoadState(filepath.Join(t.TempDir(), "nonexistent.json"))
+	if err != nil {
+		t.Fatalf("LoadState on missing file should return zero+nil err, got %v", err)
+	}
+	// Caller uses (zero == empty) as a "no state, use defaults" signal.
+	if got.MaxBuys != 0 || got.Enabled || len(got.DisabledItems) != 0 {
+		t.Errorf("missing-file load should return zero value, got %+v", got)
+	}
+}
+
+func TestSaveStateAtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "market-bot-state.json")
+
+	first := defaultConfig()
+	first.MaxBuys = 1
+	if err := SaveState(path, first); err != nil {
+		t.Fatalf("SaveState first: %v", err)
+	}
+
+	second := defaultConfig()
+	second.MaxBuys = 2
+	if err := SaveState(path, second); err != nil {
+		t.Fatalf("SaveState second: %v", err)
+	}
+
+	got, err := LoadState(path)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got.MaxBuys != 2 {
+		t.Errorf("second save not visible: MaxBuys=%d", got.MaxBuys)
+	}
+
+	// No leftover tmp files.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Errorf("atomic write left stale tmp file: %s", e.Name())
+		}
 	}
 }

--- a/internal/marketbot/exchange.go
+++ b/internal/marketbot/exchange.go
@@ -202,16 +202,54 @@ func (e *Exchange) gameNow() int64 {
 	return time.Now().Unix() - e.gameEpochUnix
 }
 
-func (e *Exchange) Init(ctx context.Context, catalog []CatalogItem) error {
-	err := e.db.QueryRow(ctx,
-		`SELECT exchange_id FROM dune.dune_exchange_orders WHERE is_npc_order = FALSE LIMIT 1`).Scan(&e.exchangeID)
-	if err != nil {
-		// No player orders yet — fall back to first non-Global exchange
-		if err2 := e.db.QueryRow(ctx,
-			`SELECT id FROM dune.dune_exchanges WHERE exchange_name != 'Global' ORDER BY id LIMIT 1`).Scan(&e.exchangeID); err2 != nil {
-			return fmt.Errorf("detect exchange id: %w", err2)
-		}
+// detectExchangeID resolves the exchange ID via a three-tier cascade:
+//  1. An existing player order's exchange_id (most reliable).
+//  2. Any row in dune_exchanges (works on fresh servers with no player trades).
+//  3. An upsert via get_dune_exchange_id('Global') so a completely empty DB
+//     still boots rather than crashing with "no rows in result set".
+//
+// Each tier is provided as a closure so the function can be unit-tested without
+// a live Postgres connection.
+func detectExchangeID(
+	fromOrders func() (int64, error),
+	fromTable func() (int64, error),
+	autoCreate func() (int64, error),
+) (int64, error) {
+	if id, err := fromOrders(); err == nil {
+		return id, nil
 	}
+	if id, err := fromTable(); err == nil {
+		return id, nil
+	}
+	id, err := autoCreate()
+	if err != nil {
+		return 0, fmt.Errorf("detect exchange id: %w", err)
+	}
+	return id, nil
+}
+
+func (e *Exchange) Init(ctx context.Context, catalog []CatalogItem) error {
+	id, err := detectExchangeID(
+		func() (int64, error) {
+			var id int64
+			return id, e.db.QueryRow(ctx,
+				`SELECT exchange_id FROM dune.dune_exchange_orders WHERE is_npc_order = FALSE LIMIT 1`).Scan(&id)
+		},
+		func() (int64, error) {
+			var id int64
+			return id, e.db.QueryRow(ctx,
+				`SELECT id FROM dune.dune_exchanges ORDER BY id LIMIT 1`).Scan(&id)
+		},
+		func() (int64, error) {
+			var id int64
+			return id, e.db.QueryRow(ctx,
+				`SELECT dune.get_dune_exchange_id('Global')`).Scan(&id)
+		},
+	)
+	if err != nil {
+		return err
+	}
+	e.exchangeID = id
 	log.Printf("exchange id: %d", e.exchangeID)
 
 	if err := e.db.QueryRow(ctx,
@@ -448,6 +486,12 @@ func (e *Exchange) buyPlayerListings(ctx context.Context, orderExpiry int64, sna
 
 		// Skip items the operator has marked as non-buyable.
 		if item, ok := e.catalogMap[tmpl]; ok && !item.Buyable {
+			skippedUnknown++
+			continue
+		}
+
+		// Skip items disabled via runtime config.
+		if snap.isDisabled(tmpl) {
 			skippedUnknown++
 			continue
 		}
@@ -697,12 +741,24 @@ func (e *Exchange) ListTick(ctx context.Context, catalog []CatalogItem) {
 		}
 
 		for _, grade := range applicableGrades(item) {
+			key := gradeKey{item.TemplateID, grade}
+			listings := current[key]
+
+			// If this item is disabled, prune all existing bot listings for it
+			// and skip creating new ones.
+			if snap.isDisabled(item.TemplateID) {
+				for _, l := range listings {
+					staleOrderIDs = append(staleOrderIDs, l.orderID)
+					staleItemIDs = append(staleItemIDs, l.itemID)
+					pruned++
+				}
+				continue
+			}
+
 			price := gradeFloor(item, grade, snap)
 			if item.MaterialCost <= 0 {
 				price = gradedPrice(basePrice, grade, snap.GradeMultipliers)
 			}
-			key := gradeKey{item.TemplateID, grade}
-			listings := current[key]
 
 			// Collect stale listings (wrong price) for bulk delete.
 			var valid []listingInfo

--- a/internal/marketbot/exchange_test.go
+++ b/internal/marketbot/exchange_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/jackc/pgx/v5"
 )
 
 func TestEnsureCachePathCreatesParentDirectories(t *testing.T) {
@@ -25,5 +27,95 @@ func TestEnsureCachePathCreatesParentDirectories(t *testing.T) {
 func TestEnsureCachePathRejectsEmptyPath(t *testing.T) {
 	if _, err := ensureCachePath("   "); err == nil {
 		t.Fatalf("ensureCachePath should reject empty path")
+	}
+}
+
+func TestConfigValuesIsDisabled(t *testing.T) {
+	snap := configValues{
+		DisabledItems: []string{"item.sword", "item.shield"},
+	}
+	if !snap.isDisabled("item.sword") {
+		t.Error("item.sword should be disabled")
+	}
+	if !snap.isDisabled("item.shield") {
+		t.Error("item.shield should be disabled")
+	}
+	if snap.isDisabled("item.axe") {
+		t.Error("item.axe should NOT be disabled")
+	}
+	if snap.isDisabled("") {
+		t.Error("empty string should NOT be disabled")
+	}
+
+	// Case-insensitive match.
+	if !snap.isDisabled("ITEM.SWORD") {
+		t.Error("isDisabled should be case-insensitive")
+	}
+}
+
+func TestConfigValuesIsDisabledEmpty(t *testing.T) {
+	snap := configValues{}
+	if snap.isDisabled("anything") {
+		t.Error("empty DisabledItems list should never block any item")
+	}
+}
+
+func TestDetectExchangeID(t *testing.T) {
+	errNoRows := pgx.ErrNoRows
+
+	tests := []struct {
+		name       string
+		fromOrders func() (int64, error)
+		fromTable  func() (int64, error)
+		autoCreate func() (int64, error)
+		wantID     int64
+		wantErr    bool
+	}{
+		{
+			name:       "found in player orders",
+			fromOrders: func() (int64, error) { return 7, nil },
+			fromTable:  func() (int64, error) { panic("should not be called") },
+			autoCreate: func() (int64, error) { panic("should not be called") },
+			wantID:     7,
+		},
+		{
+			name:       "found in dune_exchanges table",
+			fromOrders: func() (int64, error) { return 0, errNoRows },
+			fromTable:  func() (int64, error) { return 3, nil },
+			autoCreate: func() (int64, error) { panic("should not be called") },
+			wantID:     3,
+		},
+		{
+			name:       "auto-creates via upsert when table empty",
+			fromOrders: func() (int64, error) { return 0, errNoRows },
+			fromTable:  func() (int64, error) { return 0, errNoRows },
+			autoCreate: func() (int64, error) { return 1, nil },
+			wantID:     1,
+		},
+		{
+			name:       "all three fail → error",
+			fromOrders: func() (int64, error) { return 0, errNoRows },
+			fromTable:  func() (int64, error) { return 0, errNoRows },
+			autoCreate: func() (int64, error) { return 0, errNoRows },
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := detectExchangeID(tt.fromOrders, tt.fromTable, tt.autoCreate)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id != tt.wantID {
+				t.Errorf("got id=%d want %d", id, tt.wantID)
+			}
+		})
 	}
 }

--- a/listen.ps1
+++ b/listen.ps1
@@ -7,5 +7,8 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+Write-Host "NOTE: The service is now type=NodePort on port 30080." -ForegroundColor Cyan
+Write-Host "You can reach it directly at http://<VM-IP>:30080 without this script."
+Write-Host ""
 Write-Host "Opening API port-forward at http://127.0.0.1:$LocalPort ..."
 kubectl -n $Namespace port-forward svc/dune-admin "$LocalPort`:$RemotePort"

--- a/listen.sh
+++ b/listen.sh
@@ -12,6 +12,12 @@ usage() {
   cat <<'EOF'
 Usage: ./listen.sh [options]
 
+Opens a kubectl port-forward to the dune-admin service.
+
+NOTE: The service is now type=NodePort exposed on port 30080 on the VM,
+so you can also reach it directly at http://<VM-IP>:30080 without this script.
+This script is only needed if you want to map a specific local port.
+
 Options:
   --namespace <ns>         Kubernetes namespace (default: dune-admin)
   --local-port <port>      Local listen port (default: 8080)
@@ -31,4 +37,5 @@ while [[ $# -gt 0 ]]; do
 done
 
 echo "Opening API port-forward at http://127.0.0.1:${LOCAL_PORT} ..."
+echo "(Alternatively, use http://<VM-IP>:30080 directly via NodePort)"
 kubectl -n "$NAMESPACE" port-forward svc/dune-admin "${LOCAL_PORT}:${REMOTE_PORT}"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,104 +1,109 @@
-import { useState, useEffect } from 'react'
-import { Show, SignInButton, UserButton, useAuth } from '@clerk/react'
-import { Button, Chip, InputGroup, TextField, Toast, Tabs } from '@heroui/react'
-import { useLocation, useNavigate } from 'react-router-dom'
-import { useStatus } from './hooks/useStatus'
-import BattlegroupTab from './tabs/BattlegroupTab'
-import PlayersTab from './tabs/PlayersTab'
-import DatabaseTab from './tabs/DatabaseTab'
-import LogsTab from './tabs/LogsTab'
-import BlueprintsTab from './tabs/BlueprintsTab'
-import BasesTab from './tabs/BasesTab'
-import StorageTab from './tabs/StorageTab'
-import ServerSettingsTab from './tabs/ServerSettingsTab'
-import MarketTab from './tabs/MarketTab'
-import { Icon } from './dune-ui'
+import { useState, useEffect } from "react";
+import { Show, SignInButton, UserButton, useAuth } from "@clerk/react";
+import { Button, Chip, InputGroup, TextField, Toast, Tabs } from "@heroui/react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useStatus } from "./hooks/useStatus";
+import BattlegroupTab from "./tabs/BattlegroupTab";
+import PlayersTab from "./tabs/PlayersTab";
+import DatabaseTab from "./tabs/DatabaseTab";
+import LogsTab from "./tabs/LogsTab";
+import BlueprintsTab from "./tabs/BlueprintsTab";
+import BasesTab from "./tabs/BasesTab";
+import StorageTab from "./tabs/StorageTab";
+import ServerSettingsTab from "./tabs/ServerSettingsTab";
+import MarketTab from "./tabs/MarketTab";
+import { Icon } from "./dune-ui";
 
-const TAB_IDS = ['battlegroup', 'players', 'database', 'logs', 'blueprints', 'bases', 'storage', 'server', 'market'] as const
-type TabId = typeof TAB_IDS[number]
-const DEFAULT_TAB: TabId = 'battlegroup'
+const TAB_IDS = [
+  "battlegroup",
+  "players",
+  "database",
+  "logs",
+  "blueprints",
+  "bases",
+  "storage",
+  "server",
+  "market",
+] as const;
+type TabId = (typeof TAB_IDS)[number];
+const DEFAULT_TAB: TabId = "battlegroup";
 
 function currentTabFromPath(pathname: string): TabId {
-  const seg = pathname.replace(/^\//, '').split('/')[0]
-  return (TAB_IDS as readonly string[]).includes(seg) ? (seg as TabId) : DEFAULT_TAB
+  const seg = pathname.replace(/^\//, "").split("/")[0];
+  return (TAB_IDS as readonly string[]).includes(seg) ? (seg as TabId) : DEFAULT_TAB;
 }
 
-const hasClerk = !!import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+const hasClerk = !!import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
 function AppWithAuth() {
-  const { isSignedIn } = useAuth()
-  return <AppCore isSignedIn={!!isSignedIn} />
+  const { isSignedIn } = useAuth();
+  return <AppCore isSignedIn={!!isSignedIn} />;
 }
 
 export default function App() {
-  return hasClerk ? <AppWithAuth /> : <AppCore isSignedIn={true} />
+  return hasClerk ? <AppWithAuth /> : <AppCore isSignedIn={true} />;
 }
 
 function parseVer(v: string): [number, number, number] {
-  const [a, b, c] = v.replace(/^v/, '').split('.').map(Number)
-  return [a || 0, b || 0, c || 0]
+  const [a, b, c] = v.replace(/^v/, "").split(".").map(Number);
+  return [a || 0, b || 0, c || 0];
 }
 
 function isNewer(latest: string, current: string): boolean {
-  if (current === 'dev') return false
-  const [la, lb, lc] = parseVer(latest)
-  const [ca, cb, cc] = parseVer(current)
-  if (la !== ca) return la > ca
-  if (lb !== cb) return lb > cb
-  return lc > cc
+  if (current === "dev") return false;
+  const [la, lb, lc] = parseVer(latest);
+  const [ca, cb, cc] = parseVer(current);
+  if (la !== ca) return la > ca;
+  if (lb !== cb) return lb > cb;
+  return lc > cc;
 }
 
 function AppCore({ isSignedIn }: { isSignedIn: boolean }) {
-  const status = useStatus()
-  const location = useLocation()
-  const navigate = useNavigate()
-  const [showBackendConfig, setShowBackendConfig] = useState(false)
-  const [backendUrl, setBackendUrl] = useState(() => localStorage.getItem('dune_admin_backend') || '')
-  const [latestVersion, setLatestVersion] = useState<string | null>(null)
+  const status = useStatus();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [showBackendConfig, setShowBackendConfig] = useState(false);
+  const [backendUrl, setBackendUrl] = useState(() => localStorage.getItem("dune_admin_backend") || "");
+  const [latestVersion, setLatestVersion] = useState<string | null>(null);
 
   useEffect(() => {
-    const seg = location.pathname.replace(/^\//, '').split('/')[0]
+    const seg = location.pathname.replace(/^\//, "").split("/")[0];
     if (!seg || !(TAB_IDS as readonly string[]).includes(seg)) {
-      navigate(`/${DEFAULT_TAB}`, { replace: true })
+      navigate(`/${DEFAULT_TAB}`, { replace: true });
     }
-  }, [location.pathname, navigate])
+  }, [location.pathname, navigate]);
 
-  const currentTab = currentTabFromPath(location.pathname)
+  const currentTab = currentTabFromPath(location.pathname);
 
   useEffect(() => {
-    fetch('https://api.github.com/repos/Icehunter/dune-admin/releases/latest')
-      .then(r => r.json())
-      .then(d => setLatestVersion(d.tag_name || null))
-      .catch(() => {})
-  }, [])
+    fetch("https://api.github.com/repos/Icehunter/dune-admin/releases/latest")
+      .then((r) => r.json())
+      .then((d) => setLatestVersion(d.tag_name || null))
+      .catch(() => {});
+  }, []);
 
   const saveAndReload = () => {
-    localStorage.setItem('dune_admin_backend', backendUrl.trim())
-    window.location.reload()
-  }
+    localStorage.setItem("dune_admin_backend", backendUrl.trim());
+    window.location.reload();
+  };
 
   return (
     <div className="h-screen flex flex-col overflow-hidden bg-background">
       <Toast.Provider />
 
       {/* Header */}
-      <header className="flex items-center justify-between px-6 py-3 border-b border-[#4e3411] bg-surface shrink-0" style={{background: 'linear-gradient(180deg, #241a0e 0%, #1a1610 100%)'}}>
+      <header
+        className="flex items-center justify-between px-6 py-3 border-b border-[#4e3411] bg-surface shrink-0"
+        style={{ background: "linear-gradient(180deg, #241a0e 0%, #1a1610 100%)" }}
+      >
         <div className="flex items-center gap-3">
-          <span className="text-xl font-bold uppercase tracking-[0.2em] text-accent">
-            DUNE ADMIN
-          </span>
-          {status?.control && status.control !== 'none' && (
-            <span className="text-xs text-muted">{status.control}</span>
-          )}
-          {status?.ssh_host && (
-            <span className="text-xs text-muted">{status.ssh_host}</span>
-          )}
-          {status?.db_host && status.control !== 'kubectl' && (
+          <span className="text-xl font-bold uppercase tracking-[0.2em] text-accent">DUNE ADMIN</span>
+          {status?.control && status.control !== "none" && <span className="text-xs text-muted">{status.control}</span>}
+          {status?.ssh_host && <span className="text-xs text-muted">{status.ssh_host}</span>}
+          {status?.db_host && status.control !== "kubectl" && (
             <span className="text-xs text-muted">{status.db_host}</span>
           )}
-          {status?.version && (
-            <span className="text-xs text-muted">v{status.version}</span>
-          )}
+          {status?.version && <span className="text-xs text-muted">v{status.version}</span>}
           {latestVersion && status?.version && isNewer(latestVersion, status.version) && (
             <a
               href="https://github.com/Icehunter/dune-admin/releases/latest"
@@ -106,27 +111,25 @@ function AppCore({ isSignedIn }: { isSignedIn: boolean }) {
               rel="noreferrer"
               className="no-underline"
             >
-              <Chip size="sm" color="warning" variant="soft">↑ {latestVersion}</Chip>
+              <Chip size="sm" color="warning" variant="soft">
+                ↑ {latestVersion}
+              </Chip>
             </a>
           )}
         </div>
 
         <div className="flex items-center gap-3">
-          {status?.executor === 'ssh' && (
-            <ConnectionBadge label="SSH" connected={status.ssh_connected} />
-          )}
+          {status?.executor === "ssh" && <ConnectionBadge label="SSH" connected={status.ssh_connected} />}
           <ConnectionBadge label="DB" connected={status?.db_connected ?? false} />
-          {status?.pod_ns && (
-            <span className="text-xs text-muted">ns: {status.pod_ns}</span>
-          )}
+          {status?.pod_ns && <span className="text-xs text-muted">ns: {status.pod_ns}</span>}
 
           <Button
             size="sm"
             variant="ghost"
             isIconOnly
             aria-label="Configure backend"
-            onPress={() => setShowBackendConfig(v => !v)}
-            className={showBackendConfig ? 'text-accent' : ''}
+            onPress={() => setShowBackendConfig((v) => !v)}
+            className={showBackendConfig ? "text-accent" : ""}
           >
             <Icon name="settings" />
           </Button>
@@ -135,7 +138,9 @@ function AppCore({ isSignedIn }: { isSignedIn: boolean }) {
             <>
               <Show when="signed-out">
                 <SignInButton>
-                  <Button size="sm" variant="outline">Sign In</Button>
+                  <Button size="sm" variant="outline">
+                    Sign In
+                  </Button>
                 </SignInButton>
               </Show>
               <Show when="signed-in">
@@ -150,20 +155,28 @@ function AppCore({ isSignedIn }: { isSignedIn: boolean }) {
       {showBackendConfig && (
         <div
           className="fixed inset-0 z-50 bg-black/60"
-          onClick={e => { if (e.target === e.currentTarget) setShowBackendConfig(false) }}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setShowBackendConfig(false);
+          }}
         >
           <div className="absolute top-[52px] right-4 w-[360px] bg-background border border-border rounded-lg p-4 flex flex-col gap-4">
             <div className="flex items-center justify-between">
               <span className="text-sm font-semibold text-accent">Backend URL</span>
-              <Button size="sm" variant="ghost" isIconOnly aria-label="Close" onPress={() => setShowBackendConfig(false)}>
+              <Button
+                size="sm"
+                variant="ghost"
+                isIconOnly
+                aria-label="Close"
+                onPress={() => setShowBackendConfig(false)}
+              >
                 <Icon name="x" />
               </Button>
             </div>
 
             <p className="text-xs text-muted">
-              Current:{' '}
+              Current:{" "}
               <span className="font-mono text-foreground">
-                {localStorage.getItem('dune_admin_backend') || 'http://localhost:8080'}
+                {localStorage.getItem("dune_admin_backend") || "http://localhost:8080"}
               </span>
             </p>
 
@@ -172,10 +185,12 @@ function AppCore({ isSignedIn }: { isSignedIn: boolean }) {
                 <InputGroup.Prefix>URL</InputGroup.Prefix>
                 <InputGroup.Input
                   value={backendUrl}
-                  onChange={e => setBackendUrl(e.target.value)}
+                  onChange={(e) => setBackendUrl(e.target.value)}
                   placeholder="http://host:port"
                   className="font-mono"
-                  onKeyDown={e => { if (e.key === 'Enter') saveAndReload() }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") saveAndReload();
+                  }}
                 />
               </InputGroup>
             </TextField>
@@ -187,7 +202,10 @@ function AppCore({ isSignedIn }: { isSignedIn: boolean }) {
               <Button
                 size="sm"
                 variant="outline"
-                onPress={() => { localStorage.removeItem('dune_admin_backend'); window.location.reload() }}
+                onPress={() => {
+                  localStorage.removeItem("dune_admin_backend");
+                  window.location.reload();
+                }}
               >
                 Reset
               </Button>
@@ -200,20 +218,47 @@ function AppCore({ isSignedIn }: { isSignedIn: boolean }) {
       <div className="flex-1 flex flex-col overflow-hidden min-h-0">
         <Tabs
           selectedKey={currentTab}
-          onSelectionChange={k => navigate(`/${k}`)}
+          onSelectionChange={(k) => navigate(`/${k}`)}
           className="flex-1 flex flex-col overflow-hidden min-h-0"
         >
           <Tabs.ListContainer className="px-4 pt-2 shrink-0">
             <Tabs.List aria-label="Admin sections" className="gap-1">
-              <Tabs.Tab id="battlegroup">Battlegroup<Tabs.Indicator /></Tabs.Tab>
-              <Tabs.Tab id="players">Players<Tabs.Indicator /></Tabs.Tab>
-              <Tabs.Tab id="database">Database<Tabs.Indicator /></Tabs.Tab>
-              <Tabs.Tab id="logs">Logs<Tabs.Indicator /></Tabs.Tab>
-              <Tabs.Tab id="blueprints">Blueprints<Tabs.Indicator /></Tabs.Tab>
-              <Tabs.Tab id="bases">Bases<Tabs.Indicator /></Tabs.Tab>
-              <Tabs.Tab id="storage">Storage<Tabs.Indicator /></Tabs.Tab>
-              <Tabs.Tab id="server">Server<Tabs.Indicator /></Tabs.Tab>
-              <Tabs.Tab id="market">Market<Tabs.Indicator /></Tabs.Tab>
+              <Tabs.Tab id="battlegroup">
+                Battlegroup
+                <Tabs.Indicator />
+              </Tabs.Tab>
+              <Tabs.Tab id="players">
+                Players
+                <Tabs.Indicator />
+              </Tabs.Tab>
+              <Tabs.Tab id="database">
+                Database
+                <Tabs.Indicator />
+              </Tabs.Tab>
+              <Tabs.Tab id="logs">
+                Logs
+                <Tabs.Indicator />
+              </Tabs.Tab>
+              <Tabs.Tab id="blueprints">
+                Blueprints
+                <Tabs.Indicator />
+              </Tabs.Tab>
+              <Tabs.Tab id="bases">
+                Bases
+                <Tabs.Indicator />
+              </Tabs.Tab>
+              <Tabs.Tab id="storage">
+                Storage
+                <Tabs.Indicator />
+              </Tabs.Tab>
+              <Tabs.Tab id="server">
+                Server
+                <Tabs.Indicator />
+              </Tabs.Tab>
+              <Tabs.Tab id="market">
+                Market
+                <Tabs.Indicator />
+              </Tabs.Tab>
             </Tabs.List>
           </Tabs.ListContainer>
           <Tabs.Panel id="battlegroup" className="flex-1 overflow-hidden flex flex-col p-4 min-h-0">
@@ -241,19 +286,19 @@ function AppCore({ isSignedIn }: { isSignedIn: boolean }) {
             <ServerSettingsTab />
           </Tabs.Panel>
           <Tabs.Panel id="market" className="flex-1 overflow-hidden flex flex-col p-4 min-h-0">
-            <MarketTab isSignedIn={isSignedIn} />
+            <MarketTab />
           </Tabs.Panel>
         </Tabs>
       </div>
     </div>
-  )
+  );
 }
 
 function ConnectionBadge({ label, connected }: { label: string; connected: boolean }) {
   return (
     <div className="flex items-center gap-1.5 text-xs">
-      <div className={`w-2 h-2 rounded-full ${connected ? 'bg-success' : 'bg-muted/40'}`} />
-      <span className={connected ? 'text-foreground' : 'text-muted'}>{label}</span>
+      <div className={`w-2 h-2 rounded-full ${connected ? "bg-success" : "bg-muted/40"}`} />
+      <span className={connected ? "text-foreground" : "text-muted"}>{label}</span>
     </div>
-  )
+  );
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -4,9 +4,22 @@ declare global {
   }
 }
 
+function sanitizeBackendBase(raw: string): string | null {
+  try {
+    const u = new URL(raw.trim())
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return null
+    return `${u.origin}${u.pathname}`.replace(/\/$/, '')
+  } catch {
+    return null
+  }
+}
+
 function getApiBase(): string {
   const stored = localStorage.getItem('dune_admin_backend')
-  if (stored) return stored.replace(/\/$/, '') + '/api/v1'
+  if (stored) {
+    const safeBase = sanitizeBackendBase(stored)
+    if (safeBase) return safeBase + '/api/v1'
+  }
 
   // CDN-hosted deploy detection: VITE_CDN_BASE_URL is set at build time by
   // the Cloudflare Pages workflow and unset for single-binary Go builds

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -224,7 +224,7 @@ export type CatalogItem = {
 }
 export type BotStatus = {
   running: boolean
-  mode?: 'embedded'
+  mode?: 'embedded' | 'remote' | 'none'
   enabled?: boolean
   uptime: string
   last_list_tick: string | null

--- a/web/src/dune-ui/InfoCard.tsx
+++ b/web/src/dune-ui/InfoCard.tsx
@@ -13,7 +13,7 @@ type ItemProps = {
  * Bordered, slightly-elevated label/value row card — the "Phase Reconciling
  * | Database Ready" health row pattern from BattlegroupTab.
  */
-function InfoCardRoot({ children, className = '' }: CardProps) {
+export function InfoCard({ children, className = '' }: CardProps) {
   return (
     <div
       className={
@@ -27,7 +27,7 @@ function InfoCardRoot({ children, className = '' }: CardProps) {
   )
 }
 
-function InfoCardItem({ label, value, valueColor }: ItemProps) {
+export function InfoCardItem({ label, value, valueColor }: ItemProps) {
   return (
     <div className="flex items-center gap-2">
       <span className="text-muted">{label}</span>
@@ -38,4 +38,5 @@ function InfoCardItem({ label, value, valueColor }: ItemProps) {
   )
 }
 
-export const InfoCard = Object.assign(InfoCardRoot, { Item: InfoCardItem })
+// Namespace alias kept for callers using <InfoCard.Item>
+InfoCard.Item = InfoCardItem

--- a/web/src/hooks/useTableSort.ts
+++ b/web/src/hooks/useTableSort.ts
@@ -16,7 +16,7 @@ export function useTableSort<T, K extends string>(
     out.sort((a, b) => {
       const av = getValue(a, sortKey)
       const bv = getValue(b, sortKey)
-      let cmp = 0
+      let cmp: number
       if (typeof av === 'number' && typeof bv === 'number') cmp = av - bv
       else cmp = String(av ?? '').localeCompare(String(bv ?? ''), undefined, { numeric: true })
       return sortDir === 'asc' ? cmp : -cmp

--- a/web/src/tabs/BasesTab.tsx
+++ b/web/src/tabs/BasesTab.tsx
@@ -1,59 +1,74 @@
-import { useState, useEffect } from 'react'
-import { Button, Card, Spinner, toast } from '@heroui/react'
-import { api, ApiError } from '../api/client'
-import type { BaseRow } from '../api/client'
-import { DataTable, Icon, PageHeader, type Column } from '../dune-ui'
+import { useState, useEffect, useCallback } from "react";
+import { Button, Card, Spinner, toast } from "@heroui/react";
+import { api, ApiError } from "../api/client";
+import type { BaseRow } from "../api/client";
+import { DataTable, Icon, PageHeader, type Column } from "../dune-ui";
 
-type Key = 'id' | 'name' | 'pieces' | 'placeables' | 'actions'
+type Key = "id" | "name" | "pieces" | "placeables" | "actions";
 
 const COLUMNS: Column<Key>[] = [
-  { key: 'id',         label: 'ID',         width: 80 },
-  { key: 'name',       label: 'Name',       minWidth: 220 },
-  { key: 'pieces',     label: 'Pieces',     width: 100 },
-  { key: 'placeables', label: 'Placeables', width: 110 },
-  { key: 'actions',    label: '',           width: 120, sortable: false },
-]
+  { key: "id", label: "ID", width: 80 },
+  { key: "name", label: "Name", minWidth: 220 },
+  { key: "pieces", label: "Pieces", width: 100 },
+  { key: "placeables", label: "Placeables", width: 110 },
+  { key: "actions", label: "", width: 120, sortable: false },
+];
 
 export default function BasesTab({ isSignedIn = true }: { isSignedIn?: boolean }) {
-  const [bases, setBases] = useState<BaseRow[]>([])
-  const [loading, setLoading] = useState(false)
-  const [unsupported, setUnsupported] = useState(false)
+  const [bases, setBases] = useState<BaseRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [unsupported, setUnsupported] = useState(false);
 
-  const load = async () => {
-    setLoading(true)
-    setUnsupported(false)
-    try {
-      setBases(await api.bases.list())
-    } catch (e: unknown) {
-      if (e instanceof ApiError && e.status === 404) {
-        setUnsupported(true)
-      } else {
-        toast.danger(`Failed to load bases: ${e instanceof Error ? e.message : String(e)}`)
-      }
-    } finally {
-      setLoading(false)
-    }
-  }
+  const load = useCallback(() => {
+    Promise.resolve()
+      .then(() => {
+        setLoading(true);
+        setUnsupported(false);
+      })
+      .then(() => api.bases.list())
+      .then(setBases)
+      .catch((e: unknown) => {
+        if (e instanceof ApiError && e.status === 404) setUnsupported(true);
+        else toast.danger(`Failed to load bases: ${e instanceof Error ? e.message : String(e)}`);
+      })
+      .finally(() => setLoading(false));
+  }, []);
 
-  useEffect(() => { load() }, [])
+  useEffect(() => {
+    load();
+  }, [load]);
 
   return (
     <div className="flex flex-col h-full gap-3 min-h-0">
       {!isSignedIn && (
         <div className="shrink-0 rounded-[var(--radius)] px-4 py-2 text-xs font-medium bg-danger/10 border border-danger/40 text-danger flex items-center gap-2">
           <Icon name="triangle-alert" />
-          <span>A <strong>Layout Tools</strong> account is required to export bases. Sign in using the button in the top right.</span>
+          <span>
+            A <strong>Layout Tools</strong> account is required to export bases. Sign in using the button in the top
+            right.
+          </span>
         </div>
       )}
 
-      <PageHeader title={`Bases (${bases.length})`} subtitle="Live in-world player bases. Export any base as a solido-compatible blueprint.">
+      <PageHeader
+        title={`Bases (${bases.length})`}
+        subtitle="Live in-world player bases. Export any base as a solido-compatible blueprint."
+      >
         <Button size="sm" variant="ghost" onPress={load} isDisabled={loading}>
-          {loading ? <Spinner size="sm" color="current" /> : <><Icon name="refresh-cw" /> Refresh</>}
+          {loading ? (
+            <Spinner size="sm" color="current" />
+          ) : (
+            <>
+              <Icon name="refresh-cw" /> Refresh
+            </>
+          )}
         </Button>
       </PageHeader>
 
       {loading ? (
-        <div className="flex justify-center py-12"><Spinner size="lg" /></div>
+        <div className="flex justify-center py-12">
+          <Spinner size="lg" />
+        </div>
       ) : unsupported ? (
         <Card className="self-center max-w-sm">
           <Card.Header>
@@ -61,8 +76,8 @@ export default function BasesTab({ isSignedIn = true }: { isSignedIn?: boolean }
           </Card.Header>
           <Card.Content>
             <p className="text-xs text-muted text-center">
-              This version of the dune-admin binary does not support base listing.
-              Upgrade to the latest release to use this feature.
+              This version of the dune-admin binary does not support base listing. Upgrade to the latest release to use
+              this feature.
             </p>
           </Card.Content>
         </Card>
@@ -72,17 +87,21 @@ export default function BasesTab({ isSignedIn = true }: { isSignedIn?: boolean }
           className="min-h-0 max-h-full"
           columns={COLUMNS}
           rows={bases}
-          rowId={b => String(b.id)}
-          initialSort={{ column: 'id', direction: 'ascending' }}
-          sortValue={(b, k) => k === 'actions' ? '' : (b as unknown as Record<string, string | number>)[k]}
+          rowId={(b) => String(b.id)}
+          initialSort={{ column: "id", direction: "ascending" }}
+          sortValue={(b, k) => (k === "actions" ? "" : (b as unknown as Record<string, string | number>)[k])}
           emptyState={<div className="py-8 text-center text-muted">No bases found.</div>}
           renderCell={(b, key) => {
             switch (key) {
-              case 'id':         return <span className="font-mono text-muted">{b.id}</span>
-              case 'name':       return b.name || <span className="text-muted">—</span>
-              case 'pieces':     return <span className="text-muted">{b.pieces}</span>
-              case 'placeables': return <span className="text-muted">{b.placeables}</span>
-              case 'actions':
+              case "id":
+                return <span className="font-mono text-muted">{b.id}</span>;
+              case "name":
+                return b.name || <span className="text-muted">—</span>;
+              case "pieces":
+                return <span className="text-muted">{b.pieces}</span>;
+              case "placeables":
+                return <span className="text-muted">{b.placeables}</span>;
+              case "actions":
                 return isSignedIn ? (
                   <a href={api.bases.exportUrl(b.id)} download={b.name ? `${b.name}.json` : `base-${b.id}.json`}>
                     <Button size="sm" variant="outline" className="w-full">
@@ -93,11 +112,11 @@ export default function BasesTab({ isSignedIn = true }: { isSignedIn?: boolean }
                   <Button size="sm" variant="outline" className="w-full" isDisabled>
                     <Icon name="download" /> Export
                   </Button>
-                )
+                );
             }
           }}
         />
       )}
     </div>
-  )
+  );
 }

--- a/web/src/tabs/BattlegroupTab/index.tsx
+++ b/web/src/tabs/BattlegroupTab/index.tsx
@@ -37,31 +37,37 @@ export default function BattlegroupTab() {
   const [backupFiles, setBackupFiles] = useState<BackupFile[]>([])
   const [backupFilesLoading, setBackupFilesLoading] = useState(false)
 
-  const fetchStatus = useCallback(async () => {
-    setStatusLoading(true)
-    try {
-      const res = await api.battlegroup.status() as unknown as DetailedStatus
-      setStatus(res)
-    } catch (e: unknown) {
-      toast.danger(`Status failed: ${e instanceof Error ? e.message : String(e)}`)
-    } finally {
-      setStatusLoading(false)
-    }
+  const fetchStatus = useCallback(() => {
+    Promise.resolve()
+      .then(() => setStatusLoading(true))
+      .then(() => api.battlegroup.status() as Promise<unknown>)
+      .then(res => setStatus(res as DetailedStatus))
+      .catch((e: unknown) => toast.danger(`Status failed: ${e instanceof Error ? e.message : String(e)}`))
+      .finally(() => setStatusLoading(false))
   }, [])
 
   useEffect(() => { fetchStatus() }, [fetchStatus])
 
-  // Re-render when init-warning window expires
-  const [, forceRender] = useState(0)
+  // isInitializing tracks whether we're inside the post-start warning window.
+  // We use a boolean state rather than computing from Date.now() in render (impure).
+  const [isInitializing, setIsInitializing] = useState(false)
   useEffect(() => {
-    if (startedAt === null) return
+    if (startedAt === null) {
+      const t = setTimeout(() => setIsInitializing(false), 0)
+      return () => clearTimeout(t)
+    }
     const remaining = INIT_WARN_MS - (Date.now() - startedAt)
-    if (remaining <= 0) { setStartedAt(null); return }
-    const t = setTimeout(() => { setStartedAt(null); forceRender(n => n + 1) }, remaining)
-    return () => clearTimeout(t)
+    if (remaining <= 0) {
+      const t = setTimeout(() => setStartedAt(null), 0)
+      return () => clearTimeout(t)
+    }
+    const tStart = setTimeout(() => setIsInitializing(true), 0)
+    const tEnd = setTimeout(() => {
+      setStartedAt(null)
+      setIsInitializing(false)
+    }, remaining)
+    return () => { clearTimeout(tStart); clearTimeout(tEnd) }
   }, [startedAt])
-
-  const isInitializing = startedAt !== null && (Date.now() - startedAt) < INIT_WARN_MS
 
   const runCmd = async (action: ActionDef) => {
     setConfirmCmd(null)

--- a/web/src/tabs/BattlegroupTab/modals/ConfirmDialog.tsx
+++ b/web/src/tabs/BattlegroupTab/modals/ConfirmDialog.tsx
@@ -19,7 +19,7 @@ export function ConfirmDialog({ action, onConfirm, onClose }: Props) {
               <p className="text-foreground">{action?.msg ?? ''}</p>
             </Modal.Body>
             <Modal.Footer>
-              <Button variant="tertiary" onPress={onClose}>Cancel</Button>
+              <Button variant="tertiary" slot="close">Cancel</Button>
               <Button
                 variant={action?.danger ? 'danger' : 'primary'}
                 onPress={() => action && onConfirm(action)}

--- a/web/src/tabs/BlueprintsTab.tsx
+++ b/web/src/tabs/BlueprintsTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   Button,
   Label,
@@ -18,13 +18,13 @@ import { DataTable, Dropzone, Icon, PageHeader, type Column } from "../dune-ui";
 type Key = "id" | "owner_name" | "name" | "item_id" | "pieces" | "placeables" | "actions";
 
 const COLUMNS: Column<Key>[] = [
-  { key: "id",         label: "ID",         width: 80 },
-  { key: "owner_name", label: "Owner",      minWidth: 140 },
-  { key: "name",       label: "Name",       minWidth: 200 },
-  { key: "item_id",    label: "Item ID",    minWidth: 200 },
-  { key: "pieces",     label: "Pieces",     width: 100 },
+  { key: "id", label: "ID", width: 80 },
+  { key: "owner_name", label: "Owner", minWidth: 140 },
+  { key: "name", label: "Name", minWidth: 200 },
+  { key: "item_id", label: "Item ID", minWidth: 200 },
+  { key: "pieces", label: "Pieces", width: 100 },
   { key: "placeables", label: "Placeables", width: 110 },
-  { key: "actions",    label: "",           width: 110, sortable: false },
+  { key: "actions", label: "", width: 110, sortable: false },
 ];
 
 export default function BlueprintsTab({ isSignedIn = true }: { isSignedIn?: boolean }) {
@@ -32,25 +32,28 @@ export default function BlueprintsTab({ isSignedIn = true }: { isSignedIn?: bool
   const [loading, setLoading] = useState(false);
   const [showImport, setShowImport] = useState(false);
 
-  const load = async () => {
-    setLoading(true);
-    try {
-      setBlueprints(await api.blueprints.list());
-    } catch (e: unknown) {
-      toast.danger(`Failed to load blueprints: ${e instanceof Error ? e.message : String(e)}`);
-    } finally {
-      setLoading(false);
-    }
-  };
+  const load = useCallback(() => {
+    Promise.resolve()
+      .then(() => setLoading(true))
+      .then(() => api.blueprints.list())
+      .then(setBlueprints)
+      .catch((e: unknown) => toast.danger(`Failed to load blueprints: ${e instanceof Error ? e.message : String(e)}`))
+      .finally(() => setLoading(false));
+  }, []);
 
-  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    load();
+  }, [load]);
 
   return (
     <div className="flex flex-col h-full gap-3 min-h-0">
       {!isSignedIn && (
         <div className="shrink-0 rounded-[var(--radius)] px-4 py-2 text-xs font-medium bg-danger/10 border border-danger/40 text-danger flex items-center gap-2">
           <Icon name="triangle-alert" />
-          <span>A <strong>Layout Tools</strong> account is required to export or import blueprints. Sign in using the button in the top right.</span>
+          <span>
+            A <strong>Layout Tools</strong> account is required to export or import blueprints. Sign in using the button
+            in the top right.
+          </span>
         </div>
       )}
 
@@ -59,7 +62,13 @@ export default function BlueprintsTab({ isSignedIn = true }: { isSignedIn?: bool
         subtitle="Manage saved base blueprints. Export or import player constructions."
       >
         <Button size="sm" variant="ghost" onPress={load} isDisabled={loading}>
-          {loading ? <Spinner size="sm" color="current" /> : <><Icon name="refresh-cw" /> Refresh</>}
+          {loading ? (
+            <Spinner size="sm" color="current" />
+          ) : (
+            <>
+              <Icon name="refresh-cw" /> Refresh
+            </>
+          )}
         </Button>
         <Button size="sm" onPress={() => setShowImport(true)} isDisabled={!isSignedIn}>
           <Icon name="upload" /> Import Blueprint
@@ -82,12 +91,18 @@ export default function BlueprintsTab({ isSignedIn = true }: { isSignedIn?: bool
           emptyState={<div className="py-8 text-center text-muted">No blueprints found.</div>}
           renderCell={(b, key) => {
             switch (key) {
-              case "id":         return <span className="font-mono text-muted">{b.id}</span>;
-              case "owner_name": return b.owner_name;
-              case "name":       return b.name || <span className="text-muted">—</span>;
-              case "item_id":    return <span className="font-mono text-muted">{b.item_id}</span>;
-              case "pieces":     return <span className="text-muted">{b.pieces}</span>;
-              case "placeables": return <span className="text-muted">{b.placeables}</span>;
+              case "id":
+                return <span className="font-mono text-muted">{b.id}</span>;
+              case "owner_name":
+                return b.owner_name;
+              case "name":
+                return b.name || <span className="text-muted">—</span>;
+              case "item_id":
+                return <span className="font-mono text-muted">{b.item_id}</span>;
+              case "pieces":
+                return <span className="text-muted">{b.pieces}</span>;
+              case "placeables":
+                return <span className="text-muted">{b.placeables}</span>;
               case "actions":
                 return isSignedIn ? (
                   <a
@@ -111,7 +126,10 @@ export default function BlueprintsTab({ isSignedIn = true }: { isSignedIn?: bool
       <ImportModal
         open={showImport}
         onClose={() => setShowImport(false)}
-        onSuccess={() => { setShowImport(false); load(); }}
+        onSuccess={() => {
+          setShowImport(false);
+          load();
+        }}
       />
     </div>
   );
@@ -125,16 +143,27 @@ function ImportModal({ open, onClose, onSuccess }: { open: boolean; onClose: () 
 
   useEffect(() => {
     if (!open) return;
-    setFile(null);
-    setSelectedPlayerId(null);
-    api.players.list().then(setPlayers).catch(() => {});
+    Promise.resolve()
+      .then(() => {
+        setFile(null);
+        setSelectedPlayerId(null);
+      })
+      .then(() => api.players.list())
+      .then(setPlayers)
+      .catch(() => {});
   }, [open]);
 
   const selectedPlayer = players.find((p) => p.id === selectedPlayerId) ?? null;
 
   const handleSubmit = async () => {
-    if (!file) { toast.warning("Select a blueprint file"); return; }
-    if (!selectedPlayer) { toast.warning("Select a player"); return; }
+    if (!file) {
+      toast.warning("Select a blueprint file");
+      return;
+    }
+    if (!selectedPlayer) {
+      toast.warning("Select a player");
+      return;
+    }
     setSubmitting(true);
     try {
       const res = await api.blueprints.import(file, selectedPlayer.id);
@@ -208,7 +237,9 @@ function ImportModal({ open, onClose, onSuccess }: { open: boolean; onClose: () 
               </TextField>
             </Modal.Body>
             <Modal.Footer>
-              <Button variant="tertiary" onPress={onClose}>Cancel</Button>
+              <Button variant="tertiary" slot="close">
+                Cancel
+              </Button>
               <Button onPress={handleSubmit} isDisabled={submitting || !file || !selectedPlayer}>
                 {submitting ? <Spinner size="sm" color="current" /> : <Icon name="upload" />}
                 Import

--- a/web/src/tabs/LogsTab.tsx
+++ b/web/src/tabs/LogsTab.tsx
@@ -39,15 +39,16 @@ export default function LogsTab() {
   const flushTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const logContainerRef = useRef<HTMLPreElement | null>(null)
 
-  const loadPods = () => {
-    setPodsLoading(true)
-    api.logs.pods()
+  const loadPods = useCallback(() => {
+    Promise.resolve()
+      .then(() => setPodsLoading(true))
+      .then(() => api.logs.pods())
       .then(setPods)
       .catch((e: unknown) => toast.danger(`Failed to load pods: ${e instanceof Error ? e.message : String(e)}`))
       .finally(() => setPodsLoading(false))
-  }
+  }, [])
 
-  useEffect(() => { loadPods() }, [])
+  useEffect(() => { loadPods() }, [loadPods])
 
   const startFlush = useCallback(() => {
     if (flushTimerRef.current) return
@@ -198,13 +199,14 @@ export default function LogsTab() {
                   switch (key) {
                     case 'time':      return <span className="font-mono text-muted">{c.event_time}</span>
                     case 'character': return c.character_name
-                    case 'cheat_type':
+                    case 'cheat_type': {
                       const suspicious = /dup|negative/i.test(c.cheat_type)
                       return (
                         <Chip size="sm" color={suspicious ? 'danger' : 'default'} variant="soft">
                           {c.cheat_type}
                         </Chip>
                       )
+                    }
                   }
                 }}
               />

--- a/web/src/tabs/MarketTab/ItemDetail.tsx
+++ b/web/src/tabs/MarketTab/ItemDetail.tsx
@@ -41,17 +41,16 @@ export default function ItemDetail({ item, onClose }: Props) {
 
   useEffect(() => {
     if (!item) return
-    setListings([])
-    setEntry(null)
-    setLoading(true)
-    Promise.all([
-      api.market.listings(item.template_id),
-      getItemEntry(item.template_id),
-    ])
+    Promise.resolve()
+      .then(() => { setListings([]); setEntry(null); setLoading(true) })
+      .then(() => Promise.all([
+        api.market.listings(item.template_id),
+        getItemEntry(item.template_id),
+      ]))
       .then(([ls, e]) => { setListings(ls); setEntry(e) })
       .catch(() => {})
       .finally(() => setLoading(false))
-  }, [item?.template_id])
+  }, [item])
 
   if (!item) return null
 

--- a/web/src/tabs/MarketTab/MarketSearch.tsx
+++ b/web/src/tabs/MarketTab/MarketSearch.tsx
@@ -18,7 +18,10 @@ export default function MarketSearch({ filters, onChange, onReset }: Props) {
   const [searchDraft, setSearchDraft] = useState(filters.search)
 
   // Sync draft when filters are reset externally.
-  useEffect(() => { setSearchDraft(filters.search) }, [filters.search])
+  useEffect(() => {
+    const t = setTimeout(() => setSearchDraft(filters.search), 0)
+    return () => clearTimeout(t)
+  }, [filters.search])
 
   // Debounce: commit search text 350ms after the user stops typing.
   useEffect(() => {

--- a/web/src/tabs/MarketTab/bot/BotConfigEditor.tsx
+++ b/web/src/tabs/MarketTab/bot/BotConfigEditor.tsx
@@ -1,16 +1,32 @@
-import { useState } from 'react'
-import { Button, Spinner, toast } from '@heroui/react'
+import { useState, forwardRef, useImperativeHandle } from 'react'
+import { toast } from '@heroui/react'
 import { api } from '../../../api/client'
 import type { BotConfig } from '../../../api/client'
+import { Panel, SectionLabel } from '../../../dune-ui'
+
+export type ConfigEditorHandle = {
+  save: () => Promise<void>
+  reset: () => void
+  getEnabled: () => boolean
+  setEnabled: (v: boolean) => void
+}
 
 type Props = {
   config: BotConfig
   onSaved: (cfg: BotConfig) => void
 }
 
-export default function BotConfigEditor({ config, onSaved }: Props) {
+function thresholdToPercent(t: number): number {
+  return Math.round(t * 100)
+}
+
+function percentToThreshold(p: number): number {
+  return Math.round(p) / 100
+}
+
+const BotConfigEditor = forwardRef<ConfigEditorHandle, Props>(function BotConfigEditor({ config, onSaved }, ref) {
   const [draft, setDraft] = useState<BotConfig>(config)
-  const [saving, setSaving] = useState(false)
+  const [buyPct, setBuyPct] = useState<number>(thresholdToPercent(config.buy_threshold))
 
   const set = <K extends keyof BotConfig>(key: K, val: BotConfig[K]) => {
     setDraft(d => ({ ...d, [key]: val }))
@@ -32,25 +48,30 @@ export default function BotConfigEditor({ config, onSaved }: Props) {
     })
   }
 
-  const save = async () => {
-    setSaving(true)
-    try {
-      const saved = await api.marketBot.saveConfig(draft)
+  useImperativeHandle(ref, () => ({
+    save: async () => {
+      const payload: BotConfig = { ...draft, buy_threshold: percentToThreshold(buyPct) }
+      const saved = await api.marketBot.saveConfig(payload)
+      setBuyPct(thresholdToPercent(saved.buy_threshold))
       onSaved(saved)
       toast.success('Config saved — changes apply on next tick')
-    } catch (e: unknown) {
-      toast.danger(`Save failed: ${e instanceof Error ? e.message : String(e)}`)
-    } finally {
-      setSaving(false)
-    }
-  }
+    },
+    reset: () => {
+      setDraft(config)
+      setBuyPct(thresholdToPercent(config.buy_threshold))
+    },
+    getEnabled: () => draft.enabled,
+    setEnabled: (v: boolean) => set('enabled', v),
+  }), [draft, buyPct, config, onSaved])
 
   const GRADE_LABELS = ['Standard', 'Refined', 'Superior', 'Masterwork', 'Pristine', 'Flawless']
 
   return (
-    <div className="flex flex-col gap-5">
-      <Section label="Tick Intervals">
-        <div className="grid grid-cols-2 gap-3">
+    <div className="flex flex-col gap-4 pr-1">
+
+      <Panel>
+        <SectionLabel>Tick Intervals</SectionLabel>
+        <div className="grid grid-cols-2 gap-3 mt-1">
           <Field label="List tick interval" hint="e.g. 30m, 1h">
             <input
               className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-foreground w-full"
@@ -66,10 +87,12 @@ export default function BotConfigEditor({ config, onSaved }: Props) {
             />
           </Field>
         </div>
-      </Section>
+      </Panel>
 
-      <Section label="Limits">
-        <div className="grid grid-cols-3 gap-3">
+      <Panel>
+        <SectionLabel>Limits</SectionLabel>
+        <p className="text-xs text-muted -mt-1">Controls how many items the bot buys and lists each tick.</p>
+        <div className="grid grid-cols-3 gap-3 mt-1">
           <Field label="Max buys per tick">
             <input
               className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-foreground w-full"
@@ -78,7 +101,7 @@ export default function BotConfigEditor({ config, onSaved }: Props) {
               onChange={e => set('max_buys', Number(e.target.value))}
             />
           </Field>
-          <Field label="Listings per grade">
+          <Field label="Listings per grade" hint="per item per quality level">
             <input
               className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-foreground w-full"
               type="number"
@@ -86,91 +109,87 @@ export default function BotConfigEditor({ config, onSaved }: Props) {
               onChange={e => set('listings_per_grade', Number(e.target.value))}
             />
           </Field>
-          <Field label="Buy threshold" hint="1.05 = 5% below market">
-            <input
-              className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-foreground w-full"
-              type="number"
-              step="0.01"
-              value={draft.buy_threshold}
-              onChange={e => set('buy_threshold', Number(e.target.value))}
-            />
+          <Field label="Buy threshold" hint={`${buyPct}% of bot's reference price`}>
+            <div className="flex items-center gap-2">
+              <input
+                className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-foreground w-20"
+                type="number" min={1} max={200} step={1}
+                value={buyPct}
+                onChange={e => setBuyPct(Number(e.target.value))}
+              />
+              <span className="text-sm text-muted">%</span>
+            </div>
           </Field>
         </div>
-      </Section>
-
-      <Section label="Rarity Multipliers">
-        <div className="flex flex-wrap gap-3">
-          {Object.entries(draft.rarity_multipliers ?? {}).map(([rarity, mult]) => (
-            <Field key={rarity} label={rarity}>
-              <input
-                className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-foreground w-24"
-                type="number" step="0.1" value={mult}
-                onChange={e => setRarity(rarity, Number(e.target.value))}
-              />
-            </Field>
-          ))}
+        <div className="flex flex-col gap-0.5 mt-1">
+          <p className="text-xs text-muted">
+            <strong>Buy threshold:</strong> buys a listing only when its price is at or below this % of the bot's reference price.
+            100% = match or below · 70% = 30%+ discount required · 110% = up to 10% above bot price.
+          </p>
+          <p className="text-xs text-muted">
+            <strong>Listings per grade:</strong> active listings maintained per item per quality grade (0 = Standard … 5 = Flawless).
+            Stackables use grade 0 only. Example: 5 × 6 grades = up to 30 listings per gradeable item.
+          </p>
         </div>
-      </Section>
+      </Panel>
 
-      {draft.vendor_multipliers && Object.keys(draft.vendor_multipliers ?? {}).length > 0 && (
-        <Section label="Vendor Multipliers">
-          <div className="flex flex-wrap gap-3">
-            {Object.entries(draft.vendor_multipliers ?? {}).map(([rarity, mult]) => (
-              <Field key={rarity} label={rarity}>
-                <input
-                  className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-foreground w-24"
-                  type="number" step="0.1" value={mult}
-                  onChange={e => setVendor(rarity, Number(e.target.value))}
-                />
-              </Field>
-            ))}
-          </div>
-        </Section>
-      )}
-
-      <Section label="Grade Multipliers">
-        <div className="flex flex-wrap gap-3">
+      <Panel>
+        <SectionLabel>Grade Multipliers</SectionLabel>
+        <p className="text-xs text-muted -mt-1">Scales the listing price by quality grade. Grade 0 (Standard) is the base and should stay at 1.0.</p>
+        <div className="flex flex-wrap gap-3 mt-1">
           {(draft.grade_multipliers ?? []).map((mult, i) => (
-            <Field key={i} label={GRADE_LABELS[i] ?? `Grade ${i}`}>
+            <Field key={i} label={GRADE_LABELS[i] ?? `Grade ${i}`} hint={`×${mult.toFixed(2)}`}>
               <input
                 className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-foreground w-24"
-                type="number" step="0.01" value={mult}
+                type="number" step="0.05" min="0.01" value={mult}
                 onChange={e => setGrade(i, Number(e.target.value))}
               />
             </Field>
           ))}
         </div>
-      </Section>
+      </Panel>
 
-      <div className="flex items-center gap-3 pt-1">
-        <Button size="sm" onPress={save} isDisabled={saving}>
-          {saving ? <Spinner size="sm" color="current" /> : null}
-          Save Config
-        </Button>
-        <Button size="sm" variant="ghost" onPress={() => setDraft(config)}>
-          Reset
-        </Button>
-        <label className="flex items-center gap-2 text-sm cursor-pointer select-none ml-2">
-          <input
-            type="checkbox"
-            checked={draft.enabled}
-            onChange={e => set('enabled', e.target.checked)}
-            className="accent-[var(--color-accent)]"
-          />
-          Ticking enabled
-        </label>
-      </div>
+      <Panel>
+        <SectionLabel>Rarity Multipliers</SectionLabel>
+        <p className="text-xs text-muted -mt-1">Extra multiplier on top of the base price for non-common items. Stacks with grade multipliers.</p>
+        <div className="flex flex-wrap gap-3 mt-1">
+          {Object.entries(draft.rarity_multipliers ?? {}).map(([rarity, mult]) => (
+            <Field key={rarity} label={capitalize(rarity)} hint={`×${(mult as number).toFixed(2)}`}>
+              <input
+                className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-foreground w-24"
+                type="number" step="0.1" min="0.01" value={mult}
+                onChange={e => setRarity(rarity, Number(e.target.value))}
+              />
+            </Field>
+          ))}
+        </div>
+      </Panel>
+
+      {draft.vendor_multipliers && Object.keys(draft.vendor_multipliers ?? {}).length > 0 && (
+        <Panel>
+          <SectionLabel>Vendor Multipliers</SectionLabel>
+          <p className="text-xs text-muted -mt-1">Multiplier for vendor-priced items (fixed NPC purchase cost). Separate from rarity multipliers.</p>
+          <div className="flex flex-wrap gap-3 mt-1">
+            {Object.entries(draft.vendor_multipliers ?? {}).map(([rarity, mult]) => (
+              <Field key={rarity} label={capitalize(rarity)} hint={`×${(mult as number).toFixed(2)}`}>
+                <input
+                  className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-foreground w-24"
+                  type="number" step="0.1" min="0.01" value={mult}
+                  onChange={e => setVendor(rarity, Number(e.target.value))}
+                />
+              </Field>
+            ))}
+          </div>
+        </Panel>
+      )}
     </div>
   )
-}
+})
 
-function Section({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="flex flex-col gap-2">
-      <span className="text-xs font-semibold text-muted uppercase tracking-wider">{label}</span>
-      {children}
-    </div>
-  )
+export default BotConfigEditor
+
+function capitalize(s: string) {
+  return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
 function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {

--- a/web/src/tabs/MarketTab/bot/BotControlPanel.tsx
+++ b/web/src/tabs/MarketTab/bot/BotControlPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { Button, Modal, Spinner, Tabs } from '@heroui/react'
 import { api } from '../../../api/client'
 import type { BotStatus, BotConfig } from '../../../api/client'
@@ -6,7 +6,7 @@ import { Icon } from '../../../dune-ui'
 import BotStatusCard from './BotStatusCard'
 import BotActions from './BotActions'
 import BotLogViewer from './BotLogViewer'
-import BotConfigEditor from './BotConfigEditor'
+import BotConfigEditor, { type ConfigEditorHandle } from './BotConfigEditor'
 import DisabledItemsManager from './DisabledItemsManager'
 
 type Props = {
@@ -21,28 +21,24 @@ export default function BotControlPanel({ open, onClose }: Props) {
   const [configLoading, setConfigLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState('config')
+  const editorRef = useRef<ConfigEditorHandle>(null)
 
-  const loadStatus = useCallback(async () => {
-    setStatusLoading(true)
-    try {
-      setStatus(await api.marketBot.status())
-      setError(null)
-    } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : String(e))
-    } finally {
-      setStatusLoading(false)
-    }
+  const loadStatus = useCallback(() => {
+    Promise.resolve()
+      .then(() => setStatusLoading(true))
+      .then(() => api.marketBot.status())
+      .then(s => { setStatus(s); setError(null) })
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setStatusLoading(false))
   }, [])
 
-  const loadConfig = useCallback(async () => {
-    setConfigLoading(true)
-    try {
-      setConfig(await api.marketBot.config())
-    } catch {
-      // config load failure is non-fatal
-    } finally {
-      setConfigLoading(false)
-    }
+  const loadConfig = useCallback(() => {
+    Promise.resolve()
+      .then(() => setConfigLoading(true))
+      .then(() => api.marketBot.config())
+      .then(setConfig)
+      .catch(() => { /* config load failure is non-fatal */ })
+      .finally(() => setConfigLoading(false))
   }, [])
 
   useEffect(() => {
@@ -55,34 +51,29 @@ export default function BotControlPanel({ open, onClose }: Props) {
   return (
     <Modal>
       <Modal.Backdrop isOpen={open} onOpenChange={v => !v && onClose()}>
-        <Modal.Container size="cover">
+        <Modal.Container size="cover" scroll="outside">
           <Modal.Dialog className="h-[92vh] flex flex-col dialog-surface-alt">
             <Modal.CloseTrigger />
             <Modal.Header>
-              <div className="flex items-center justify-between w-full pr-8">
-                <Modal.Heading>Bot Control — Revy</Modal.Heading>
-                <Button size="sm" variant="ghost" onPress={() => { loadStatus(); loadConfig() }} isDisabled={statusLoading}>
-                  {statusLoading ? <Spinner size="sm" color="current" /> : <Icon name="refresh-cw" />}
-                </Button>
-              </div>
+              <Modal.Heading>Bot Control — Revy</Modal.Heading>
             </Modal.Header>
 
-            <Modal.Body className="flex flex-col gap-4 overflow-y-auto flex-1">
+            <Modal.Body className="flex flex-col gap-4 overflow-y-auto flex-1 pr-1 min-h-0">
               {/* Status + actions */}
               {error ? (
                 <p className="text-xs text-danger">{error}</p>
               ) : status ? (
-                <div className="flex flex-wrap items-start gap-4 justify-between pb-2 border-b border-border">
+                <div className="flex flex-wrap items-start gap-4 justify-between pb-2 border-b border-border shrink-0">
                   <BotStatusCard status={status} />
                   <BotActions status={status} onRefresh={loadStatus} />
                 </div>
               ) : statusLoading ? (
-                <div className="flex justify-center py-4"><Spinner size="sm" /></div>
+                <div className="flex justify-center py-4 shrink-0"><Spinner size="sm" /></div>
               ) : null}
 
-              {/* Tabs */}
-              <Tabs selectedKey={activeTab} onSelectionChange={k => setActiveTab(String(k))}>
-                <Tabs.ListContainer>
+              {/* Tabs — flex-1 so logs panel can fill the remaining height */}
+              <Tabs selectedKey={activeTab} onSelectionChange={k => setActiveTab(String(k))} className="flex flex-col flex-1 min-h-0">
+                <Tabs.ListContainer className="shrink-0">
                   <Tabs.List aria-label="Bot sections">
                     <Tabs.Tab id="config">Config<Tabs.Indicator /></Tabs.Tab>
                     <Tabs.Tab id="disabled">Disabled Items<Tabs.Indicator /></Tabs.Tab>
@@ -90,17 +81,17 @@ export default function BotControlPanel({ open, onClose }: Props) {
                   </Tabs.List>
                 </Tabs.ListContainer>
 
-                <Tabs.Panel id="config" className="pt-4">
+                <Tabs.Panel id="config" className="pt-4 overflow-y-auto flex-1 pr-1">
                   {configLoading ? (
                     <div className="flex justify-center py-6"><Spinner size="sm" /></div>
                   ) : config ? (
-                    <BotConfigEditor config={config} onSaved={setConfig} />
+                    <BotConfigEditor ref={editorRef} config={config} onSaved={setConfig} />
                   ) : (
                     <p className="text-xs text-muted">Config unavailable.</p>
                   )}
                 </Tabs.Panel>
 
-                <Tabs.Panel id="disabled" className="pt-4">
+                <Tabs.Panel id="disabled" className="pt-4 overflow-y-auto flex-1 pr-1">
                   {configLoading ? (
                     <div className="flex justify-center py-6"><Spinner size="sm" /></div>
                   ) : config ? (
@@ -110,14 +101,70 @@ export default function BotControlPanel({ open, onClose }: Props) {
                   )}
                 </Tabs.Panel>
 
-                <Tabs.Panel id="logs" className="pt-4 flex-1 min-h-0 flex flex-col">
+                <Tabs.Panel id="logs" className="pt-4 flex-1 min-h-0 flex flex-col overflow-hidden">
                   <BotLogViewer active={activeTab === 'logs'} />
                 </Tabs.Panel>
               </Tabs>
             </Modal.Body>
+
+            {/* Static config footer — only shown on the config tab */}
+            {activeTab === 'config' && config && !configLoading && (
+              <ConfigFooter editorRef={editorRef} initialEnabled={config.enabled} onReload={loadConfig} />
+            )}
           </Modal.Dialog>
         </Modal.Container>
       </Modal.Backdrop>
     </Modal>
+  )
+}
+
+function ConfigFooter({ editorRef, initialEnabled, onReload }: { editorRef: React.RefObject<ConfigEditorHandle | null>; initialEnabled: boolean; onReload: () => void }) {
+  const [saving, setSaving] = useState(false)
+  const [reloading, setReloading] = useState(false)
+  const [enabled, setEnabledLocal] = useState(initialEnabled)
+
+  return (
+    <div className="shrink-0 flex items-center gap-3 px-4 py-3 border-t border-border">
+      <label className="flex items-center gap-2 text-sm cursor-pointer select-none mr-auto">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={e => {
+            setEnabledLocal(e.target.checked)
+            editorRef.current?.setEnabled(e.target.checked)
+          }}
+          className="accent-[var(--color-accent)]"
+        />
+        Ticking enabled
+      </label>
+      <Button size="sm" variant="ghost" onPress={() => editorRef.current?.reset()}>
+        Reset
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        isDisabled={reloading}
+        onPress={() => {
+          setReloading(true)
+          Promise.resolve().then(onReload).finally(() => setReloading(false))
+        }}
+      >
+        {reloading ? <Spinner size="sm" color="current" /> : <Icon name="refresh-cw" />}
+        Reload Config
+      </Button>
+      <Button
+        size="sm"
+        isDisabled={saving}
+        onPress={() => {
+          setSaving(true)
+          editorRef.current?.save()
+            .catch(() => { /* toast shown inside save */ })
+            .finally(() => setSaving(false))
+        }}
+      >
+        {saving ? <Spinner size="sm" color="current" /> : null}
+        Save Config
+      </Button>
+    </div>
   )
 }

--- a/web/src/tabs/MarketTab/bot/BotLogViewer.tsx
+++ b/web/src/tabs/MarketTab/bot/BotLogViewer.tsx
@@ -42,65 +42,55 @@ export default function BotLogViewer({ active = false }: Props) {
     if (timerRef.current) { clearInterval(timerRef.current); timerRef.current = null }
   }, [])
 
-  const connect = useCallback(async () => {
+  const connect = useCallback(() => {
     if (wsRef.current) { wsRef.current.close(); wsRef.current = null }
     stopFlush()
     bufRef.current = []
-    setLines([])
-    setError(null)
-    setConnState('connecting')
-
-    try {
-      const check = await api.marketBot.logsReady()
-      if (!check.ready) {
-        setError(check.reason ?? 'Log streaming not available')
-        setConnState('error')
-        return
-      }
-    } catch {
-      setError('Could not reach backend — check that it is running.')
-      setConnState('error')
-      return
-    }
-
-    const ws = new WebSocket(`${getWsBase()}/market-bot/logs`)
-    wsRef.current = ws
-
-    ws.onopen = () => { setConnState('connected'); startFlush() }
-
-    ws.onmessage = (e: MessageEvent) => { bufRef.current.push(e.data as string) }
-
-    ws.onerror = () => {
-      setError('WebSocket connection failed — the log stream was interrupted.')
-      setConnState('error')
-    }
-
-    ws.onclose = (e) => {
-      stopFlush()
-      if (bufRef.current.length > 0) {
-        setLines(prev => [...prev, ...bufRef.current])
-        bufRef.current = []
-      }
-      if (connState !== 'error') {
-        if (e.code !== 1000 && e.code !== 1001) {
-          setError(`Connection closed (code ${e.code})${e.reason ? ': ' + e.reason : ''}`)
+    Promise.resolve()
+      .then(() => { setLines([]); setError(null); setConnState('connecting') })
+      .then(() => api.marketBot.logsReady())
+      .then(check => {
+        if (!check.ready) {
+          setError(check.reason ?? 'Log streaming not available')
           setConnState('error')
-        } else {
-          setConnState('idle')
+          return
         }
-      }
-    }
-  }, [startFlush, stopFlush, connState])
+        const ws = new WebSocket(`${getWsBase()}/market-bot/logs`)
+        wsRef.current = ws
+        ws.onopen = () => { setConnState('connected'); startFlush() }
+        ws.onmessage = (e: MessageEvent) => { bufRef.current.push(e.data as string) }
+        ws.onerror = () => {
+          setError('WebSocket connection failed — the log stream was interrupted.')
+          setConnState('error')
+        }
+        ws.onclose = (e) => {
+          stopFlush()
+          if (bufRef.current.length > 0) {
+            setLines(prev => [...prev, ...bufRef.current])
+            bufRef.current = []
+          }
+          if (e.code !== 1000 && e.code !== 1001) {
+            setError(`Connection closed (code ${e.code})${e.reason ? ': ' + e.reason : ''}`)
+            setConnState('error')
+          } else {
+            setConnState('idle')
+          }
+        }
+      })
+      .catch(() => {
+        setError('Could not reach backend — check that it is running.')
+        setConnState('error')
+      })
+  }, [startFlush, stopFlush])
 
   const disconnect = useCallback(() => {
     if (wsRef.current) { wsRef.current.close(1000); wsRef.current = null }
     stopFlush()
-    setConnState('idle')
-    setError(null)
+    Promise.resolve().then(() => { setConnState('idle'); setError(null) })
   }, [stopFlush])
 
   useEffect(() => {
-    if (active) connect()
+    if (active) void connect()
     else disconnect()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active])
@@ -151,7 +141,7 @@ export default function BotLogViewer({ active = false }: Props) {
 
       <pre
         ref={containerRef}
-        className="flex-1 overflow-auto p-3 text-xs font-mono m-0 whitespace-pre-wrap break-all rounded-[var(--radius)] border border-border/60 bg-background text-success min-h-[200px]"
+        className="flex-1 overflow-auto p-3 text-xs font-mono m-0 whitespace-pre-wrap break-all rounded-[var(--radius)] border border-border/60 bg-background text-success"
       >
         {lines.length === 0
           ? (connState === 'connected' ? 'Waiting for log lines…' : connState === 'connecting' ? 'Connecting…' : '')

--- a/web/src/tabs/MarketTab/bot/DisabledItemsManager.tsx
+++ b/web/src/tabs/MarketTab/bot/DisabledItemsManager.tsx
@@ -27,7 +27,7 @@ export default function DisabledItemsManager({ config, onSaved }: Props) {
     api.market.catalog().then(setCatalog).catch(() => {})
   }, [])
 
-  const safeItems = config.disabled_items ?? []
+  const safeItems = useMemo(() => config.disabled_items ?? [], [config.disabled_items])
 
   const results = useMemo(() => {
     const q = search.trim().toLowerCase()

--- a/web/src/tabs/MarketTab/index.tsx
+++ b/web/src/tabs/MarketTab/index.tsx
@@ -1,88 +1,106 @@
-import { useState, useEffect, useCallback } from 'react'
-import { Button, Spinner } from '@heroui/react'
-import { api } from '../../api/client'
-import type { MarketItem } from '../../api/client'
-import { Icon, PageHeader } from '../../dune-ui'
-import MarketSidebar from './MarketSidebar'
-import MarketSearch, { type MarketFilters } from './MarketSearch'
-import MarketTable from './MarketTable'
-import MarketGrid from './MarketGrid'
-import ViewToggle, { type MarketView } from './ViewToggle'
-import ItemDetail from './ItemDetail'
-import BotControlPanel from './bot/BotControlPanel'
+import { useState, useEffect, useCallback } from "react";
+import { Button, Spinner } from "@heroui/react";
+import { api } from "../../api/client";
+import type { MarketItem } from "../../api/client";
+import { Icon, PageHeader } from "../../dune-ui";
+import MarketSidebar from "./MarketSidebar";
+import MarketSearch, { type MarketFilters } from "./MarketSearch";
+import MarketTable from "./MarketTable";
+import MarketGrid from "./MarketGrid";
+import ViewToggle, { type MarketView } from "./ViewToggle";
+import ItemDetail from "./ItemDetail";
+import BotControlPanel from "./bot/BotControlPanel";
 
-const DEFAULT_FILTERS: MarketFilters = { search: '', category: '', owner: '' }
+const DEFAULT_FILTERS: MarketFilters = { search: "", category: "", owner: "" };
 
-export default function MarketTab({ isSignedIn = true }: { isSignedIn?: boolean }) {
-  const [items, setItems] = useState<MarketItem[]>([])
-  const [categories, setCategories] = useState<string[]>([])
-  const [loading, setLoading] = useState(false)
-  const [filters, setFilters] = useState<MarketFilters>(DEFAULT_FILTERS)
-  const [selected, setSelected] = useState<MarketItem | null>(null)
-  const [view, setView] = useState<MarketView>('table')
-  const [botOpen, setBotOpen] = useState(false)
+// Set VITE_MARKET_BOT_ENABLED=true at build time to show the Bot Control button.
+// When absent (local dev, CDN deploy without a bot) the button is hidden entirely.
+const botEnabled = !!(import.meta.env.VITE_MARKET_BOT_ENABLED as string | undefined);
 
-  const load = useCallback(async () => {
-    setLoading(true)
-    try {
-      const [res, cats] = await Promise.all([
-        api.market.items({
-          search: filters.search || undefined,
-          category: filters.category || undefined,
-          owner: filters.owner || undefined,
-        }),
-        categories.length === 0 ? api.market.categories() : Promise.resolve(categories),
-      ])
-      setItems(res.items)
-      if (categories.length === 0) setCategories(cats)
-    } catch {
-      // errors surface via empty state
-    } finally {
-      setLoading(false)
-    }
-  }, [filters])
+export default function MarketTab() {
+  const [items, setItems] = useState<MarketItem[]>([]);
+  const [categories, setCategories] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [filters, setFilters] = useState<MarketFilters>(DEFAULT_FILTERS);
+  const [selected, setSelected] = useState<MarketItem | null>(null);
+  const [view, setView] = useState<MarketView>("table");
+  const [botOpen, setBotOpen] = useState(false);
 
-  useEffect(() => { load() }, [load])
+  const load = useCallback(() => {
+    Promise.resolve()
+      .then(() => setLoading(true))
+      .then(() =>
+        Promise.all([
+          api.market.items({
+            search: filters.search || undefined,
+            category: filters.category || undefined,
+            owner: filters.owner || undefined,
+          }),
+          categories.length === 0 ? api.market.categories() : Promise.resolve(categories),
+        ]),
+      )
+      .then(([res, cats]) => {
+        setItems(res.items);
+        if (categories.length === 0) setCategories(cats);
+      })
+      .catch(() => {
+        /* errors surface via empty state */
+      })
+      .finally(() => setLoading(false));
+  }, [filters, categories]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
 
   const handleFiltersChange = (f: MarketFilters) => {
-    setFilters(f)
-    if (selected && f.category !== filters.category) setSelected(null)
-  }
+    setFilters(f);
+    if (selected && f.category !== filters.category) setSelected(null);
+  };
 
   const handleCategorySelect = (cat: string) => {
-    setFilters(f => ({ ...f, category: cat }))
-    setSelected(null)
-  }
+    setFilters((f) => ({ ...f, category: cat }));
+    setSelected(null);
+  };
 
   return (
     <div className="flex flex-col h-full gap-3 min-h-0">
       <PageHeader title="Market Board" subtitle="Browse active exchange listings from bot and player sellers.">
-        <Button size="sm" variant="ghost" onPress={() => setBotOpen(true)} isDisabled={!isSignedIn}>
-          <Icon name="bot" /> Bot Control
-        </Button>
+        {botEnabled && (
+          <Button size="sm" variant="ghost" onPress={() => setBotOpen(true)}>
+            <Icon name="bot" /> Bot Control
+          </Button>
+        )}
         <ViewToggle view={view} onChange={setView} />
         <Button size="sm" variant="ghost" onPress={load} isDisabled={loading}>
-          {loading ? <Spinner size="sm" color="current" /> : <><Icon name="refresh-cw" /> Refresh</>}
+          {loading ? (
+            <Spinner size="sm" color="current" />
+          ) : (
+            <>
+              <Icon name="refresh-cw" /> Refresh
+            </>
+          )}
         </Button>
       </PageHeader>
 
       <MarketSearch
         filters={filters}
         onChange={handleFiltersChange}
-        onReset={() => { setFilters(DEFAULT_FILTERS); setSelected(null) }}
+        onReset={() => {
+          setFilters(DEFAULT_FILTERS);
+          setSelected(null);
+        }}
       />
 
       <div className="flex flex-1 gap-3 min-h-0 overflow-hidden">
-        <MarketSidebar
-          categories={categories}
-          selected={filters.category}
-          onSelect={handleCategorySelect}
-        />
+        <MarketSidebar categories={categories} selected={filters.category} onSelect={handleCategorySelect} />
 
         <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
           {loading ? (
-            <div className="flex flex-1 justify-center py-12"><Spinner size="lg" /></div>
-          ) : view === 'grid' ? (
+            <div className="flex flex-1 justify-center py-12">
+              <Spinner size="lg" />
+            </div>
+          ) : view === "grid" ? (
             <MarketGrid items={items} onSelect={setSelected} />
           ) : (
             <MarketTable items={items} onSelect={setSelected} />
@@ -94,5 +112,5 @@ export default function MarketTab({ isSignedIn = true }: { isSignedIn?: boolean 
 
       <BotControlPanel open={botOpen} onClose={() => setBotOpen(false)} />
     </div>
-  )
+  );
 }

--- a/web/src/tabs/PlayersTab/index.tsx
+++ b/web/src/tabs/PlayersTab/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { toast } from '@heroui/react'
 import { api } from '../../api/client'
 import type {
@@ -36,18 +36,16 @@ export default function PlayersTab() {
   const [showGiveItems, setShowGiveItems] = useState(false)
   const [showActions, setShowActions] = useState(false)
 
-  useEffect(() => { loadPlayers() }, [])
+  const loadPlayers = useCallback(() => {
+    Promise.resolve()
+      .then(() => setLoading(true))
+      .then(() => api.players.list())
+      .then(setPlayers)
+      .catch((e: unknown) => toast.danger(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoading(false))
+  }, [])
 
-  const loadPlayers = async () => {
-    setLoading(true)
-    try {
-      setPlayers(await api.players.list())
-    } catch (e: unknown) {
-      toast.danger(e instanceof Error ? e.message : String(e))
-    } finally {
-      setLoading(false)
-    }
-  }
+  useEffect(() => { loadPlayers() }, [loadPlayers])
 
   const loadSideData = async (section: SidebarKey) => {
     setActive(section)

--- a/web/src/tabs/PlayersTab/modals/GiveItemsModal.tsx
+++ b/web/src/tabs/PlayersTab/modals/GiveItemsModal.tsx
@@ -28,10 +28,15 @@ export function GiveItemsModal({ player, open, onClose }: Props) {
 
   useEffect(() => {
     if (!open) return
-    setLoading(true)
-    api.players.templates().then(setTemplates).catch(() => {}).finally(() => setLoading(false))
-    fetch('/packs.json').then(r => r.json()).then(setPacksData).catch(() => setPacksData({ packs: {} }))
-    setQuery(''); setSelected(''); setQty(1); setQuality(0); setStaged([]); setResult(null)
+    Promise.resolve()
+      .then(() => { setLoading(true); setQuery(''); setSelected(''); setQty(1); setQuality(0); setStaged([]); setResult(null) })
+      .then(() => Promise.all([
+        api.players.templates(),
+        fetch('/packs.json').then(r => r.json() as Promise<PacksData>).catch(() => ({ packs: {} } as PacksData)),
+      ]))
+      .then(([tmpls, packs]) => { setTemplates(tmpls); setPacksData(packs) })
+      .catch(() => {})
+      .finally(() => setLoading(false))
   }, [open])
 
   const filtered = useMemo(() => {
@@ -92,13 +97,13 @@ export function GiveItemsModal({ player, open, onClose }: Props) {
   return (
     <Modal>
       <Modal.Backdrop isOpen={open} onOpenChange={v => !v && onClose()}>
-        <Modal.Container size="cover">
-          <Modal.Dialog className="flex flex-col">
+        <Modal.Container size="cover" scroll="outside">
+          <Modal.Dialog>
             <Modal.CloseTrigger />
             <Modal.Header>
               <Modal.Heading className="text-accent">{player.name} — Give Items</Modal.Heading>
             </Modal.Header>
-            <Modal.Body className="flex flex-col gap-3 overflow-hidden">
+            <Modal.Body className="flex flex-col gap-3">
               {loading ? (
                 <div className="flex justify-center py-6"><Spinner size="lg" /></div>
               ) : (
@@ -239,7 +244,7 @@ export function GiveItemsModal({ player, open, onClose }: Props) {
               )}
             </Modal.Body>
             <Modal.Footer>
-              <Button variant="tertiary" size="sm" onPress={onClose}>Cancel</Button>
+              <Button variant="tertiary" size="sm" slot="close">Cancel</Button>
               <Button size="sm" onPress={handleSubmit} isDisabled={submitting || staged.length === 0}>
                 {submitting ? <Spinner size="sm" color="current" /> : <Icon name="gift" />}
                 Give {staged.length} Item{staged.length !== 1 ? 's' : ''}

--- a/web/src/tabs/PlayersTab/modals/InventoryModal.tsx
+++ b/web/src/tabs/PlayersTab/modals/InventoryModal.tsx
@@ -38,19 +38,18 @@ export function InventoryModal({ player, open, onClose }: Props) {
 
   useEffect(() => {
     if (!open) {
-      setVehicles([])
+      Promise.resolve().then(() => setVehicles([]))
       return
     }
-    setLoading(true)
-    setVehiclesLoading(true)
-    api.players.inventory(player.id)
-      .then(setItems)
+    Promise.resolve()
+      .then(() => { setLoading(true); setVehiclesLoading(true) })
+      .then(() => Promise.all([
+        api.players.inventory(player.id),
+        api.players.vehicles(player.controller_id),
+      ]))
+      .then(([inv, vehs]) => { setItems(inv); setVehicles(vehs) })
       .catch((e: unknown) => toast.danger(e instanceof Error ? e.message : String(e)))
-      .finally(() => setLoading(false))
-    api.players.vehicles(player.controller_id)
-      .then(setVehicles)
-      .catch(() => {})
-      .finally(() => setVehiclesLoading(false))
+      .finally(() => { setLoading(false); setVehiclesLoading(false) })
   }, [open, player.id, player.controller_id])
 
   const handleDelete = async (itemId: number) => {
@@ -122,11 +121,11 @@ export function InventoryModal({ player, open, onClose }: Props) {
   return (
     <Modal>
       <Modal.Backdrop isOpen={open} onOpenChange={v => !v && onClose()}>
-        <Modal.Container size="cover">
+        <Modal.Container size="cover" scroll="outside">
           <Modal.Dialog>
             <Modal.CloseTrigger />
             <Modal.Header><Modal.Heading className="text-accent">{player.name} — Inventory</Modal.Heading></Modal.Header>
-            <Modal.Body className="flex flex-col gap-4 overflow-hidden">
+            <Modal.Body className="flex flex-col gap-4">
               {loading ? (
                 <div className="flex justify-center py-8"><Spinner size="lg" /></div>
               ) : (

--- a/web/src/tabs/PlayersTab/modals/PlayerActionsModal.tsx
+++ b/web/src/tabs/PlayersTab/modals/PlayerActionsModal.tsx
@@ -139,26 +139,37 @@ export function PlayerActionsModal({ player, open, onClose }: Props) {
 
   useEffect(() => {
     if (!open) {
-      setSection('resources')
-      setNodesLoaded(false); setNodes([])
-      setPlayerSpecs([]); setPlayerKeystones([]); setSpecsLoaded(false)
-      setHistoryLoaded(false); setEvents([]); setDungeons([])
-      setCharXPCurrent(null)
-      setTagsLoaded(false); setTags([]); setPendingTags([])
-      setConfirmPending(null)
+      Promise.resolve().then(() => {
+        setSection('resources')
+        setNodesLoaded(false); setNodes([])
+        setPlayerSpecs([]); setPlayerKeystones([]); setSpecsLoaded(false)
+        setHistoryLoaded(false); setEvents([]); setDungeons([])
+        setCharXPCurrent(null)
+        setTagsLoaded(false); setTags([]); setPendingTags([])
+        setConfirmPending(null)
+      })
     } else {
-      setFactionId(player.faction_id > 0 ? player.faction_id : 1)
-      api.players.partitions().then(setPartitions).catch(() => {})
-      api.players.charXPCurrent(player.id).then(setCharXPCurrent).catch(() => {})
-      // Pull every player so the teleport-to-player selector can offer a target.
-      api.players.list().then(ps => setAllPlayers(ps.filter(p => p.id !== player.id))).catch(() => {})
+      Promise.resolve()
+        .then(() => setFactionId(player.faction_id > 0 ? player.faction_id : 1))
+        .then(() => Promise.all([
+          api.players.partitions(),
+          api.players.charXPCurrent(player.id),
+          api.players.list(),
+        ]))
+        .then(([parts, xp, ps]) => {
+          setPartitions(parts)
+          setCharXPCurrent(xp)
+          setAllPlayers(ps.filter(p => p.id !== player.id))
+        })
+        .catch(() => {})
     }
   }, [open, player.faction_id, player.id])
 
   useEffect(() => {
     if (section === 'journey' && !nodesLoaded && open) {
-      setNodesLoading(true)
-      api.players.journey(player.account_id)
+      Promise.resolve()
+        .then(() => setNodesLoading(true))
+        .then(() => api.players.journey(player.account_id))
         .then(n => { setNodes(n); setNodesLoaded(true) })
         .catch((e: unknown) => toast.danger(e instanceof Error ? e.message : String(e)))
         .finally(() => setNodesLoading(false))
@@ -177,13 +188,13 @@ export function PlayerActionsModal({ player, open, onClose }: Props) {
 
   useEffect(() => {
     if (section === 'specs' && !specsLoaded && open) {
-      setSpecsLoading(true)
-      Promise.all([
-        api.players.specs_for(player.controller_id),
-        api.players.keystones(player.controller_id),
-      ]).then(([s, k]) => {
-        setPlayerSpecs(s); setPlayerKeystones(k); setSpecsLoaded(true)
-      })
+      Promise.resolve()
+        .then(() => setSpecsLoading(true))
+        .then(() => Promise.all([
+          api.players.specs_for(player.controller_id),
+          api.players.keystones(player.controller_id),
+        ]))
+        .then(([s, k]) => { setPlayerSpecs(s); setPlayerKeystones(k); setSpecsLoaded(true) })
         .catch((e: unknown) => toast.danger(e instanceof Error ? e.message : String(e)))
         .finally(() => setSpecsLoading(false))
     }
@@ -191,13 +202,13 @@ export function PlayerActionsModal({ player, open, onClose }: Props) {
 
   useEffect(() => {
     if (section === 'history' && !historyLoaded && open) {
-      setHistoryLoading(true)
-      Promise.all([
-        api.players.events(player.id),
-        api.players.dungeons(player.id),
-      ]).then(([evts, dngns]) => {
-        setEvents(evts); setDungeons(dngns); setHistoryLoaded(true)
-      })
+      Promise.resolve()
+        .then(() => setHistoryLoading(true))
+        .then(() => Promise.all([
+          api.players.events(player.id),
+          api.players.dungeons(player.id),
+        ]))
+        .then(([evts, dngns]) => { setEvents(evts); setDungeons(dngns); setHistoryLoaded(true) })
         .catch((e: unknown) => toast.danger(e instanceof Error ? e.message : String(e)))
         .finally(() => setHistoryLoading(false))
     }
@@ -205,8 +216,9 @@ export function PlayerActionsModal({ player, open, onClose }: Props) {
 
   useEffect(() => {
     if (section !== 'tags' || tagsLoaded || !open) return
-    setTagsLoading(true)
-    api.players.tags(player.account_id)
+    Promise.resolve()
+      .then(() => setTagsLoading(true))
+      .then(() => api.players.tags(player.account_id))
       .then(t => { setTags(t); setTagsLoaded(true) })
       .catch(() => {})
       .finally(() => setTagsLoading(false))
@@ -271,7 +283,7 @@ export function PlayerActionsModal({ player, open, onClose }: Props) {
     <>
     <Modal>
       <Modal.Backdrop isOpen={open} onOpenChange={v => !v && onClose()}>
-        <Modal.Container size="cover">
+        <Modal.Container size="cover" scroll="outside">
           <Modal.Dialog className="h-[92vh] flex flex-col dialog-surface-alt">
             <Modal.CloseTrigger />
             <Modal.Header>

--- a/web/src/tabs/ServerSettingsTab.tsx
+++ b/web/src/tabs/ServerSettingsTab.tsx
@@ -396,20 +396,13 @@ export default function ServerSettingsTab() {
     localStorage.getItem('serverSettings.expandedCategory') || null
   )
 
-  const load = useCallback(async () => {
-    setLoading(true)
-    setError(null)
-    try {
-      const data = await api.serverSettings.get()
-      setItems(data.settings ?? [])
-      setRaw(data.raw ?? [])
-      setPending(new Map())
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e)
-      setError(msg)
-    } finally {
-      setLoading(false)
-    }
+  const load = useCallback(() => {
+    Promise.resolve()
+      .then(() => { setLoading(true); setError(null) })
+      .then(() => api.serverSettings.get())
+      .then(data => { setItems(data.settings ?? []); setRaw(data.raw ?? []); setPending(new Map()) })
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoading(false))
   }, [])
 
   useEffect(() => { load() }, [load])

--- a/web/src/tabs/StorageTab.tsx
+++ b/web/src/tabs/StorageTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import {
   Button, Chip, Input, InputGroup, Modal, Spinner, TextField, toast,
 } from '@heroui/react'
@@ -42,18 +42,16 @@ export default function StorageTab() {
   const [showAdd, setShowAdd] = useState(false)
   const [search, setSearch] = useState('')
 
-  const load = async () => {
-    setLoading(true)
-    try {
-      setContainers(await api.storage.list())
-    } catch (e: unknown) {
-      toast.danger(e instanceof Error ? e.message : String(e))
-    } finally {
-      setLoading(false)
-    }
-  }
+  const load = useCallback(() => {
+    Promise.resolve()
+      .then(() => setLoading(true))
+      .then(() => api.storage.list())
+      .then(setContainers)
+      .catch((e: unknown) => toast.danger(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoading(false))
+  }, [])
 
-  useEffect(() => { load() }, [])
+  useEffect(() => { load() }, [load])
 
   const selectContainer = async (c: Container) => {
     setSelected(c)
@@ -238,9 +236,12 @@ function AddItemsModal({ container, open, onClose, onSuccess, onRefresh }: {
 
   useEffect(() => {
     if (!open) return
-    setLoading(true)
-    api.players.templates().then(setTemplates).catch(() => {}).finally(() => setLoading(false))
-    setQuery(''); setSelected(''); setQty(1); setQuality(0); setStaged([]); setResult(null)
+    Promise.resolve()
+      .then(() => { setLoading(true); setQuery(''); setSelected(''); setQty(1); setQuality(0); setStaged([]); setResult(null) })
+      .then(() => api.players.templates())
+      .then(setTemplates)
+      .catch(() => {})
+      .finally(() => setLoading(false))
   }, [open])
 
   const filtered = useMemo(() => {
@@ -287,15 +288,15 @@ function AddItemsModal({ container, open, onClose, onSuccess, onRefresh }: {
   return (
     <Modal>
       <Modal.Backdrop isOpen={open} onOpenChange={v => !v && onClose()}>
-        <Modal.Container size="cover">
-          <Modal.Dialog className="flex flex-col">
+        <Modal.Container size="cover" scroll="outside">
+          <Modal.Dialog>
             <Modal.CloseTrigger />
             <Modal.Header>
               <Modal.Heading className="text-accent">
                 {container.name || `Container #${container.id}`} — Add Items
               </Modal.Heading>
             </Modal.Header>
-            <Modal.Body className="flex flex-col gap-3 overflow-hidden">
+            <Modal.Body className="flex flex-col gap-3">
               {loading ? (
                 <div className="flex justify-center py-6"><Spinner size="lg" /></div>
               ) : (
@@ -403,7 +404,7 @@ function AddItemsModal({ container, open, onClose, onSuccess, onRefresh }: {
               )}
             </Modal.Body>
             <Modal.Footer>
-              <Button variant="tertiary" size="sm" onPress={onClose}>Cancel</Button>
+              <Button variant="tertiary" size="sm" slot="close">Cancel</Button>
               <Button size="sm" onPress={handleSubmit} isDisabled={submitting || staged.length === 0}>
                 {submitting ? <Spinner size="sm" color="current" /> : <Icon name="plus" />}
                 Add {staged.length} Item{staged.length !== 1 ? 's' : ''}


### PR DESCRIPTION
This pull request introduces support for proxying market bot API requests to a remote HTTP API, allowing the admin server to operate without running an embedded market bot. It adds a `remoteBotClient` for forwarding API calls and updates all relevant handlers to support both embedded and remote bot modes. The configuration is enhanced to allow explicit selection between embedded, remote, or disabled modes, and comprehensive tests for the new remote proxy logic are included.

**Remote market bot proxy support:**

* Introduced the `remoteBotClient` type in `handlers_market_bot.go`, enabling the admin server to forward `/api/v1/market-bot/*` requests to a remote market bot HTTP API when `market_bot_enabled` is false but `market_bot_remote_url` is set. This includes logic for HTTP and WebSocket proxying and error handling.
* Updated all market bot HTTP handlers (`handleMarketBotStatus`, `handleMarketBotConfig`, `handleMarketBotExec`, `handleMarketBotCleanup`, `handleMarketBotLogsReady`, `handleMarketBotLogs`) to support three modes: embedded bot, remote proxy, or not configured, with appropriate behavior and error responses for each. [[1]](diffhunk://#diff-ff08a5dc2bec83d7fffddbe3d18c63eaf08fc850d9a423294946e3446d354d96R88-R150) [[2]](diffhunk://#diff-ff08a5dc2bec83d7fffddbe3d18c63eaf08fc850d9a423294946e3446d354d96L98-R201) [[3]](diffhunk://#diff-ff08a5dc2bec83d7fffddbe3d18c63eaf08fc850d9a423294946e3446d354d96R241-R276)

**Configuration changes:**

* Modified the `appConfig` struct in `main.go` to make `MarketBotEnabled` a pointer (to distinguish unset from explicitly false), added `MarketBotRemoteURL` and `MarketBotRemoteToken` fields, and provided a helper function to determine the effective enabled state.
* Updated path resolution and initialization logic to accommodate the new configuration options. [[1]](diffhunk://#diff-f95fef1922da5dc33ef707ab8aaf561b59db1691b09f53b25474722fc3827e3eL445-R462) [[2]](diffhunk://#diff-f95fef1922da5dc33ef707ab8aaf561b59db1691b09f53b25474722fc3827e3eL541-R558)

**Testing improvements:**

* Added `handlers_market_bot_test.go` with comprehensive tests for all new remote proxy code paths, covering status, config, exec, cleanup, and log endpoints in both remote and unconfigured modes.