### PR TITLE
[#79] fix: delegate EvalOnGameBroker to kubectl when control_namespace is set

### DIFF
--- a/cmd/dune-admin/control_local.go
+++ b/cmd/dune-admin/control_local.go
@@ -111,7 +111,10 @@ func (c *localControl) brokerBase() string {
 	return "rabbitmqctl"
 }
 
-func (c *localControl) EvalOnGameBroker(_ context.Context, exec Executor, expr string) (string, error) {
+func (c *localControl) EvalOnGameBroker(ctx context.Context, exec Executor, expr string) (string, error) {
+	if c.kubectlEnabled(exec) {
+		return c.kubectlDelegate().EvalOnGameBroker(ctx, exec, expr)
+	}
 	out, err := exec.Exec(fmt.Sprintf("%s eval %s 2>&1", c.brokerBase(), shellQuote(expr)))
 	if err != nil {
 		return "", fmt.Errorf("rabbitmqctl eval: %w (output: %s)", err, strings.TrimSpace(out))


### PR DESCRIPTION
## Summary

Fixes #79

`localControl.EvalOnGameBroker` was the only method missing the `kubectlEnabled` delegation guard. When dune-admin runs as a k3s pod, the local executor has no `rabbitmqctl` binary — so give-item always failed. Running locally via SSH worked because the SSH executor has `rabbitmqctl` available on the VM host.

## Change

```go
// Before
func (c *localControl) EvalOnGameBroker(_ context.Context, exec Executor, expr string) (string, error) {
    out, err := exec.Exec(fmt.Sprintf("%s eval %s 2>&1", c.brokerBase(), shellQuote(expr)))
    ...
}

// After
func (c *localControl) EvalOnGameBroker(ctx context.Context, exec Executor, expr string) (string, error) {
    if c.kubectlEnabled(exec) {
        return c.kubectlDelegate().EvalOnGameBroker(ctx, exec, expr)
    }
    out, err := exec.Exec(fmt.Sprintf("%s eval %s 2>&1", c.brokerBase(), shellQuote(expr)))
    ...
}
```

When `control_namespace` is set and kubectl is available, calls now route through `kubectl exec <mq-game-pod> -- rabbitmqctl eval ...` — consistent with every other method on `localControl`.

The bare `rabbitmqctl` path (with optional `broker_exec_prefix`) is preserved as the fallback for AMP/bare-metal deployments.