### PR TITLE
fix(amp): wrap listGameProcesses ps in container exec (#99)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ deploy/k8s/dune-admin.rendered.yaml
 # Reference material / ideas / scratch — not for sharing
 Samples-Ideas/
 tmp/dune-admin
+.worktrees

--- a/cmd/dune-admin/control_amp.go
+++ b/cmd/dune-admin/control_amp.go
@@ -138,6 +138,9 @@ func parseAMPGameProcess(line string) (ampGameProcess, bool) {
 func (c *ampControl) listGameProcesses(exec Executor) ([]ampGameProcess, error) {
 	cmd := `ps -eo pid,args --no-headers 2>/dev/null | grep 'DuneSandboxServer-Linux-Shipping' | grep -v grep`
 	if c.useContainer {
+		if c.container == "" {
+			return nil, fmt.Errorf("amp_container not configured")
+		}
 		cmd = c.wrapInContainer(cmd)
 	}
 	out, err := exec.Exec(cmd)

--- a/cmd/dune-admin/control_amp.go
+++ b/cmd/dune-admin/control_amp.go
@@ -136,7 +136,11 @@ func parseAMPGameProcess(line string) (ampGameProcess, bool) {
 }
 
 func (c *ampControl) listGameProcesses(exec Executor) ([]ampGameProcess, error) {
-	out, err := exec.Exec(`ps -eo pid,args --no-headers 2>/dev/null | grep 'DuneSandboxServer-Linux-Shipping' | grep -v grep`)
+	cmd := `ps -eo pid,args --no-headers 2>/dev/null | grep 'DuneSandboxServer-Linux-Shipping' | grep -v grep`
+	if c.useContainer {
+		cmd = c.wrapInContainer(cmd)
+	}
+	out, err := exec.Exec(cmd)
 	if err != nil && strings.TrimSpace(out) == "" {
 		return []ampGameProcess{}, nil
 	}

--- a/cmd/dune-admin/control_amp_test.go
+++ b/cmd/dune-admin/control_amp_test.go
@@ -104,6 +104,39 @@ func TestListGameProcesses_EmptyOnExecErrorWithoutOutput(t *testing.T) {
 	}
 }
 
+func TestListGameProcesses_NoContainer(t *testing.T) {
+	t.Parallel()
+
+	ctrl := &ampControl{useContainer: false}
+	exec := &fakeAMPExecutor{out: ""}
+	_, _ = ctrl.listGameProcesses(exec)
+	if strings.Contains(exec.cmd, " exec ") {
+		t.Fatalf("expected no container wrapping for useContainer=false, got cmd: %q", exec.cmd)
+	}
+	if !strings.Contains(exec.cmd, "DuneSandboxServer") {
+		t.Fatalf("expected ps command for DuneSandboxServer, got: %q", exec.cmd)
+	}
+}
+
+func TestListGameProcesses_WithContainer(t *testing.T) {
+	t.Parallel()
+
+	ctrl := &ampControl{
+		useContainer:     true,
+		container:        "AMP_Dune01",
+		ampUser:          "amp",
+		containerRuntime: "podman",
+	}
+	exec := &fakeAMPExecutor{out: ""}
+	_, _ = ctrl.listGameProcesses(exec)
+	if !strings.Contains(exec.cmd, "podman exec AMP_Dune01") {
+		t.Fatalf("expected podman exec wrapping, got cmd: %q", exec.cmd)
+	}
+	if !strings.Contains(exec.cmd, "DuneSandboxServer") {
+		t.Fatalf("expected ps command inside wrapper, got: %q", exec.cmd)
+	}
+}
+
 // TestAmpDiscoverIniDir_PrefersUE5SavedPath verifies that when
 // ue5-saved/UserSettings/UserGame.ini exists (install.sh layout),
 // DiscoverIniDir returns that sub-directory rather than the base state dir.

--- a/cmd/dune-admin/control_amp_test.go
+++ b/cmd/dune-admin/control_amp_test.go
@@ -109,7 +109,10 @@ func TestListGameProcesses_NoContainer(t *testing.T) {
 
 	ctrl := &ampControl{useContainer: false}
 	exec := &fakeAMPExecutor{out: ""}
-	_, _ = ctrl.listGameProcesses(exec)
+	_, err := ctrl.listGameProcesses(exec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if strings.Contains(exec.cmd, " exec ") {
 		t.Fatalf("expected no container wrapping for useContainer=false, got cmd: %q", exec.cmd)
 	}
@@ -128,12 +131,26 @@ func TestListGameProcesses_WithContainer(t *testing.T) {
 		containerRuntime: "podman",
 	}
 	exec := &fakeAMPExecutor{out: ""}
-	_, _ = ctrl.listGameProcesses(exec)
+	_, err := ctrl.listGameProcesses(exec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if !strings.Contains(exec.cmd, "podman exec AMP_Dune01") {
 		t.Fatalf("expected podman exec wrapping, got cmd: %q", exec.cmd)
 	}
 	if !strings.Contains(exec.cmd, "DuneSandboxServer") {
 		t.Fatalf("expected ps command inside wrapper, got: %q", exec.cmd)
+	}
+}
+
+func TestListGameProcesses_WithContainer_MissingContainerName(t *testing.T) {
+	t.Parallel()
+
+	ctrl := &ampControl{useContainer: true, container: "", ampUser: "amp"}
+	exec := &fakeAMPExecutor{out: ""}
+	_, err := ctrl.listGameProcesses(exec)
+	if err == nil {
+		t.Fatal("expected error when useContainer=true but container name is empty")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `listGameProcesses` was running `ps` directly on the host, but containerised AMP setups (podman/docker) give the container its own PID namespace — host `ps` sees no `DuneSandboxServer` processes
- Added a `useContainer` guard matching the pattern already used by `ListLogSources`, `StreamLog`, `ReadDefaultINI`, and `EvalOnGameBroker`
- Added two new tests: `TestListGameProcesses_NoContainer` (no wrapping) and `TestListGameProcesses_WithContainer` (podman exec wrapping)

## Test plan

- [ ] `make verify` passes (all checks green)
- [ ] `TestListGameProcesses_WithContainer` confirms `podman exec AMP_Dune01` prefix is present
- [ ] `TestListGameProcesses_NoContainer` confirms host path is unchanged

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)