### PR TITLE
fix: warn on stale .env that may shadow config.yaml (#87)

### DIFF
--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -233,10 +234,29 @@ func loadConfig() {
 			setEnvIfMissing("BROKER_JWT_SECRET", cfg.BrokerJWTSecret)
 			setEnvIfMissing("BACKUP_DIR", cfg.BackupDir)
 			setEnvIfMissing("SERVER_INI_DIR", cfg.ServerIniDir)
+			detectStaleEnvFile(".")
 			return
 		}
 	}
 	loadDotEnv()
+}
+
+// detectStaleEnvFile warns when a .env file exists in workDir alongside a
+// successfully-loaded config.yaml. A stale .env is ignored by dune-admin, but
+// values pre-exported into the process environment before startup (e.g. via a
+// shell that sourced the old file) can shadow config.yaml and silently break
+// features like market-bot control. Returns true when the file is detected.
+func detectStaleEnvFile(workDir string) bool {
+	if _, err := os.Stat(filepath.Join(workDir, ".env")); err != nil {
+		return false
+	}
+	log.Printf("[WARN] stale .env file found in %s", workDir)
+	log.Printf("[WARN] dune-admin is using %s — .env is ignored.", configPath())
+	log.Printf("[WARN] However, env vars pre-exported from .env before startup can")
+	log.Printf("[WARN] shadow config.yaml and silently break features (e.g. market-bot")
+	log.Printf("[WARN] control). Delete or rename .env and restart to be sure:")
+	log.Printf("[WARN]   mv %s %s.bak", filepath.Join(workDir, ".env"), filepath.Join(workDir, ".env"))
+	return true
 }
 
 func loadDotEnv() {

--- a/cmd/dune-admin/main_loadconfig_test.go
+++ b/cmd/dune-admin/main_loadconfig_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectStaleEnvFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no .env file returns false", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		if detectStaleEnvFile(dir) {
+			t.Fatal("expected false when no .env exists")
+		}
+	})
+
+	t.Run("present .env file returns true", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("DB_HOST=old-host\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if !detectStaleEnvFile(dir) {
+			t.Fatal("expected true when .env exists alongside config.yaml")
+		}
+	})
+
+	t.Run("unreadable directory returns false safely", func(t *testing.T) {
+		t.Parallel()
+		if detectStaleEnvFile("/nonexistent-path-that-cannot-exist") {
+			t.Fatal("expected false for nonexistent directory")
+		}
+	})
+}


### PR DESCRIPTION
## Problem

Users with a `.env` left over from an old install (before `config.yaml` was introduced by the setup wizard) had market-bot control silently broken. dune-admin ignores `.env` once `config.yaml` exists, but values pre-exported into the process environment before startup — e.g. via a systemd `EnvironmentFile=` or a shell that sourced the old file — can shadow `config.yaml` values and break things like the market-bot DB connection.

Affected users had to delete `.env` and run setup again; the root cause was invisible.

## Fix

After successfully loading `config.yaml`, `detectStaleEnvFile(".")` checks whether a `.env` still exists in the working directory and emits prominent `[WARN]` log lines telling operators exactly what file to delete and why:

```
[WARN] stale .env file found in .
[WARN] dune-admin is using ~/.dune-admin/config.yaml — .env is ignored.
[WARN] However, env vars pre-exported from .env before startup can
[WARN] shadow config.yaml and silently break features (e.g. market-bot
[WARN] control). Delete or rename .env and restart to be sure:
[WARN]   mv ./.env ./.env.bak
```

## Test plan

- [ ] Service starts with both `config.yaml` and `.env` present → `[WARN]` lines appear in logs
- [ ] Service starts with only `config.yaml` → no warning
- [ ] Service starts with only `.env` (no config.yaml) → no warning (`.env` is the expected path here)
- [ ] `make verify` passes

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)