### PR TITLE
docs(amp): document Docker as an AMP container runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dune-admin
 
-Web-based admin panel for a Dune Awakening private server. Works against any deployment topology — CubeCoders AMP with podman, k3s/k8s over SSH, Docker containers, or a bare-metal install.
+Web-based admin panel for a Dune Awakening private server. Works against any deployment topology — CubeCoders AMP (podman or docker), k3s/k8s over SSH, Docker containers, or a bare-metal install.
 
 ---
 
@@ -37,7 +37,7 @@ Pick the provider that matches your game-server topology. Each guide covers prer
 
 | Provider | Use when | Guide |
 |----------|----------|-------|
-| **amp** | Game server runs under CubeCoders AMP (host or podman container) | [SETUP_AMP.md](SETUP_AMP.md) |
+| **amp** | Game server runs under CubeCoders AMP (host, or a podman/docker container) | [SETUP_AMP.md](SETUP_AMP.md) |
 | **kubectl** | Game server runs in k3s/K8s on a remote VM | [SETUP_KUBECTL.md](SETUP_KUBECTL.md) |
 | **docker** | Game server runs as Docker containers (compose or standalone) | [SETUP_DOCKER.md](SETUP_DOCKER.md) |
 | **local** | Game server runs on the same machine — bare metal, LGSM, custom | [SETUP_LOCAL.md](SETUP_LOCAL.md) |

--- a/SETUP_AMP.md
+++ b/SETUP_AMP.md
@@ -1,6 +1,6 @@
 # Provider: amp (CubeCoders AMP)
 
-Use this provider when your Dune server is managed by AMP (`ampinstmgr`) and RabbitMQ/Postgres live in the AMP stack (host-native or podman-backed).
+Use this provider when your Dune server is managed by AMP (`ampinstmgr`) and RabbitMQ/Postgres live in the AMP stack (host-native, or in a podman- or docker-backed container). Set `amp_container_runtime` to match (`podman` default, or `docker`).
 
 ```
 dune-admin
@@ -15,7 +15,7 @@ dune-admin
 |-------------|-------|
 | **Go 1.21+** | `brew install go` or <https://go.dev/dl/> |
 | **AMP host access** | Run dune-admin on the AMP host, or set `ssh_host` to run remotely over SSH |
-| **Sudoers grant** | dune-admin user must run `ampinstmgr`, `podman`, and `tee` as AMP user without prompts |
+| **Sudoers grant** | dune-admin user must run `ampinstmgr`, the container runtime (`podman`, or `docker` when `amp_container_runtime: docker`), and `tee` as AMP user without prompts |
 
 Example sudoers entry (adjust user/path names as needed):
 
@@ -97,4 +97,4 @@ External market-bot mode is removed; use embedded mode for AMP deployments.
 
 **INI changes fail** — verify `server_ini_dir` and that AMP user owns `UserGame.ini` / `UserEngine.ini`.
 
-**Broker commands fail** — set `broker_exec_prefix` to the exact `podman exec` wrapper used on your AMP host.
+**Broker commands fail** — set `broker_exec_prefix` to the exact `podman exec` (or `docker exec`) wrapper used on your AMP host.


### PR DESCRIPTION
## Summary

Follow-up to #107, which added the `amp_container_runtime` config key (`podman` | `docker`) so the AMP control plane can drive a Docker-backed install. That PR updated `CLAUDE.md` and added the key to `SETUP_AMP.md`, but the README and parts of `SETUP_AMP.md` still framed AMP as **podman-only**. This sweeps that.

## Changes (docs only — no code)

**README.md**
- Intro: "CubeCoders AMP (podman or docker)" (was "AMP with podman").
- Providers table: AMP "host, or a podman/docker container".

**SETUP_AMP.md**
- Intro notes host-native / podman / docker backends and points at `amp_container_runtime`.
- Sudoers-grant row notes the container runtime is `podman` **or `docker`** (grant `/usr/bin/docker` when `amp_container_runtime: docker`).
- Broker-troubleshooting note mentions the `docker exec` variant.

Verified with `markdownlint` (the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)