### PR TITLE
fix: show meaningful version for source builds, fix update check (#88)

### DIFF
--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -18,15 +18,37 @@ import (
 	"dune-admin/internal/marketbot"
 )
 
-// AppVersion is the conduit release version shown to users.
+// AppVersion is the release version shown to users.
 // Populated at build time via -ldflags "-X main.AppVersion=$(VERSION)".
-// Defaults to "dev" so unreleased builds don't masquerade as a real
-// release and don't trigger the update notifier.
+// Falls back to "<VERSION file>-dev" for source builds without ldflags.
 var AppVersion = "dev"
 
 // GitCommit and BuildTime are stamped at build time.
 var GitCommit = "unknown"
 var BuildTime = "unknown"
+
+func init() {
+	AppVersion = resolveAppVersion(AppVersion, ".")
+}
+
+// resolveAppVersion returns ldflagsVersion when it was set by the build pipeline.
+// For plain `go build` / `go run` invocations that leave the default "dev", it
+// reads the VERSION file from workDir and returns "<version>-dev" so operators
+// can still tell which codebase they're running and update notifications work.
+func resolveAppVersion(ldflagsVersion, workDir string) string {
+	if ldflagsVersion != "dev" {
+		return ldflagsVersion
+	}
+	data, err := os.ReadFile(filepath.Join(workDir, "VERSION"))
+	if err != nil {
+		return "dev"
+	}
+	v := strings.TrimSpace(string(data))
+	if v == "" {
+		return "dev"
+	}
+	return v + "-dev"
+}
 
 // ── config ────────────────────────────────────────────────────────────────────
 

--- a/cmd/dune-admin/main_version_test.go
+++ b/cmd/dune-admin/main_version_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveAppVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		ldflagsVersion string
+		versionFile    string // empty = don't create
+		want           string
+	}{
+		{
+			name:           "ldflags version is used as-is",
+			ldflagsVersion: "0.14.2",
+			want:           "0.14.2",
+		},
+		{
+			name:           "dev with VERSION file returns version-dev",
+			ldflagsVersion: "dev",
+			versionFile:    "0.14.2",
+			want:           "0.14.2-dev",
+		},
+		{
+			name:           "dev with VERSION file strips trailing newline",
+			ldflagsVersion: "dev",
+			versionFile:    "0.14.2\n",
+			want:           "0.14.2-dev",
+		},
+		{
+			name:           "dev without VERSION file stays dev",
+			ldflagsVersion: "dev",
+			want:           "dev",
+		},
+		{
+			name:           "dev with empty VERSION file stays dev",
+			ldflagsVersion: "dev",
+			versionFile:    "   \n",
+			want:           "dev",
+		},
+		{
+			name:           "non-dev version ignores VERSION file entirely",
+			ldflagsVersion: "0.13.0",
+			versionFile:    "0.14.2",
+			want:           "0.13.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			if tt.versionFile != "" {
+				if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte(tt.versionFile), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got := resolveAppVersion(tt.ldflagsVersion, dir)
+			if got != tt.want {
+				t.Fatalf("resolveAppVersion(%q, dir) = %q, want %q", tt.ldflagsVersion, got, tt.want)
+			}
+		})
+	}
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -45,12 +45,12 @@ export default function App() {
 }
 
 function parseVer(v: string): [number, number, number] {
-  const [a, b, c] = v.replace(/^v/, "").split(".").map(Number);
+  // Strip leading "v" and any pre-release suffix (-dev, -rc1, etc.) before parsing.
+  const [a, b, c] = v.replace(/^v/, "").replace(/-.*$/, "").split(".").map(Number);
   return [a || 0, b || 0, c || 0];
 }
 
 function isNewer(latest: string, current: string): boolean {
-  if (current === "dev") return false;
   const [la, lb, lc] = parseVer(latest);
   const [ca, cb, cc] = parseVer(current);
   if (la !== ca) return la > ca;


### PR DESCRIPTION
## Problem

Source builds (plain `go build`, `go run`, `make dev` via air without ldflags) left `AppVersion` at its `"dev"` default, causing:
- The header to display **"vdev"** (confusing)
- The update notifier to be permanently suppressed (`isNewer` returned `false` for `"dev"`)

Self-hosters running from source never knew a newer release was available.

## Fix

**Backend** — `resolveAppVersion(ldflagsVersion, workDir string)` reads the `VERSION` file from the working directory when `AppVersion == "dev"` (no ldflags injected) and returns `"<version>-dev"` (e.g. `"0.14.2-dev"`). Called from `init()`. Release builds injected by `-ldflags` are completely unaffected.

**Frontend** — `parseVer()` now strips pre-release suffixes (`-dev`, `-rc1`, etc.) before semver comparison, so `"0.14.2-dev"` compares correctly against `"0.14.3"`. Removed the `isNewer` early-return that permanently suppressed the update chip for any unversioned build.

## Result

| Build path | Before | After |
|---|---|---|
| `goreleaser` / `make linux` | `v0.14.2` ✓ | `v0.14.2` ✓ (unchanged) |
| `make go` / `make build` | `v0.14.2` ✓ | `v0.14.2` ✓ (unchanged) |
| `go build` / `make dev` (air) | `vdev` ✗ | `v0.14.2-dev` ✓ |
| No VERSION file present | `vdev` ✗ | `vdev` (graceful fallback) |

## Test plan

- [ ] `make verify` passes
- [ ] `go build ./cmd/dune-admin/ && ./dune-admin` — header shows `v0.14.2-dev`, not `vdev`
- [ ] If a newer release exists on GitHub, update chip appears for the `-dev` build
- [ ] `goreleaser` / `make linux` build still shows plain `v0.14.2`

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)