### PR TITLE
[#77] fix: prescience unlock + Contracts tab split

### DIFF
--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -1699,6 +1699,12 @@ func cmdCompleteJourneyNode(accountID int64, nodeID string) Cmd {
 			return msgMutate{err: err}
 		}
 
+		svExtra, svErr := maybeGrantSpiceVision(ctx, accountID, nodeID)
+		if svErr != nil {
+			return msgMutate{err: svErr}
+		}
+		extra += svExtra
+
 		return msgMutate{ok: fmt.Sprintf("Completed %s + %d node(s)%s — takes effect on next login", nodeID, updated, extra)}
 	}
 }
@@ -2327,6 +2333,68 @@ func grantSkillBlocks(ctx context.Context, accountID int64, skillKeys []string) 
 		return ", no skill blocks needed (all already unlocked)", nil
 	}
 	return fmt.Sprintf(", unlocked %d skill block(s)", granted), nil
+}
+
+// spiceVisionEnableSQL sets FSpiceAddictionComponent.SpiceVisionEnabledStatus
+// to "FullyEnabled" on the player's DuneCharacter FGL entity. This is the
+// persistent flag the game reads to determine whether the player has unlocked
+// the Prescience state (3rd ability slot + spice-vision buff). In-game it is
+// written by the 4th Trial of Aql quest script, not by a journey tag — hence
+// it must be applied explicitly when admin-completing FindTheFremen.
+const spiceVisionEnableSQL = `
+	UPDATE dune.fgl_entities fe
+	SET components = jsonb_set(
+		fe.components,
+		ARRAY['FSpiceAddictionComponent','1','SpiceVisionEnabledStatus'],
+		'"FullyEnabled"'::jsonb,
+		true)
+	WHERE fe.entity_id = (
+		SELECT entity_id FROM dune.actor_fgl_entities
+		WHERE actor_id = $1 AND slot_name = 'DuneCharacter'
+	)
+	AND COALESCE(
+		fe.components->'FSpiceAddictionComponent'->1->>'SpiceVisionEnabledStatus',
+		''
+	) <> 'FullyEnabled'`
+
+// maybeGrantSpiceVision conditionally enables SpiceVision for the account
+// when nodeID is within the FindTheFremen quest. It is a thin wrapper so
+// cmdCompleteJourneyNode stays under the complexity gate.
+func maybeGrantSpiceVision(ctx context.Context, accountID int64, nodeID string) (string, error) {
+	if !nodeIDTriggersSpiceVision(nodeID) {
+		return "", nil
+	}
+	var pawnID int64
+	_ = globalDB.QueryRow(ctx,
+		`SELECT player_pawn_id FROM dune.player_state WHERE account_id = $1 LIMIT 1`,
+		accountID).Scan(&pawnID)
+	return grantSpiceVision(ctx, pawnID)
+}
+
+// nodeIDTriggersSpiceVision reports whether completing nodeID should also
+// enable SpiceVision (Prescience). Only DA_MQ_FindTheFremen and its subtree
+// warrant this — it is the quest that contains the 4th Trial of Aql.
+func nodeIDTriggersSpiceVision(nodeID string) bool {
+	const root = "DA_MQ_FindTheFremen"
+	return nodeID == root || len(nodeID) > len(root) && nodeID[:len(root)+1] == root+"."
+}
+
+// grantSpiceVision enables the Prescience / SpiceVision state on the player's
+// DuneCharacter FGL entity. It is idempotent — a no-op if already enabled.
+// Returns a short extra fragment for the caller's success message, or "" if
+// the pawn was not found or the flag was already set.
+func grantSpiceVision(ctx context.Context, pawnID int64) (string, error) {
+	if pawnID == 0 {
+		return ", spice vision skipped (no pawn yet)", nil
+	}
+	res, err := globalDB.Exec(ctx, spiceVisionEnableSQL, pawnID)
+	if err != nil {
+		return "", fmt.Errorf("grant spice vision: %w", err)
+	}
+	if res.RowsAffected() == 0 {
+		return "", nil
+	}
+	return ", enabled Prescience (SpiceVision)", nil
 }
 
 // allJourneyTags returns the union of every tag any journey node would emit

--- a/cmd/dune-admin/db_cmd_spice_vision_test.go
+++ b/cmd/dune-admin/db_cmd_spice_vision_test.go
@@ -1,0 +1,59 @@
+package main
+
+import "testing"
+
+func TestSpiceVisionNodeIDs(t *testing.T) {
+	t.Parallel()
+
+	// DA_MQ_FindTheFremen and any of its sub-nodes must trigger spice vision.
+	cases := []struct {
+		nodeID string
+		want   bool
+	}{
+		{"DA_MQ_FindTheFremen", true},
+		{"DA_MQ_FindTheFremen.FourthTest", true},
+		{"DA_MQ_FindTheFremen.FourthTest.FourthQuestion.CompleteFourthTest", true},
+		{"DA_MQ_FindTheFremen.Epilogue", true},
+		{"DA_MQ_ANewBeginning", false},
+		{"DA_MQ_ANewBeginning.Aql No 1.FabricateStillsuit.Equip the Stillsuit", false},
+		{"DA_SQ_VermiliusGap", false},
+		{"DA_FQ_ClimbTheRanks", false},
+	}
+
+	for _, tc := range cases {
+		got := nodeIDTriggersSpiceVision(tc.nodeID)
+		if got != tc.want {
+			t.Errorf("nodeIDTriggersSpiceVision(%q) = %v, want %v", tc.nodeID, got, tc.want)
+		}
+	}
+}
+
+func TestSpiceVisionSQL(t *testing.T) {
+	t.Parallel()
+
+	// Verify the SQL snippet is well-formed and targets the right JSONB path.
+	sql := spiceVisionEnableSQL
+	for _, substr := range []string{
+		"FSpiceAddictionComponent",
+		"SpiceVisionEnabledStatus",
+		"FullyEnabled",
+		"DuneCharacter",
+	} {
+		if !containsSubstring(sql, substr) {
+			t.Errorf("spiceVisionEnableSQL missing %q", substr)
+		}
+	}
+}
+
+func containsSubstring(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsSubstringHelper(s, sub))
+}
+
+func containsSubstringHelper(s, sub string) bool {
+	for i := range s {
+		if i+len(sub) <= len(s) && s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/web/src/tabs/PlayersTab/modals/PlayerActionsModal.tsx
+++ b/web/src/tabs/PlayersTab/modals/PlayerActionsModal.tsx
@@ -44,6 +44,25 @@ function useDebounce<T>(value: T, delay = 300): T {
   return debounced
 }
 
+function DebouncedSearchField({ onSearch, placeholder, className }: {
+  onSearch: (q: string) => void
+  placeholder?: string
+  className?: string
+}) {
+  const [value, setValue] = useState('')
+  const debounced = useDebounce(value)
+  useEffect(() => { onSearch(debounced) }, [debounced, onSearch])
+  return (
+    <SearchField aria-label="Search" className={className} value={value} onChange={setValue}>
+      <SearchField.Group>
+        <SearchField.SearchIcon />
+        <SearchField.Input placeholder={placeholder} />
+        <SearchField.ClearButton />
+      </SearchField.Group>
+    </SearchField>
+  )
+}
+
 export function PlayerActionsModal({ player, open, onClose }: Props) {
   const [section, setSection] = useState<ActionSection>('resources')
   const [busy, setBusy] = useState(false)
@@ -72,7 +91,6 @@ export function PlayerActionsModal({ player, open, onClose }: Props) {
   const [nodesLoaded, setNodesLoaded] = useState(false)
   const [nodesLoading, setNodesLoading] = useState(false)
   const [nodeSearch, setNodeSearch] = useState('')
-  const debouncedNodeSearch = useDebounce(nodeSearch)
   const [unlockFaction, setUnlockFaction] = useState('atreides')
   const [unlockPreset, setUnlockPreset] = useState('ch3_start')
 
@@ -174,7 +192,7 @@ export function PlayerActionsModal({ player, open, onClose }: Props) {
         .catch((e: unknown) => toast.danger(e instanceof Error ? e.message : String(e)))
         .finally(() => setNodesLoading(false))
     }
-    if (section === 'progression' && !contractCatalogLoaded && open) {
+    if ((section === 'progression' || section === 'contracts') && !contractCatalogLoaded && open) {
       api.contracts.list()
         .then(c => { setContractCatalog(c); setContractCatalogLoaded(true); setContractCatalogError('') })
         .catch((e: unknown) => { setContractCatalogError(e instanceof Error ? e.message : String(e)); setContractCatalogLoaded(true) })
@@ -241,10 +259,10 @@ export function PlayerActionsModal({ player, open, onClose }: Props) {
   }
 
   const filteredNodes = useMemo(() => {
-    if (!debouncedNodeSearch) return nodes
-    const q = debouncedNodeSearch.toLowerCase()
+    if (!nodeSearch) return nodes
+    const q = nodeSearch.toLowerCase()
     return nodes.filter(n => n.node_id.toLowerCase().includes(q))
-  }, [nodes, debouncedNodeSearch])
+  }, [nodes, nodeSearch])
 
   const numInput = (val: number, set: (v: number) => void, min = 1, max = 9999999) => (
     <Input
@@ -699,8 +717,12 @@ export function PlayerActionsModal({ player, open, onClose }: Props) {
                         </div>
                       </Panel>
                     </div>
+                  </div>
+                  )
+                })()}
 
-                    {/* Complete Contract(s) — fills remaining space, owns its scroll */}
+                {section === 'contracts' && (
+                  <div className="flex flex-col gap-3 flex-1 min-h-0 pr-1">
                     <Panel className="flex-1 min-h-0">
                       <div className="flex items-baseline gap-2">
                         <SectionLabel>Complete Contract(s)</SectionLabel>
@@ -734,13 +756,18 @@ export function PlayerActionsModal({ player, open, onClose }: Props) {
                       )}
 
                       <div className="flex items-center gap-2 flex-wrap">
-                        <Input
+                        <SearchField
                           aria-label="Filter contracts"
                           className="flex-1 min-w-48"
-                          placeholder="Filter contracts (e.g. Trainer_Mentat, Atre_Rank01)..."
                           value={contractSearch}
-                          onChange={e => setContractSearch(e.target.value)}
-                        />
+                          onChange={setContractSearch}
+                        >
+                          <SearchField.Group>
+                            <SearchField.SearchIcon />
+                            <SearchField.Input placeholder="Filter contracts (e.g. Trainer_Mentat, Atre_Rank01)..." />
+                            <SearchField.ClearButton />
+                          </SearchField.Group>
+                        </SearchField>
                         <Button size="sm" variant="secondary" isDisabled={busy || selectedContracts.length === 0}
                           onPress={() => run(
                             () => api.players.completeContracts(player.account_id, selectedContracts),
@@ -792,8 +819,7 @@ export function PlayerActionsModal({ player, open, onClose }: Props) {
                       )}
                     </Panel>
                   </div>
-                  )
-                })()}
+                )}
 
                 {section === 'journey' && (
                   <div className="flex flex-col gap-3 flex-1 min-h-0 pr-1">
@@ -814,12 +840,10 @@ export function PlayerActionsModal({ player, open, onClose }: Props) {
                           Wipe All
                         </Button>
                       </div>
-                      <Input
-                        aria-label="Filter journey nodes"
+                      <DebouncedSearchField
                         className="shrink-0"
                         placeholder="Filter nodes..."
-                        value={nodeSearch}
-                        onChange={e => setNodeSearch(e.target.value)}
+                        onSearch={setNodeSearch}
                       />
                     {nodesLoading ? (
                       <div className="flex justify-center py-8"><Spinner size="lg" /></div>

--- a/web/src/tabs/PlayersTab/types.ts
+++ b/web/src/tabs/PlayersTab/types.ts
@@ -1,7 +1,7 @@
 export type Sidebar = 'players' | 'currency' | 'factions' | 'specs' | 'online'
 
 export type ActionSection =
-  | 'resources' | 'specs' | 'progression' | 'journey' | 'admin' | 'tags' | 'history' | 'experimental'
+  | 'resources' | 'specs' | 'progression' | 'contracts' | 'journey' | 'admin' | 'tags' | 'history' | 'experimental'
 
 export type PlayerSortKey = 'id' | 'name' | 'class' | 'map' | 'faction_id'
 
@@ -26,6 +26,7 @@ export const ACTION_SECTIONS: { key: ActionSection; label: string }[] = [
   { key: 'resources',    label: 'Stats' },
   { key: 'specs',        label: 'Specs' },
   { key: 'progression',  label: 'Progression' },
+  { key: 'contracts',    label: 'Contracts' },
   { key: 'journey',      label: 'Journey' },
   { key: 'admin',        label: 'Admin' },
   { key: 'tags',         label: 'Tags' },


### PR DESCRIPTION
## Summary

Closes #77

### Backend: Prescience / 3rd ability slot unlock

Completing `DA_MQ_FindTheFremen` via dune-admin didn't grant the Prescience state (3rd ability slot) because the unlock is **not a journey tag** — it's a JSONB field on the player's `DuneCharacter` FGL entity:

```
FSpiceAddictionComponent[1].SpiceVisionEnabledStatus = "FullyEnabled"
```

This was confirmed by diffing a real completed save. New functions added to `db.go`:

- `nodeIDTriggersSpiceVision` — true for `DA_MQ_FindTheFremen` and its entire subtree
- `grantSpiceVision` — idempotent UPDATE targeting the FGL component field
- `maybeGrantSpiceVision` — wrapper called from `cmdCompleteJourneyNode`; no-ops for unrelated nodes, skips gracefully if no pawn exists yet

Fires automatically via Quick Presets, Unlock Main Quest, and direct journey node completion (all delegate through `cmdCompleteJourneyNode`). Success message includes `, enabled Prescience (SpiceVision)` when applied.

2 new tests in `db_cmd_spice_vision_test.go`.

### Frontend: Contracts tab + SearchField improvements

- **Contracts tab**: moved "Complete Contract(s)" out of the Progression section into its own left-nav section. The full contract list now has all the vertical space it needs. Contract catalog loads on entry to either Progression or Contracts.
- **SearchField**: replaced plain `Input` with `SearchField` (icon + native clear/Escape) in both the Contracts filter and Journey Nodes filter.
- **Typing lag fix**: Journey node filter is now a `DebouncedSearchField` component that owns its own input state. The parent only re-renders after the 300ms debounce fires, eliminating lag when typing quickly against a large node list.