### PR TITLE
fix(players): route schematic and augment items through DB path (#106)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ deploy/k8s/dune-admin.rendered.yaml
 # Reference material / ideas / scratch — not for sharing
 Samples-Ideas/
 tmp/dune-admin
+.worktrees

--- a/cmd/dune-admin/handlers_players.go
+++ b/cmd/dune-admin/handlers_players.go
@@ -236,6 +236,36 @@ func handleGetJourney(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /api/v1/players/give-item [post]
+// tryGiveItemViaRMQ attempts to deliver an item to an online player via the RMQ
+// server command path (instant, no relog needed). Returns true if the request
+// was handled (success or error written to w), false if the caller should fall
+// through to the DB path. RMQ is skipped for quality > 0 or for item types
+// (schematics, augments) where grade is stored as quality_level in the DB.
+func tryGiveItemViaRMQ(w http.ResponseWriter, playerID int64, template string, qty int64) bool {
+	ctx := context.Background()
+	if checkPlayerOffline(ctx, playerID) == nil {
+		return false
+	}
+	if err := checkInventoryCapacity(ctx, playerID, template, qty); err != nil {
+		jsonErr(w, err, 400)
+		return true
+	}
+	flsID, err := flsIDFromActorID(ctx, playerID)
+	if err != nil {
+		jsonErr(w, fmt.Errorf("resolve player: %w", err), 404)
+		return true
+	}
+	if err := rmqAddItemToInventory(flsID, template, int(qty), 1.0); err != nil {
+		jsonErr(w, err, 500)
+		return true
+	}
+	jsonOK(w, map[string]any{
+		"ok":   fmt.Sprintf("sent %d × %s to online player %d via server command (instant)", qty, template, playerID),
+		"path": "rmq",
+	})
+	return true
+}
+
 func handleGiveItem(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		PlayerID int64  `json:"player_id"`
@@ -248,34 +278,16 @@ func handleGiveItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Route online + quality-0 items through RMQ (instant, no relog needed).
-	// RMQ AddItemToInventory has no Quality field so the DB path is required for quality > 0.
-	if req.Quality == 0 {
-		ctx := context.Background()
-		if checkPlayerOffline(ctx, req.PlayerID) != nil {
-			// Player is online — use RMQ path.
-			if err := checkInventoryCapacity(ctx, req.PlayerID, req.Template, req.Qty); err != nil {
-				jsonErr(w, err, 400)
-				return
-			}
-			flsID, err := flsIDFromActorID(ctx, req.PlayerID)
-			if err != nil {
-				jsonErr(w, fmt.Errorf("resolve player: %w", err), 404)
-				return
-			}
-			if err := rmqAddItemToInventory(flsID, req.Template, int(req.Qty), 1.0); err != nil {
-				jsonErr(w, err, 500)
-				return
-			}
-			jsonOK(w, map[string]any{
-				"ok":   fmt.Sprintf("sent %d × %s to online player %d via server command (instant)", req.Qty, req.Template, req.PlayerID),
-				"path": "rmq",
-			})
+	// RMQ path: online player, quality=0, and item grade doesn't matter.
+	// Schematics and augment items are excluded — their quality_level must be
+	// stored explicitly in the DB; the RMQ command has no grade field.
+	if req.Quality == 0 && !itemNeedsDBPath(req.Template) {
+		if tryGiveItemViaRMQ(w, req.PlayerID, req.Template, req.Qty) {
 			return
 		}
 	}
 
-	// DB path: offline player or quality > 0.
+	// DB path: offline player, quality > 0, or grade-sensitive item.
 	msg, ok := cmdGiveItem(req.PlayerID, req.Template, req.Qty, req.Quality)().(msgMutate)
 	if !ok {
 		jsonErr(w, fmt.Errorf("internal error"), 500)
@@ -308,6 +320,7 @@ type giveItemsDeps struct {
 	checkCapacity func(context.Context, int64, string, int64) error
 	rmqAdd        func(string, string, int, float64) error
 	dbGive        func(int64, string, int64, int64) (msgMutate, bool)
+	needsDBPath   func(string) bool
 }
 
 func resolveGiveItemsOnlinePath(
@@ -327,8 +340,21 @@ func resolveGiveItemsOnlinePath(
 	return true, flsID
 }
 
+// itemNeedsDBPath reports whether the item must bypass the RMQ path so that its
+// quality_level is stored explicitly. Schematics and augmentation-category items
+// have grade-dependent behaviour that the RMQ AddItemToInventory command cannot
+// express (it has no quality/grade field).
+func itemNeedsDBPath(template string) bool {
+	rule, ok := itemRuleLookup(template)
+	if !ok {
+		return false
+	}
+	return rule.IsSchematic || strings.Contains(strings.ToLower(rule.Category), "augment")
+}
+
 func processOneGiveItem(ctx context.Context, playerID int64, item giveItemInput, online bool, flsID string, deps giveItemsDeps) (string, *skippedItem) {
-	if online && item.Quality == 0 {
+	needsDB := deps.needsDBPath != nil && deps.needsDBPath(item.Template)
+	if online && item.Quality == 0 && !needsDB {
 		if err := deps.checkCapacity(ctx, playerID, item.Template, item.Qty); err != nil {
 			return "", &skippedItem{Template: item.Template, Reason: err.Error()}
 		}
@@ -392,6 +418,7 @@ func handleGiveItems(w http.ResponseWriter, r *http.Request) {
 			msg, ok := cmdGiveItem(playerID, template, qty, quality)().(msgMutate)
 			return msg, ok
 		},
+		needsDBPath: itemNeedsDBPath,
 	})
 
 	jsonOK(w, map[string]any{"given": given, "skipped": skipped})

--- a/cmd/dune-admin/handlers_players_give_items_test.go
+++ b/cmd/dune-admin/handlers_players_give_items_test.go
@@ -58,6 +58,7 @@ func TestProcessGiveItems(t *testing.T) {
 			}
 			return msgMutate{ok: "done"}, true
 		},
+		needsDBPath: func(string) bool { return false },
 	})
 
 	if len(given) != 2 || given[0] != "A" || given[1] != "B" {
@@ -91,6 +92,7 @@ func TestProcessGiveItems_DBFailureReasons(t *testing.T) {
 			}
 			return msgMutate{err: errors.New("db failed")}, true
 		},
+		needsDBPath: func(string) bool { return false },
 	})
 
 	if len(given) != 0 {
@@ -104,5 +106,67 @@ func TestProcessGiveItems_DBFailureReasons(t *testing.T) {
 	}
 	if skipped[1].Template != "Y" || skipped[1].Reason != "db failed" {
 		t.Fatalf("unexpected second skipped entry: %+v", skipped[1])
+	}
+}
+
+func TestProcessGiveItems_SchematicUsesDBPath(t *testing.T) {
+	t.Parallel()
+
+	req := giveItemsRequest{
+		PlayerID: 11,
+		Items:    []giveItemInput{{Template: "SchematicPattern_Sword", Qty: 1, Quality: 0}},
+	}
+
+	var rmqCalled bool
+	var dbCalled bool
+	processGiveItems(context.Background(), req, true, "fls-abc", giveItemsDeps{
+		checkCapacity: func(context.Context, int64, string, int64) error { return nil },
+		rmqAdd: func(string, string, int, float64) error {
+			rmqCalled = true
+			return nil
+		},
+		dbGive: func(_ int64, _ string, _, _ int64) (msgMutate, bool) {
+			dbCalled = true
+			return msgMutate{ok: "done"}, true
+		},
+		needsDBPath: func(template string) bool { return template == "SchematicPattern_Sword" },
+	})
+
+	if rmqCalled {
+		t.Fatal("schematic with quality=0 should not use RMQ path")
+	}
+	if !dbCalled {
+		t.Fatal("schematic with quality=0 should use DB path")
+	}
+}
+
+func TestProcessGiveItems_AugmentUsesDBPath(t *testing.T) {
+	t.Parallel()
+
+	req := giveItemsRequest{
+		PlayerID: 11,
+		Items:    []giveItemInput{{Template: "Augment_ArmorPiercing", Qty: 1, Quality: 0}},
+	}
+
+	var rmqCalled bool
+	var dbCalled bool
+	processGiveItems(context.Background(), req, true, "fls-abc", giveItemsDeps{
+		checkCapacity: func(context.Context, int64, string, int64) error { return nil },
+		rmqAdd: func(string, string, int, float64) error {
+			rmqCalled = true
+			return nil
+		},
+		dbGive: func(_ int64, _ string, _, _ int64) (msgMutate, bool) {
+			dbCalled = true
+			return msgMutate{ok: "done"}, true
+		},
+		needsDBPath: func(template string) bool { return template == "Augment_ArmorPiercing" },
+	})
+
+	if rmqCalled {
+		t.Fatal("augment item with quality=0 should not use RMQ path")
+	}
+	if !dbCalled {
+		t.Fatal("augment item with quality=0 should use DB path")
 	}
 }

--- a/cmd/dune-admin/welcome_package.go
+++ b/cmd/dune-admin/welcome_package.go
@@ -111,6 +111,7 @@ func welcomeGrantViaGiveItems(ctx context.Context, pawnID int64, flsID string, i
 			msg, ok := cmdGiveItem(playerID, template, qty, quality)().(msgMutate)
 			return msg, ok
 		},
+		needsDBPath: itemNeedsDBPath,
 	})
 	reasons := make([]string, 0, len(skipped))
 	for _, s := range skipped {


### PR DESCRIPTION
## Summary

- The RMQ `AddItemToInventory` command has no quality/grade field; items given to online players via RMQ always land at the game server's default quality (0)
- For schematic patterns and augmentation items, `quality_level=0` results in unbounded resource requirements (e.g. 1000 spice)
- Added `itemNeedsDBPath(template)` helper: returns `true` for `IsSchematic` items and items in the `augment` category
- Both `handleGiveItem` and `processOneGiveItem` now skip RMQ for these item types, ensuring `quality_level` is stored explicitly via the DB path regardless of player online status
- Extracted `tryGiveItemViaRMQ` helper to keep `handleGiveItem` under the cognitive complexity limit
- The RMQ fast path for regular quality-0 items (consumables, ammo, gear) is unchanged

## Test plan

- [ ] `make verify` passes (all checks green)
- [ ] `TestProcessGiveItems_SchematicUsesDBPath`: schematic with quality=0, online player → DB path, not RMQ
- [ ] `TestProcessGiveItems_AugmentUsesDBPath`: augment item with quality=0, online player → DB path, not RMQ
- [ ] Existing `TestProcessGiveItems` still passes (regular items still use RMQ)

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)