### PR TITLE
fix: repair targets in-row MaxDurability, not the PAK catalog

### DIFF
--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -3865,11 +3865,10 @@ func parseDurabilityText(value pgtype.Text) float64 {
 	return parsed
 }
 
-func repairTargetForItem(templateID string, maxDurability pgtype.Text) float64 {
-	// Target priority: catalog (vehicle modules stored as items) → stats.MaxDurability → 100.
-	if value, ok := itemMaxDurability(templateID); ok && value > 0 {
-		return value
-	}
+func repairTargetForItem(maxDurability pgtype.Text) float64 {
+	// The in-row MaxDurability is the source of truth. Default to 100 only for
+	// plain 0–100 gear that carries no MaxDurability. The PAK catalog is NOT
+	// consulted — it under-reports some scales (e.g. transport modules).
 	if maxDurability.Valid {
 		if value, err := strconv.ParseFloat(maxDurability.String, 64); err == nil && value > 0 {
 			return value
@@ -3880,12 +3879,19 @@ func repairTargetForItem(templateID string, maxDurability pgtype.Text) float64 {
 
 func buildRepairCandidate(
 	id int64,
-	templateID string,
 	maxDurability, currentDurability, decayedDurability pgtype.Text,
 ) (repairCandidate, bool) {
-	target := repairTargetForItem(templateID, maxDurability)
 	current := parseDurabilityText(currentDurability)
 	decayed := parseDurabilityText(decayedDurability)
+	// Never lower an existing value: a default-100 must not cap a higher-scale
+	// item whose MaxDurability is absent but whose stored values exceed 100.
+	target := repairTargetForItem(maxDurability)
+	if current > target {
+		target = current
+	}
+	if decayed > target {
+		target = decayed
+	}
 	if math.Abs(current-target) < 0.01 && math.Abs(decayed-target) < 0.01 {
 		return repairCandidate{}, false
 	}
@@ -3894,7 +3900,7 @@ func buildRepairCandidate(
 
 func loadPlayerGearRepairCandidates(ctx context.Context, playerID int64) ([]repairCandidate, int, error) {
 	rows, err := globalDB.Query(ctx, `
-		SELECT i.id, i.template_id,
+		SELECT i.id,
 		       (i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability'),
 		       (i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability'),
 		       (i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')
@@ -3915,13 +3921,12 @@ func loadPlayerGearRepairCandidates(ctx context.Context, playerID int64) ([]repa
 		scanned++
 
 		var id int64
-		var templateID string
 		var maxDurability, currentDurability, decayedDurability pgtype.Text
-		if err := rows.Scan(&id, &templateID, &maxDurability, &currentDurability, &decayedDurability); err != nil {
+		if err := rows.Scan(&id, &maxDurability, &currentDurability, &decayedDurability); err != nil {
 			return nil, scanned, fmt.Errorf("scan item: %w", err)
 		}
 
-		candidate, needsRepair := buildRepairCandidate(id, templateID, maxDurability, currentDurability, decayedDurability)
+		candidate, needsRepair := buildRepairCandidate(id, maxDurability, currentDurability, decayedDurability)
 		if needsRepair {
 			toRepair = append(toRepair, candidate)
 		}
@@ -4015,13 +4020,18 @@ func validateRepairVehicleInput(playerID int64) error {
 }
 
 type vehicleModule struct {
-	id         int64
-	templateID string
+	id                int64
+	maxDurability     pgtype.Text
+	currentDurability pgtype.Text
+	decayedDurability pgtype.Text
 }
 
 func loadVehicleModules(ctx context.Context, vehicleID int64) ([]vehicleModule, error) {
 	rows, err := globalDB.Query(ctx, `
-			SELECT id, template_id
+			SELECT id,
+			       (stats->'FVehicleModuleDurabilityStats'->1->>'MaxDurability'),
+			       (stats->'FVehicleModuleDurabilityStats'->1->>'CurrentDurability'),
+			       (stats->'FVehicleModuleDurabilityStats'->1->>'DecayedMaxDurability')
 			FROM dune.vehicle_modules
 			WHERE vehicle_id = $1::bigint`, vehicleID)
 	if err != nil {
@@ -4032,7 +4042,7 @@ func loadVehicleModules(ctx context.Context, vehicleID int64) ([]vehicleModule, 
 	var modules []vehicleModule
 	for rows.Next() {
 		var module vehicleModule
-		if err := rows.Scan(&module.id, &module.templateID); err != nil {
+		if err := rows.Scan(&module.id, &module.maxDurability, &module.currentDurability, &module.decayedDurability); err != nil {
 			return nil, fmt.Errorf("scan module: %w", err)
 		}
 		modules = append(modules, module)
@@ -4050,12 +4060,32 @@ type vehicleRepairSummary struct {
 	err      error
 }
 
-func vehicleRepairTarget(templateID string) (float64, bool) {
-	target, ok := itemMaxDurability(templateID)
-	if !ok || target <= 0 {
+// vehicleModuleRepairTarget derives the repair target from the module's own
+// in-row MaxDurability — the authoritative 100% ceiling. ok=false means the
+// module has no usable in-row MaxDurability and must be skipped: the PAK catalog
+// is NOT a fallback (it under-reports transport-ornithopter modules by ~half).
+// The target never lowers an existing higher value.
+func vehicleModuleRepairTarget(module vehicleModule) (float64, bool) {
+	maxDur := parseDurabilityText(module.maxDurability)
+	if !module.maxDurability.Valid || maxDur <= 0 {
 		return 0, false
 	}
+	target := maxDur
+	if current := parseDurabilityText(module.currentDurability); current > target {
+		target = current
+	}
+	if decayed := parseDurabilityText(module.decayedDurability); decayed > target {
+		target = decayed
+	}
 	return target, true
+}
+
+// vehicleModuleAtTarget reports whether the module already sits at the target
+// on both the current and decayed ceilings, so no write is needed.
+func vehicleModuleAtTarget(module vehicleModule, target float64) bool {
+	current := parseDurabilityText(module.currentDurability)
+	decayed := parseDurabilityText(module.decayedDurability)
+	return math.Abs(current-target) < 0.01 && math.Abs(decayed-target) < 0.01
 }
 
 func runVehicleModuleRepairs(
@@ -4064,10 +4094,13 @@ func runVehicleModuleRepairs(
 ) vehicleRepairSummary {
 	summary := vehicleRepairSummary{total: len(modules)}
 	for _, module := range modules {
-		target, ok := vehicleRepairTarget(module.templateID)
+		target, ok := vehicleModuleRepairTarget(module)
 		if !ok {
 			summary.skipped++
 			continue
+		}
+		if vehicleModuleAtTarget(module, target) {
+			continue // already at full — no write needed
 		}
 		if err := update(module, target); err != nil {
 			summary.err = fmt.Errorf("repair module %d: %w", module.id, err)

--- a/cmd/dune-admin/db_cmd_repair_player_gear_test.go
+++ b/cmd/dune-admin/db_cmd_repair_player_gear_test.go
@@ -8,10 +8,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func floatPtr(v float64) *float64 {
-	return &v
-}
-
 func TestParseDurabilityText(t *testing.T) {
 	t.Parallel()
 
@@ -27,50 +23,40 @@ func TestParseDurabilityText(t *testing.T) {
 }
 
 func TestRepairTargetForItem(t *testing.T) {
-	originalItemData := itemData
-	itemData = itemDataFile{
-		Items: map[string]itemRule{
-			"dune.item.catalog": {MaxDurability: floatPtr(250)},
-		},
-	}
-	t.Cleanup(func() { itemData = originalItemData })
+	t.Parallel()
 
 	tests := []struct {
-		name       string
-		templateID string
-		maxText    pgtype.Text
-		want       float64
+		name    string
+		maxText pgtype.Text
+		want    float64
 	}{
 		{
-			name:       "catalog value wins",
-			templateID: "Dune.Item.Catalog",
-			maxText:    pgtype.Text{String: "125", Valid: true},
-			want:       250,
+			name:    "in-row MaxDurability is the source of truth (200-scale item)",
+			maxText: pgtype.Text{String: "200", Valid: true},
+			want:    200,
 		},
 		{
-			name:       "falls back to max durability text",
-			templateID: "Dune.Item.Unknown",
-			maxText:    pgtype.Text{String: "125", Valid: true},
-			want:       125,
+			name:    "plain gear without MaxDurability defaults to 100",
+			maxText: pgtype.Text{},
+			want:    100,
 		},
 		{
-			name:       "invalid max durability text",
-			templateID: "Dune.Item.Unknown",
-			maxText:    pgtype.Text{String: "oops", Valid: true},
-			want:       100,
+			name:    "unparseable MaxDurability defaults to 100",
+			maxText: pgtype.Text{String: "oops", Valid: true},
+			want:    100,
 		},
 		{
-			name:       "missing max durability text",
-			templateID: "Dune.Item.Unknown",
-			maxText:    pgtype.Text{},
-			want:       100,
+			name:    "zero MaxDurability defaults to 100",
+			maxText: pgtype.Text{String: "0", Valid: true},
+			want:    100,
 		},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			if got := repairTargetForItem(tt.templateID, tt.maxText); got != tt.want {
+			t.Parallel()
+			if got := repairTargetForItem(tt.maxText); got != tt.want {
 				t.Fatalf("expected %v, got %v", tt.want, got)
 			}
 		})
@@ -78,18 +64,11 @@ func TestRepairTargetForItem(t *testing.T) {
 }
 
 func TestBuildRepairCandidate(t *testing.T) {
-	originalItemData := itemData
-	itemData = itemDataFile{
-		Items: map[string]itemRule{
-			"dune.item.catalog": {MaxDurability: floatPtr(250)},
-		},
-	}
-	t.Cleanup(func() { itemData = originalItemData })
+	t.Parallel()
 
 	tests := []struct {
 		name          string
 		itemID        int64
-		templateID    string
 		maxDurability pgtype.Text
 		current       pgtype.Text
 		decayed       pgtype.Text
@@ -99,38 +78,45 @@ func TestBuildRepairCandidate(t *testing.T) {
 		{
 			name:          "already at target",
 			itemID:        1,
-			templateID:    "Dune.Item.Unknown",
 			maxDurability: pgtype.Text{String: "100", Valid: true},
 			current:       pgtype.Text{String: "100", Valid: true},
 			decayed:       pgtype.Text{String: "100", Valid: true},
 			wantNeedsFix:  false,
 		},
 		{
-			name:          "needs repair by current durability",
+			name:          "plain 0-100 gear restores to 100",
 			itemID:        2,
-			templateID:    "Dune.Item.Unknown",
-			maxDurability: pgtype.Text{String: "100", Valid: true},
+			maxDurability: pgtype.Text{},
 			current:       pgtype.Text{String: "75", Valid: true},
 			decayed:       pgtype.Text{String: "100", Valid: true},
 			wantNeedsFix:  true,
 			wantTarget:    100,
 		},
 		{
-			name:          "catalog durability target",
+			name:          "200-scale item restores to 200, not capped at 100",
 			itemID:        3,
-			templateID:    "Dune.Item.Catalog",
-			maxDurability: pgtype.Text{String: "100", Valid: true},
-			current:       pgtype.Text{String: "150", Valid: true},
-			decayed:       pgtype.Text{String: "150", Valid: true},
+			maxDurability: pgtype.Text{String: "200", Valid: true},
+			current:       pgtype.Text{String: "50", Valid: true},
+			decayed:       pgtype.Text{String: "200", Valid: true},
 			wantNeedsFix:  true,
-			wantTarget:    250,
+			wantTarget:    200,
+		},
+		{
+			name:          "never lowers below an existing value when MaxDurability absent",
+			itemID:        4,
+			maxDurability: pgtype.Text{},
+			current:       pgtype.Text{String: "150", Valid: true},
+			decayed:       pgtype.Text{String: "120", Valid: true},
+			wantNeedsFix:  true,
+			wantTarget:    150,
 		},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			candidate, needsFix := buildRepairCandidate(tt.itemID, tt.templateID, tt.maxDurability, tt.current, tt.decayed)
+			t.Parallel()
+			candidate, needsFix := buildRepairCandidate(tt.itemID, tt.maxDurability, tt.current, tt.decayed)
 			if needsFix != tt.wantNeedsFix {
 				t.Fatalf("expected needsFix=%v, got %v", tt.wantNeedsFix, needsFix)
 			}

--- a/cmd/dune-admin/db_cmd_repair_vehicle_test.go
+++ b/cmd/dune-admin/db_cmd_repair_vehicle_test.go
@@ -4,8 +4,14 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// durText builds a valid pgtype.Text holding a numeric durability string.
+func durText(s string) pgtype.Text {
+	return pgtype.Text{String: s, Valid: true}
+}
 
 func TestValidateRepairVehicleInput(t *testing.T) {
 	originalDB := globalDB
@@ -25,44 +31,87 @@ func TestValidateRepairVehicleInput(t *testing.T) {
 	}
 }
 
-func TestVehicleRepairTarget(t *testing.T) {
-	originalItemData := itemData
-	itemData = itemDataFile{
-		Items: map[string]itemRule{
-			"dune.vehicle.catalog": {MaxDurability: floatPtr(300)},
+func TestVehicleModuleRepairTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		module  vehicleModule
+		wantTgt float64
+		wantOK  bool
+	}{
+		{
+			name:    "in-row MaxDurability is the source of truth (regression: was halved by catalog)",
+			module:  vehicleModule{maxDurability: durText("12000"), currentDurability: durText("6000"), decayedDurability: durText("6000")},
+			wantTgt: 12000,
+			wantOK:  true,
+		},
+		{
+			name:   "no in-row MaxDurability is skipped, never guessed from catalog",
+			module: vehicleModule{maxDurability: pgtype.Text{}, currentDurability: durText("6000")},
+			wantOK: false,
+		},
+		{
+			name:   "unparseable MaxDurability is skipped",
+			module: vehicleModule{maxDurability: durText("oops")},
+			wantOK: false,
+		},
+		{
+			name:   "zero MaxDurability is skipped",
+			module: vehicleModule{maxDurability: durText("0")},
+			wantOK: false,
+		},
+		{
+			name:    "never lowers an existing higher value",
+			module:  vehicleModule{maxDurability: durText("100"), currentDurability: durText("80"), decayedDurability: durText("150")},
+			wantTgt: 150,
+			wantOK:  true,
 		},
 	}
-	t.Cleanup(func() { itemData = originalItemData })
 
-	target, ok := vehicleRepairTarget("Dune.Vehicle.Catalog")
-	if !ok || target != 300 {
-		t.Fatalf("expected catalog target=300, ok=true, got target=%v ok=%v", target, ok)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			target, ok := vehicleModuleRepairTarget(tt.module)
+			if ok != tt.wantOK {
+				t.Fatalf("expected ok=%v, got ok=%v (target=%v)", tt.wantOK, ok, target)
+			}
+			if ok && target != tt.wantTgt {
+				t.Fatalf("expected target=%v, got %v", tt.wantTgt, target)
+			}
+		})
+	}
+}
+
+func TestVehicleModuleAtTarget(t *testing.T) {
+	t.Parallel()
+
+	full := vehicleModule{currentDurability: durText("12000"), decayedDurability: durText("12000")}
+	if !vehicleModuleAtTarget(full, 12000) {
+		t.Fatalf("expected full module to be at target")
 	}
 
-	if target, ok = vehicleRepairTarget("Dune.Vehicle.Unknown"); ok || target != 0 {
-		t.Fatalf("expected unknown template to be skipped, got target=%v ok=%v", target, ok)
+	damaged := vehicleModule{currentDurability: durText("6000"), decayedDurability: durText("6000")}
+	if vehicleModuleAtTarget(damaged, 12000) {
+		t.Fatalf("expected damaged module to not be at target")
 	}
 }
 
 func TestRunVehicleModuleRepairs(t *testing.T) {
-	originalItemData := itemData
-	itemData = itemDataFile{
-		Items: map[string]itemRule{
-			"dune.vehicle.repairable": {MaxDurability: floatPtr(125)},
-		},
-	}
-	t.Cleanup(func() { itemData = originalItemData })
+	t.Parallel()
 
 	modules := []vehicleModule{
-		{id: 1, templateID: "Dune.Vehicle.Repairable"},
-		{id: 2, templateID: "Dune.Vehicle.Missing"},
-		{id: 3, templateID: "Dune.Vehicle.Repairable"},
+		{id: 1, maxDurability: durText("12000"), currentDurability: durText("6000"), decayedDurability: durText("6000")}, // repair → 12000
+		{id: 2, maxDurability: pgtype.Text{}, currentDurability: durText("6000")},                                        // skip (no in-row max)
+		{id: 3, maxDurability: durText("9000"), currentDurability: durText("9000"), decayedDurability: durText("9000")},  // full → no-op
+		{id: 4, maxDurability: durText("12000"), currentDurability: durText("0"), decayedDurability: durText("12000")},   // repair → 12000
 	}
 
 	var repairedIDs []int64
 	summary := runVehicleModuleRepairs(modules, func(module vehicleModule, target float64) error {
-		if target != 125 {
-			t.Fatalf("expected target 125, got %v", target)
+		if target != 12000 {
+			t.Fatalf("expected target 12000, got %v for module %d", target, module.id)
 		}
 		repairedIDs = append(repairedIDs, module.id)
 		return nil
@@ -70,27 +119,21 @@ func TestRunVehicleModuleRepairs(t *testing.T) {
 	if summary.err != nil {
 		t.Fatalf("unexpected error: %v", summary.err)
 	}
-	if summary.total != 3 || summary.repaired != 2 || summary.skipped != 1 {
+	if summary.total != 4 || summary.repaired != 2 || summary.skipped != 1 {
 		t.Fatalf("unexpected summary: %+v", summary)
 	}
-	if len(repairedIDs) != 2 || repairedIDs[0] != 1 || repairedIDs[1] != 3 {
+	if len(repairedIDs) != 2 || repairedIDs[0] != 1 || repairedIDs[1] != 4 {
 		t.Fatalf("unexpected repaired IDs: %v", repairedIDs)
 	}
 }
 
 func TestRunVehicleModuleRepairs_StopsOnError(t *testing.T) {
-	originalItemData := itemData
-	itemData = itemDataFile{
-		Items: map[string]itemRule{
-			"dune.vehicle.repairable": {MaxDurability: floatPtr(125)},
-		},
-	}
-	t.Cleanup(func() { itemData = originalItemData })
+	t.Parallel()
 
 	modules := []vehicleModule{
-		{id: 10, templateID: "Dune.Vehicle.Repairable"},
-		{id: 11, templateID: "Dune.Vehicle.Repairable"},
-		{id: 12, templateID: "Dune.Vehicle.Missing"},
+		{id: 10, maxDurability: durText("125"), currentDurability: durText("0"), decayedDurability: durText("0")},
+		{id: 11, maxDurability: durText("125"), currentDurability: durText("0"), decayedDurability: durText("0")},
+		{id: 12, maxDurability: pgtype.Text{}},
 	}
 
 	failErr := errors.New("boom")

--- a/cmd/dune-admin/helpers.go
+++ b/cmd/dune-admin/helpers.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"regexp"
 	"strings"
 )
 
@@ -21,24 +20,4 @@ func shortClass(s string) string {
 		"DunePlayerState", "PlayerState",
 	)
 	return replacer.Replace(s)
-}
-
-// Per-position locomotion modules (e.g. OrnithopterLightLocomotionFrontLeft_6) share
-// a single generic catalog entry (ornithopterlightlocomotion_6).
-var locomotionPositionRe = regexp.MustCompile(`locomotion(frontleft|frontright|backleft|backright|backcenter)`)
-
-// itemMaxDurability returns the catalog-defined max_durability for a template_id,
-// retrying with the position suffix stripped for per-position locomotion modules.
-// Returns (0, false) when the catalog has no max_durability for the template.
-func itemMaxDurability(templateID string) (float64, bool) {
-	key := strings.ToLower(templateID)
-	if rule, ok := itemData.Items[key]; ok && rule.MaxDurability != nil {
-		return *rule.MaxDurability, true
-	}
-	if stripped := locomotionPositionRe.ReplaceAllString(key, "locomotion"); stripped != key {
-		if rule, ok := itemData.Items[stripped]; ok && rule.MaxDurability != nil {
-			return *rule.MaxDurability, true
-		}
-	}
-	return 0, false
 }


### PR DESCRIPTION
## Problem

Vehicle and batch-gear repair source the durability target from the PAK catalog (`item-data.json` `max_durability`, via `itemMaxDurability`). For transport-ornithopter T6 modules that catalog value is **~half** the module's true ceiling, so repairing a full Carrier Ornithopter dropped 8 of its 16 modules to **exactly 50%**. (The only modules left untouched were the ones whose template names the catalog lookup *failed* to match — the "tell" that confirmed the mechanism.)

The authoritative 100% ceiling is the `MaxDurability` already stored inside each module's / item's own `stats` jsonb. Single-item repair (`repairItemDurability`) already reads it correctly via `COALESCE((stats->...->>'MaxDurability')::float8, 100.0)`; the vehicle and batch-gear paths did not.

## Fix

Make all repair paths consistent with the single-item SQL:

- **Vehicle repair** — `loadVehicleModules` now fetches the in-row durability block (`MaxDurability/CurrentDurability/DecayedMaxDurability`). New `vehicleModuleRepairTarget` uses the in-row `MaxDurability` as the source of truth, **skips** modules that don't have it (the catalog is *not* used as a fallback — it's the thing that's wrong), and never lowers an existing higher value. `vehicleModuleAtTarget` makes an already-full module a genuine no-op.
- **Batch gear repair** — `repairTargetForItem` drops the catalog: in-row `MaxDurability` → `100.0` (default only for plain 0–100 gear). `buildRepairCandidate` applies a never-lower guard so a default-100 can't cap a higher-scale item (e.g. `MaxDurability=200`).
- **Single-item repair** — unchanged; it was already correct and is the reference pattern.
- Removed the now-unused `itemMaxDurability` catalog helper (and its `locomotionPositionRe` regex) from the repair paths.

## Behaviour invariants

- In-row `MaxDurability` is the source of truth; `100.0` is the default only for gear with no `MaxDurability`.
- Never write a value lower than what's already stored.
- Skip (and count) modules without an in-row `MaxDurability` rather than guessing from the catalog — dormant vehicles that haven't materialised `MaxDurability` need a single in-game load first.
- Both `CurrentDurability` and `DecayedMaxDurability` are written (current-only is clamped back to the surviving decayed ceiling on reload). Repairs remain gated on the owning player being **Offline**; relog required to see it in-game.

## Tests

Test-first. Extended the existing pure-helper tables in `db_cmd_repair_vehicle_test.go` and `db_cmd_repair_player_gear_test.go`:

- module with in-row `MaxDurability=12000`, `Current=6000` → restores to 12000 (the regression)
- module with no `MaxDurability` → skipped, counted, never written from catalog
- full module (`Current==Max`) → no-op
- 200-scale item (`MaxDurability=200`, damaged) → restores to 200, not 100
- plain 0–100 gear (no `MaxDurability`, damaged) → restores to 100
- never-lower guards on both paths

`go test ./...` green; `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)