### PR TITLE
[#73] fix: make build cross-platform for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ deploy/k8s/dune-admin.rendered.yaml
 
 # Reference material / ideas / scratch — not for sharing
 Samples-Ideas/
+tmp/dune-admin

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,22 @@
         version version-patch version-minor version-major
 
 # ── Build ─────────────────────────────────────────────────────────────────────
-BIN    := bin/dune-admin
 CMD    := ./cmd/dune-admin
 PKG    := ./...
 GO     := go
 PREFIX ?= /usr/local
 COGNIT_TARGET := $(if $(wildcard cmd/dune-admin),./cmd/dune-admin,.)
+
+# Windows produces .exe binaries. On Windows, bare `make` runs recipes under
+# cmd.exe, which lacks POSIX `mkdir -p` and `install` — so the `go` target
+# branches on OS below.
+ifeq ($(OS),Windows_NT)
+BIN       := bin/dune-admin.exe
+LOCAL_BIN := dune-admin.exe
+else
+BIN       := bin/dune-admin
+LOCAL_BIN := dune-admin
+endif
 
 VERSION    ?= $(shell cat VERSION 2>/dev/null || git describe --tags --always --dirty 2>/dev/null || echo "dev")
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -23,9 +33,15 @@ build: web go
 
 # Build backend binary only.
 go:
+ifeq ($(OS),Windows_NT)
+	@if not exist bin mkdir bin
+	$(GO) build -trimpath $(LDFLAGS) -o $(BIN) $(CMD)
+	@copy /Y "bin\dune-admin.exe" "$(LOCAL_BIN)" >NUL
+else
 	@mkdir -p bin
 	$(GO) build -trimpath $(LDFLAGS) -o $(BIN) $(CMD)
-	install -m 0755 $(BIN) ./dune-admin
+	install -m 0755 $(BIN) ./$(LOCAL_BIN)
+endif
 
 # Install the binary system-wide.
 install: go

--- a/README.md
+++ b/README.md
@@ -202,6 +202,13 @@ Then run the setup wizard:
 
 Prerequisites: Go 1.26+, Node 20.19+ or 22.12+, pnpm 10.28+, `make`.
 
+> **Windows note:** `make build` works from PowerShell or `cmd.exe` as long as
+> [GNU Make](https://gnuwin32.sourceforge.net/packages/make.htm) is installed (e.g.
+> `winget install GnuWin32.Make` or `choco install make`). The binary is named
+> `dune-admin.exe`. For `make dev`, `make verify`, and the `make version-*` targets,
+> run from a **Git Bash** shell (right-click the folder → "Git Bash Here") — those
+> recipes use POSIX shell features that cmd.exe can't run.
+
 ---
 
 ## Development


### PR DESCRIPTION
Fixes #73.

## Root cause

`make build` on Windows printed *"The system cannot find the path specified."* three times. Bare `make` on Windows runs recipes under `cmd.exe`, which can't handle the `go:` target's POSIX-only `mkdir -p` and `install` commands. The output binary also lacked the `.exe` extension.

## Changes

- **Makefile** — `OS=Windows_NT` detection sets `BIN`/`LOCAL_BIN` to `.exe` variants; `go:` target branches so Windows uses `if not exist bin mkdir bin` + `copy /Y` (cmd.exe-native), while Unix keeps `mkdir -p` + `install -m 0755` unchanged.
- **`.gitignore`** — `/dune-admin.exe` + `*.exe`
- **README.md** — Windows build note: GNU Make for `make build` from PowerShell; Git Bash for `dev`/`verify`/`version-*` which need POSIX shell.