### PR TITLE
fix(ui): even out nav spacing + tidy Welcome Kits config layout

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -352,8 +352,8 @@ function AppCore({ isSignedIn }: { isSignedIn: boolean }) {
 
       {/* Body: grouped left sidebar + content. All tabs stay mounted (inactive
           hidden) so per-tab state and isActive auto-refresh behavior persist. */}
-      <div className="flex-1 flex overflow-hidden min-h-0">
-        <nav className="w-60 shrink-0 flex flex-col gap-3 p-3 overflow-y-auto">
+      <div className="flex-1 flex gap-4 p-4 overflow-hidden min-h-0">
+        <nav className="w-60 shrink-0 flex flex-col gap-3 overflow-y-auto">
           {NAV_GROUPS.map((group) => (
             <SideNav
               key={group.title}
@@ -406,7 +406,7 @@ function AppCore({ isSignedIn }: { isSignedIn: boolean }) {
 // state and the isActive auto-refresh contract when switching via the sidebar.
 function TabPane({ active, children }: { active: boolean, children: ReactNode }) {
   return (
-    <div className={`h-full min-h-0 p-4 ${active ? 'flex flex-col' : 'hidden'}`}>
+    <div className={`h-full min-h-0 ${active ? 'flex flex-col' : 'hidden'}`}>
       {children}
     </div>
   )

--- a/web/src/tabs/WelcomePackageTab.tsx
+++ b/web/src/tabs/WelcomePackageTab.tsx
@@ -165,7 +165,7 @@ export default function WelcomePackageTab() {
       <Panel>
         <SectionLabel>Configuration</SectionLabel>
 
-        <label className="flex items-center gap-2 mt-1 cursor-pointer select-none">
+        <label className="flex items-center gap-2 mt-1 cursor-pointer select-none w-fit">
           <input
             type="checkbox"
             checked={enabled}
@@ -173,15 +173,16 @@ export default function WelcomePackageTab() {
             className="h-4 w-4 accent-accent"
           />
           <span className="text-sm text-foreground">Enabled</span>
-          <span className="text-xs text-muted">
-            — grants the active package to online players who haven't received that version.
-          </span>
         </label>
+        <p className="text-xs text-muted mt-1">
+          Grants the active package to online players who haven't received that version.
+        </p>
 
-        <div className="grid grid-cols-2 gap-3 mt-3 max-w-md">
-          <Field label="Active version (granted)" hint="what players receive">
+        <div className="flex flex-wrap items-end gap-4 mt-3">
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-muted">Active version</label>
             <select
-              className={`${INPUT_CLS} w-full`}
+              className={`${INPUT_CLS} w-48`}
               value={activeVersion}
               onChange={(e) => setActiveVersion(e.target.value)}
             >
@@ -190,48 +191,50 @@ export default function WelcomePackageTab() {
                 <option key={p.version} value={p.version}>{p.version}</option>
               ))}
             </select>
-          </Field>
-          <Field label="Scan interval (seconds)" hint="min 5s">
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-muted">Scan interval (sec)</label>
             <input
-              className={`${INPUT_CLS} w-full`}
+              className={`${INPUT_CLS} w-28`}
               type="number"
               min={5}
               value={scanSecs}
               onChange={(e) => setScanSecs(Number(e.target.value))}
             />
-          </Field>
+          </div>
         </div>
       </Panel>
 
       <Panel>
         <SectionLabel>Packages</SectionLabel>
 
-        <div className="flex flex-wrap items-end gap-3 mt-1">
-          <Field label="Editing version">
-            <select
-              className={`${INPUT_CLS} w-44`}
-              value={selected}
-              onChange={(e) => setSelected(e.target.value)}
-            >
-              <option value="">— select —</option>
-              {packages.map((p) => (
-                <option key={p.version} value={p.version}>
-                  {p.version}
-                  {p.version === activeVersion ? ' (active)' : ''}
-                </option>
-              ))}
-            </select>
-          </Field>
+        <div className="flex flex-col gap-3 mt-1">
+          <div className="flex items-end gap-3">
+            <Field label="Editing version">
+              <select
+                className={`${INPUT_CLS} w-44`}
+                value={selected}
+                onChange={(e) => setSelected(e.target.value)}
+              >
+                <option value="">— select —</option>
+                {packages.map((p) => (
+                  <option key={p.version} value={p.version}>
+                    {p.version}
+                    {p.version === activeVersion ? ' (active)' : ''}
+                  </option>
+                ))}
+              </select>
+            </Field>
+            {selected && (
+              <Button size="sm" variant="ghost" onPress={() => deleteVersion(selected)}>
+                <Icon name="trash-2" />
+                {' '}
+                Delete version
+              </Button>
+            )}
+          </div>
 
-          {selected && (
-            <Button size="sm" variant="ghost" onPress={() => deleteVersion(selected)}>
-              <Icon name="trash-2" />
-              {' '}
-              Delete version
-            </Button>
-          )}
-
-          <div className="flex items-end gap-2 ml-auto">
+          <div className="flex items-end gap-2">
             <Field label="New version name">
               <input
                 className={`${INPUT_CLS} w-40`}


### PR DESCRIPTION
Follow-up UI polish on top of #103 (Welcome Kits + SideNav), which merged just
before these two fixes were pushed.

## Even out nav/content spacing
The grouped SideNav's outer `nav` (p-3) + content pane (p-4) produced a ~28px gap
between the sidebar and tab content, while tabs with their own sub-nav (Database,
Logs, Storage, Players) use `gap-4` (16px) internally — so the outer gap read
larger than the inner one. Padding moved to the body row (`gap-4 p-4`); the nav's
`p-3` and the pane's `p-4` are dropped. Now window→nav, nav→content, and
sub-nav→content are all a uniform 16px.

## Tidy the Welcome Kits config layout
- Active Version / Scan Interval were in a `grid-cols-2` with wrapping hint labels
  that left the two inputs at different heights — replaced with a bottom-aligned
  flex row, fixed widths, and clean labels.
- Moved the "New version name + Add" controls out of the right-floated (`ml-auto`)
  group into a row directly under the Editing Version selector.

Layout-only; ESLint + `tsc -b` clean, deployed and eyeballed on a test server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
