### PR TITLE
[#55] Server Settings search + standardise SearchField across app

### DIFF
--- a/web/src/tabs/MarketTab/MarketSearch.tsx
+++ b/web/src/tabs/MarketTab/MarketSearch.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { InputGroup, ListBox, Select, TextField, Button } from '@heroui/react'
+import { ListBox, SearchField, Select, Button } from '@heroui/react'
 import { Icon } from '../../dune-ui'
 
 export type MarketFilters = {
@@ -38,27 +38,18 @@ export default function MarketSearch({ filters, onChange, onReset }: Props) {
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <TextField aria-label="Search items" className="flex-1 min-w-[200px]">
-        <InputGroup>
-          <InputGroup.Prefix><Icon name="search" /></InputGroup.Prefix>
-          <InputGroup.Input
-            value={searchDraft}
-            onChange={e => setSearchDraft(e.target.value)}
-            placeholder="Search items…"
-          />
-          {searchDraft && (
-            <InputGroup.Suffix>
-              <button
-                className="text-muted hover:text-foreground px-1"
-                onClick={() => { setSearchDraft(''); onChange({ ...filters, search: '' }) }}
-                aria-label="Clear search"
-              >
-                <Icon name="x" />
-              </button>
-            </InputGroup.Suffix>
-          )}
-        </InputGroup>
-      </TextField>
+      <SearchField
+        aria-label="Search items"
+        className="flex-1 min-w-[200px]"
+        value={searchDraft}
+        onChange={setSearchDraft}
+      >
+        <SearchField.Group>
+          <SearchField.SearchIcon />
+          <SearchField.Input placeholder="Search items…" />
+          <SearchField.ClearButton />
+        </SearchField.Group>
+      </SearchField>
 
       <Select
         selectedKey={filters.owner || 'all'}

--- a/web/src/tabs/MarketTab/bot/DisabledItemsManager.tsx
+++ b/web/src/tabs/MarketTab/bot/DisabledItemsManager.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
-import { Button, Spinner, toast } from '@heroui/react'
+import { Button, SearchField, Spinner, toast } from '@heroui/react'
 import { api } from '../../../api/client'
 import type { BotConfig, CatalogItem } from '../../../api/client'
 import { DataTable, type Column, Icon } from '../../../dune-ui'
@@ -76,12 +76,18 @@ export default function DisabledItemsManager({ config, onSaved }: Props) {
       <div className="flex gap-2 items-end">
         <div className="flex flex-col gap-0.5 flex-1">
           <label className="text-xs text-muted">Search items to disable</label>
-          <input
-            className="bg-surface border border-border rounded px-2 py-1.5 text-sm text-foreground w-full"
-            placeholder="Search by name or template ID…"
+          <SearchField
+            aria-label="Search disabled items"
             value={search}
-            onChange={e => setSearch(e.target.value)}
-          />
+            onChange={setSearch}
+            className="w-full"
+          >
+            <SearchField.Group>
+              <SearchField.SearchIcon />
+              <SearchField.Input placeholder="Search by name or template ID…" />
+              <SearchField.ClearButton />
+            </SearchField.Group>
+          </SearchField>
         </div>
         {saving && <Spinner size="sm" color="current" className="mb-2" />}
       </div>

--- a/web/src/tabs/PlayersTab/modals/GiveItemsModal.tsx
+++ b/web/src/tabs/PlayersTab/modals/GiveItemsModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import {
   Button, Header, Input, InputGroup, ListBox, Modal,
-  Select, Separator, Spinner, TextField, toast,
+  SearchField, Select, Separator, Spinner, TextField, toast,
 } from '@heroui/react'
 import { api } from '../../../api/client'
 import type { Player } from '../../../api/client'
@@ -144,15 +144,17 @@ export function GiveItemsModal({ player, open, onClose }: Props) {
                   <div className="flex items-center gap-3">
                     <TextField className="flex-1 min-w-0" aria-label="Template">
                       <div className="relative w-full">
-                        <InputGroup className="w-full">
-                          <InputGroup.Prefix>Template</InputGroup.Prefix>
-                          <InputGroup.Input
-                            className="flex-1 w-full"
-                            placeholder="Search templates..."
-                            value={query}
-                            onChange={e => { setQuery(e.target.value); setSelected('') }}
-                          />
-                        </InputGroup>
+                        <SearchField
+                          className="w-full"
+                          value={query}
+                          onChange={v => { setQuery(v); setSelected('') }}
+                        >
+                          <SearchField.Group>
+                            <SearchField.SearchIcon />
+                            <SearchField.Input placeholder="Search templates..." />
+                            <SearchField.ClearButton />
+                          </SearchField.Group>
+                        </SearchField>
                         {filtered.length > 0 && (
                           <div className="absolute z-50 w-full mt-1 rounded-[var(--radius)] border border-border bg-surface overflow-y-auto max-h-52">
                             {filtered.map(t => (

--- a/web/src/tabs/PlayersTab/modals/PlayerActionsModal.tsx
+++ b/web/src/tabs/PlayersTab/modals/PlayerActionsModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, type ReactNode } from 'react'
 import {
-  Button, Chip, Input, ListBox, ListLayout, Modal, Select,
+  Button, Chip, Input, ListBox, ListLayout, Modal, SearchField, Select,
   Spinner, Virtualizer, toast,
 } from '@heroui/react'
 import { ConfirmDialog, DataTable, Panel, SectionLabel } from '../../../dune-ui'
@@ -1064,13 +1064,17 @@ export function PlayerActionsModal({ player, open, onClose }: Props) {
                         Drop {player.name} exactly on another character's current position. Live (TeleportToExact via RMQ) when {player.name} is online; written to DB at the target's partition if offline.
                       </div>
                       <div className="flex flex-col gap-2">
-                        <input
-                          type="text"
+                        <SearchField
                           value={targetSearch}
-                          onChange={e => setTargetSearch(e.target.value)}
-                          placeholder="Search by name…"
-                          className="w-full bg-surface border border-border rounded px-3 py-1.5 text-sm text-foreground focus:outline-none focus:border-accent/60"
-                        />
+                          onChange={setTargetSearch}
+                          className="w-full"
+                        >
+                          <SearchField.Group>
+                            <SearchField.SearchIcon />
+                            <SearchField.Input placeholder="Search by name…" aria-label="Search players" />
+                            <SearchField.ClearButton />
+                          </SearchField.Group>
+                        </SearchField>
                         <div className="flex items-end gap-3">
                           <Select
                             aria-label="Target player"

--- a/web/src/tabs/PlayersTab/views/CurrencyView.tsx
+++ b/web/src/tabs/PlayersTab/views/CurrencyView.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react'
-import { Input } from '@heroui/react'
+import { SearchField } from '@heroui/react'
 import type { CurrencyRow } from '../../../api/client'
 import { DataTable, PageHeader, type Column } from '../../../dune-ui'
 
@@ -32,13 +32,18 @@ export function CurrencyView({ data, loading, controllerToName }: Props) {
   return (
     <>
       <PageHeader title={`Currency (${filtered.length}${search ? ` / ${data.length}` : ''})`}>
-        <Input
+        <SearchField
           aria-label="Search currency"
           className="w-72"
-          placeholder="Search..."
           value={search}
-          onChange={e => setSearch(e.target.value)}
-        />
+          onChange={setSearch}
+        >
+          <SearchField.Group>
+            <SearchField.SearchIcon />
+            <SearchField.Input placeholder="Search..." />
+            <SearchField.ClearButton />
+          </SearchField.Group>
+        </SearchField>
       </PageHeader>
 
       <DataTable<CurrencyRow, Key>

--- a/web/src/tabs/PlayersTab/views/FactionsView.tsx
+++ b/web/src/tabs/PlayersTab/views/FactionsView.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react'
-import { Input } from '@heroui/react'
+import { SearchField } from '@heroui/react'
 import type { FactionRep } from '../../../api/client'
 import { DataTable, PageHeader, type Column } from '../../../dune-ui'
 
@@ -33,13 +33,18 @@ export function FactionsView({ data, loading, controllerToName }: Props) {
   return (
     <>
       <PageHeader title={`Factions (${filtered.length}${search ? ` / ${data.length}` : ''})`}>
-        <Input
+        <SearchField
           aria-label="Search factions"
           className="w-72"
-          placeholder="Search..."
           value={search}
-          onChange={e => setSearch(e.target.value)}
-        />
+          onChange={setSearch}
+        >
+          <SearchField.Group>
+            <SearchField.SearchIcon />
+            <SearchField.Input placeholder="Search..." />
+            <SearchField.ClearButton />
+          </SearchField.Group>
+        </SearchField>
       </PageHeader>
 
       <DataTable<FactionRep, Key>

--- a/web/src/tabs/PlayersTab/views/OnlineView.tsx
+++ b/web/src/tabs/PlayersTab/views/OnlineView.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react'
-import { Input } from '@heroui/react'
+import { SearchField } from '@heroui/react'
 import type { OnlineRow } from '../../../api/client'
 import { DataTable, PageHeader, type Column } from '../../../dune-ui'
 import { OnlineBadge } from '../components/OnlineBadge'
@@ -32,13 +32,18 @@ export function OnlineView({ data, loading }: Props) {
   return (
     <>
       <PageHeader title={`Online State (${filtered.length}${search ? ` / ${data.length}` : ''})`}>
-        <Input
+        <SearchField
           aria-label="Search online"
           className="w-72"
-          placeholder="Search..."
           value={search}
-          onChange={e => setSearch(e.target.value)}
-        />
+          onChange={setSearch}
+        >
+          <SearchField.Group>
+            <SearchField.SearchIcon />
+            <SearchField.Input placeholder="Search..." />
+            <SearchField.ClearButton />
+          </SearchField.Group>
+        </SearchField>
       </PageHeader>
 
       <DataTable<OnlineRow, Key>

--- a/web/src/tabs/PlayersTab/views/PlayersListView.tsx
+++ b/web/src/tabs/PlayersTab/views/PlayersListView.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react'
-import { Button, Input, Spinner } from '@heroui/react'
+import { Button, SearchField, Spinner } from '@heroui/react'
 import type { Player } from '../../../api/client'
 import { DataTable, Icon, PageHeader, type Column } from '../../../dune-ui'
 import { PLAYER_COLUMNS, type PlayerSortKey } from '../types'
@@ -36,13 +36,18 @@ export function PlayersListView({ players, loading, onRefresh, onAction }: Props
   return (
     <>
       <PageHeader title={`Players (${filtered.length}${search ? ` / ${players.length}` : ''})`}>
-        <Input
+        <SearchField
           aria-label="Search players"
           className="w-72"
-          placeholder="Search..."
           value={search}
-          onChange={e => setSearch(e.target.value)}
-        />
+          onChange={setSearch}
+        >
+          <SearchField.Group>
+            <SearchField.SearchIcon />
+            <SearchField.Input placeholder="Search..." />
+            <SearchField.ClearButton />
+          </SearchField.Group>
+        </SearchField>
         <Button size="sm" variant="ghost" onPress={onRefresh} isDisabled={loading}>
           {loading
             ? <Spinner size="sm" color="current" />

--- a/web/src/tabs/PlayersTab/views/SpecsView.tsx
+++ b/web/src/tabs/PlayersTab/views/SpecsView.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react'
-import { Input } from '@heroui/react'
+import { SearchField } from '@heroui/react'
 import type { SpecTrack } from '../../../api/client'
 import { DataTable, PageHeader, type Column } from '../../../dune-ui'
 
@@ -33,13 +33,18 @@ export function SpecsView({ data, loading, controllerToName }: Props) {
   return (
     <>
       <PageHeader title={`Specs / XP (${filtered.length}${search ? ` / ${data.length}` : ''})`}>
-        <Input
+        <SearchField
           aria-label="Search specs"
           className="w-72"
-          placeholder="Search..."
           value={search}
-          onChange={e => setSearch(e.target.value)}
-        />
+          onChange={setSearch}
+        >
+          <SearchField.Group>
+            <SearchField.SearchIcon />
+            <SearchField.Input placeholder="Search..." />
+            <SearchField.ClearButton />
+          </SearchField.Group>
+        </SearchField>
       </PageHeader>
 
       <DataTable<SpecTrack, Key>

--- a/web/src/tabs/ServerSettingsTab.tsx
+++ b/web/src/tabs/ServerSettingsTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, Fragment } from 'react'
-import { Button, ListBox, Select, Spinner, toast } from '@heroui/react'
+import { Button, ListBox, SearchField, Select, Spinner, toast } from '@heroui/react'
 import { api } from '../api/client'
 import type { ServerSetting, ServerSettingUpdate, RawSection } from '../api/client'
 import { PageHeader, Panel, SectionLabel, Icon } from '../dune-ui'
@@ -92,6 +92,30 @@ function shortSection(section: string) {
   // "/Script/DuneSandbox.BuildingSettings" → "BuildingSettings"
   const dot = section.lastIndexOf('.')
   return dot >= 0 ? section.slice(dot + 1) : section
+}
+
+// matchesSetting returns true when the lower-cased query appears in any of the
+// fields an admin would reasonably search by. Empty query matches everything.
+function matchesSetting(item: ServerSetting, q: string): boolean {
+  if (!q) return true
+  return (
+    item.label.toLowerCase().includes(q) ||
+    item.description.toLowerCase().includes(q) ||
+    item.key.toLowerCase().includes(q) ||
+    item.category.toLowerCase().includes(q) ||
+    shortSection(item.section).toLowerCase().includes(q)
+  )
+}
+
+// matchesRawSection matches on the INI section name or any contained key/value.
+function matchesRawSection(sections: RawSection[], q: string): boolean {
+  if (!q) return true
+  if (shortSection(sections[0].section).toLowerCase().includes(q)) return true
+  return sections.some(sec =>
+    sec.lines.some(l =>
+      l.key.toLowerCase().includes(q) || l.value.toLowerCase().includes(q),
+    ),
+  )
 }
 
 function SettingRow({
@@ -389,6 +413,7 @@ export default function ServerSettingsTab() {
   const [loading, setLoading] = useState(true)
   const [saving, setSaving]   = useState(false)
   const [error, setError]     = useState<string | null>(null)
+  const [search, setSearch]   = useState('')
   const [showAll, setShowAll] = useState(() =>
     localStorage.getItem('serverSettings.showAll') === 'true'
   )
@@ -477,12 +502,20 @@ export default function ServerSettingsTab() {
     ? items
     : items.filter(item => item.layers.some(l => USER_SOURCES.has(l.source)))
 
+  const q = search.trim().toLowerCase()
+  const searching = q.length > 0
+
   // Partition into "common" (curated top-of-page list) vs "everything else"
   // (the categorised grid below). When the showAll toggle is off and a
   // common key has no user override, it's still surfaced — common settings
-  // are interesting even before they've been touched.
-  const commonItems = items.filter(item => COMMON_KEYS.has(`${item.section}|${item.key}`))
-  const advancedItems = visibleItems.filter(item => !COMMON_KEYS.has(`${item.section}|${item.key}`))
+  // are interesting even before they've been touched. An active search query
+  // filters all three groups (common / category / raw) down to matches.
+  const commonItems = items
+    .filter(item => COMMON_KEYS.has(`${item.section}|${item.key}`))
+    .filter(item => matchesSetting(item, q))
+  const advancedItems = visibleItems
+    .filter(item => !COMMON_KEYS.has(`${item.section}|${item.key}`))
+    .filter(item => matchesSetting(item, q))
   const categories = groupByCategory(advancedItems)
 
   const toggleCategory = (cat: string) => {
@@ -508,16 +541,33 @@ export default function ServerSettingsTab() {
   }
 
   // In "user settings" mode, hide raw panels whose entries are only from default files.
-  const visibleRawSections = showAll
+  // An active search query further narrows to sections matching the query.
+  const visibleRawSections = (showAll
     ? [...rawBySection.values()]
     : [...rawBySection.values()].filter(secs =>
         secs.some(s => USER_SOURCES.has(s.source))
       )
+  ).filter(secs => matchesRawSection(secs, q))
+
+  const hasResults =
+    commonItems.length > 0 || categories.length > 0 || visibleRawSections.length > 0
 
   return (
     <div className="flex flex-col h-full gap-3 min-h-0">
       <PageHeader title="Server Settings">
         <div className="flex items-center gap-2">
+          <SearchField
+            aria-label="Search settings"
+            className="w-56"
+            value={search}
+            onChange={setSearch}
+          >
+            <SearchField.Group>
+              <SearchField.SearchIcon />
+              <SearchField.Input placeholder="Search settings…" />
+              <SearchField.ClearButton />
+            </SearchField.Group>
+          </SearchField>
           <Button size="sm" variant="ghost" onPress={load} isDisabled={loading || saving}>
             <Icon name="refresh-cw" />
           </Button>
@@ -544,6 +594,12 @@ export default function ServerSettingsTab() {
       </p>
 
       <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-4 pb-6 pr-1">
+
+        {searching && !hasResults && (
+          <div className="text-sm text-muted py-8 text-center">
+            No settings match “{search.trim()}”.
+          </div>
+        )}
 
         {/* Common Settings — curated subset, always visible at top */}
         {commonItems.length > 0 && (
@@ -578,7 +634,7 @@ export default function ServerSettingsTab() {
             </div>
             <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2 mt-2">
               {categories.map(([cat, catItems]) => {
-                const isOpen = expandedCategory === cat
+                const isOpen = searching || expandedCategory === cat
                 const overrideCount = catItems.filter(i =>
                   i.layers.some(l => USER_SOURCES.has(l.source))
                 ).length
@@ -614,14 +670,16 @@ export default function ServerSettingsTab() {
                       <Panel className="col-span-full mt-1 mb-1">
                         <div className="flex items-center justify-between mb-2">
                           <SectionLabel>{cat}</SectionLabel>
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            onPress={() => toggleCategory(cat)}
-                            aria-label="Collapse category"
-                          >
-                            <Icon name="x" className="w-3.5 h-3.5" />
-                          </Button>
+                          {!searching && (
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              onPress={() => toggleCategory(cat)}
+                              aria-label="Collapse category"
+                            >
+                              <Icon name="x" className="w-3.5 h-3.5" />
+                            </Button>
+                          )}
                         </div>
                         <div>
                           {catItems.map(item => (

--- a/web/src/tabs/StorageTab.tsx
+++ b/web/src/tabs/StorageTab.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import {
-  Button, Chip, Input, InputGroup, Modal, Spinner, TextField, toast,
+  Button, Chip, Input, InputGroup, Modal, SearchField, Spinner, TextField, toast,
 } from '@heroui/react'
 import { api } from '../api/client'
 import type { InventoryItem } from '../api/client'
@@ -126,13 +126,18 @@ export default function StorageTab() {
           }
           width="w-72"
         >
-          <Input
+          <SearchField
             aria-label="Search containers"
-            placeholder="Search..."
             value={search}
-            onChange={e => setSearch(e.target.value)}
+            onChange={setSearch}
             className="w-full"
-          />
+          >
+            <SearchField.Group>
+              <SearchField.SearchIcon />
+              <SearchField.Input placeholder="Search..." />
+              <SearchField.ClearButton />
+            </SearchField.Group>
+          </SearchField>
         </SideNav>
 
         <div className="flex-1 flex flex-col gap-3 min-h-0">
@@ -304,15 +309,17 @@ function AddItemsModal({ container, open, onClose, onSuccess, onRefresh }: {
                   <div className="flex items-center gap-3 shrink-0">
                     <TextField className="flex-1 min-w-0" aria-label="Template">
                       <div className="relative w-full">
-                        <InputGroup className="w-full">
-                          <InputGroup.Prefix>Template</InputGroup.Prefix>
-                          <InputGroup.Input
-                            className="flex-1 w-full"
-                            placeholder="Search templates..."
-                            value={query}
-                            onChange={e => { setQuery(e.target.value); setSelected('') }}
-                          />
-                        </InputGroup>
+                        <SearchField
+                          className="w-full"
+                          value={query}
+                          onChange={v => { setQuery(v); setSelected('') }}
+                        >
+                          <SearchField.Group>
+                            <SearchField.SearchIcon />
+                            <SearchField.Input placeholder="Search templates..." />
+                            <SearchField.ClearButton />
+                          </SearchField.Group>
+                        </SearchField>
                         {filtered.length > 0 && (
                           <div className="absolute z-50 w-full mt-1 rounded-[var(--radius)] border border-border bg-surface overflow-y-auto max-h-52">
                             {filtered.map(t => (


### PR DESCRIPTION
## Summary

Closes #55

### Server Settings search (commit 1)
Adds a keyword search box to the Server Settings tab header.

- Filters Common Settings, the category grid, and Raw INI Sections in real time
- Matches on setting label, description, key, category, and section name
- Raw sections match on section name or any line key/value
- Matching categories auto-expand while a query is active (collapse button hidden)
- Empty-state message when query yields no results
- Composes with the existing All / User toggle

### SearchField standardisation (commit 2)
Replaces every search input across the app with HeroUI v3 `SearchField`, giving a consistent search icon, animated clear button, and native Escape-to-clear behaviour (Escape clears a non-empty field; only closes the modal once the field is already empty).

Files updated: `PlayersListView`, `OnlineView`, `CurrencyView`, `SpecsView`, `FactionsView`, `StorageTab`, `GiveItemsModal`, `PlayerActionsModal`, `MarketSearch`, `DisabledItemsManager`, `ServerSettingsTab`

## Checklist
- [x] `pnpm lint` passes
- [x] `pnpm build` (tsc + vite) passes