### PR TITLE
feat(chat): GM/Server identity + corrected admin whisper

### DIFF
--- a/cmd/dune-admin/connection.go
+++ b/cmd/dune-admin/connection.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"net"
 
 	"github.com/jackc/pgx/v5"
@@ -118,6 +119,14 @@ func connectAll() error {
 		return fmt.Errorf("DB connect: %w", err)
 	}
 	globalDB = pool
+
+	// Best-effort: ensure the GM/Server chat persona exists for admin messaging
+	// (whisper, map announce). Idempotent (ON CONFLICT DO NOTHING); a failure here
+	// must never block startup or reconnect, so it is logged and swallowed.
+	if err := cmdEnsureGMIdentity(context.Background()); err != nil {
+		log.Printf("connectAll: ensure GM identity: %v", err)
+	}
+
 	return nil
 }
 

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -72,8 +72,8 @@ func cmdFetchPlayers() Msg {
 		LEFT JOIN dune.encrypted_accounts e ON e.id = a.owner_account_id
 		LEFT JOIN dune.accounts ac ON ac.id = a.owner_account_id
 		LEFT JOIN dune.player_faction pf ON pf.actor_id = a.id
-		WHERE a.class ILIKE '%PlayerCharacter%'
-		ORDER BY a.id`)
+		WHERE a.class ILIKE '%PlayerCharacter%' AND a.owner_account_id <> $1
+		ORDER BY a.id`, gmIdentityAccountID)
 	if err != nil {
 		return msgPlayers{err: err}
 	}
@@ -730,7 +730,7 @@ func listWelcomeOnlineAccounts(ctx context.Context) ([]welcomeAccount, error) {
 		FROM dune.player_state ps
 		JOIN dune.actors a ON a.id = ps.player_pawn_id
 		JOIN dune.accounts ac ON ac.id = a.owner_account_id
-		WHERE ps.online_status = 'Online' AND ps.player_pawn_id IS NOT NULL`)
+		WHERE ps.online_status = 'Online' AND ps.player_pawn_id IS NOT NULL AND ps.account_id <> $1`, gmIdentityAccountID)
 	if err != nil {
 		return nil, fmt.Errorf("list welcome accounts: %w", err)
 	}
@@ -980,6 +980,164 @@ func rawFuncomID(ctx context.Context, accountID int64) (string, error) {
 	return id, err
 }
 
+// Seeded "GM/Server" chat persona sentinels. The account id is held in a high,
+// out-of-range slot so it never collides with a real player (Phase 0 recon: real
+// accounts max out near id 2, actors near 54) and so operator-facing queries can
+// exclude it. The actor ids derive from the account id. Single source of truth;
+// the seed routine and the blast-radius exclusions both key off these.
+const (
+	gmIdentityAccountID     int64  = 9000001
+	gmIdentityHexID         string = "DA5EBA11DA5EBA11" // accounts."user" (AMQP user_id)
+	gmIdentityFuncomID      string = "GM#0001"          // chat id (m_FuncomIdFrom)
+	gmIdentityCharacterName string = "GM"               // in-game display name
+)
+
+// errGMNotProvisioned signals that the GM/Server chat persona has not been seeded
+// yet, so admin chat cannot resolve a sender identity. Mapped to 503 by handlers.
+var errGMNotProvisioned = errors.New("gm identity not provisioned")
+
+// cmdGetGMIdentity reads the seeded GM/Server persona used as the sender for admin
+// chat. Returns its hex FLS id (the AMQP user_id) and funcom id (m_FuncomIdFrom).
+// Reads the dune.accounts VIEW, which decrypts funcom_id from the encrypted base
+// table — so this stays correct even if user-data encryption is enabled. Returns
+// errGMNotProvisioned if the identity row does not exist yet.
+func cmdGetGMIdentity(ctx context.Context) (gmIdentity, error) {
+	gm := gmIdentity{AccountID: gmIdentityAccountID}
+	err := globalDB.QueryRow(ctx, `
+		SELECT "user", funcom_id
+		FROM dune.accounts
+		WHERE id = $1`, gmIdentityAccountID).Scan(&gm.HexID, &gm.FuncomID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return gmIdentity{}, errGMNotProvisioned
+	}
+	if err != nil {
+		return gmIdentity{}, fmt.Errorf("read gm identity: %w", err)
+	}
+	return gm, nil
+}
+
+// cmdResolveRecipientChatIdentity resolves a whisper recipient by account id into
+// the values the whisper wire body needs: funcom id (m_SubChannelId + AMQP routing
+// key) and character name (m_UserNameTo). Reads the decrypting accounts/player_state
+// views so it is correct regardless of the user-data encryption setting.
+func cmdResolveRecipientChatIdentity(ctx context.Context, accountID int64) (funcomID, charName string, err error) {
+	err = globalDB.QueryRow(ctx, `
+		SELECT a.funcom_id, COALESCE(ps.character_name, '')
+		FROM dune.accounts a
+		LEFT JOIN dune.player_state ps ON ps.account_id = a.id
+		WHERE a.id = $1`, accountID).Scan(&funcomID, &charName)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve recipient %d: %w", accountID, err)
+	}
+	return funcomID, charName, nil
+}
+
+// gmSeed holds the fixed values written for the GM/Server persona. Centralised so
+// the sentinel ids, the actor class paths (which MUST match the live schema or the
+// game's player-info lookup fails), and the blast-radius-safe defaults are testable
+// and have one source of truth. Class paths + partition are from Phase 0 recon.
+type gmSeed struct {
+	AccountID       int64
+	HexID           string
+	FuncomID        string
+	CharacterName   string
+	ControllerID    int64
+	StateID         int64
+	PawnID          int64
+	ControllerClass string
+	StateClass      string
+	PawnClass       string
+	Map             string
+	PartitionID     int64
+	DimensionIndex  int
+	OnlineStatus    string
+	LifeState       string
+}
+
+func gmSeedSpec() gmSeed {
+	return gmSeed{
+		AccountID:       gmIdentityAccountID,
+		HexID:           gmIdentityHexID,
+		FuncomID:        gmIdentityFuncomID,
+		CharacterName:   gmIdentityCharacterName,
+		ControllerID:    gmIdentityAccountID*100 + 1, // 900000101
+		StateID:         gmIdentityAccountID*100 + 2, // 900000102
+		PawnID:          gmIdentityAccountID*100 + 3, // 900000103
+		ControllerClass: "/Game/Dune/Characters/Player/BP_DunePlayerController.BP_DunePlayerController_C",
+		StateClass:      "/Script/DuneSandbox.DunePlayerState",
+		PawnClass:       "/Game/Dune/Characters/Player/BP_DunePlayerCharacter.BP_DunePlayerCharacter_C",
+		Map:             "HaggaBasin",
+		PartitionID:     1,
+		DimensionIndex:  0,
+		OnlineStatus:    "Offline", // blast-radius safe; flip to Online only if verify needs it
+		LifeState:       "Alive",
+	}
+}
+
+// cmdEnsureGMIdentity idempotently seeds the GM/Server persona used as the sender
+// for admin chat. It writes the BASE tables (dune.accounts / dune.player_state are
+// VIEWS over them, per Phase 0 recon) plus the three linked actor rows the game's
+// player-info lookup requires. Names go through dune.encrypt_user_data so the seed
+// stays correct if user-data encryption is ever enabled. actors.transform is left
+// NULL so the GM never plots on the live map. Safe to call on every startup
+// (ON CONFLICT DO NOTHING); the connectAll wiring logs-and-continues on failure.
+func cmdEnsureGMIdentity(ctx context.Context) error {
+	if globalDB == nil {
+		return fmt.Errorf("not connected")
+	}
+	s := gmSeedSpec()
+
+	tx, err := globalDB.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin gm seed: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO dune.encrypted_accounts (id, "user", encrypted_funcom_id, takeoverable, platform_id, platform_name)
+		VALUES ($1, $2, dune.encrypt_user_data($3), false, 'dune-admin', 'DuneAdmin')
+		ON CONFLICT DO NOTHING`, s.AccountID, s.HexID, s.FuncomID); err != nil {
+		return fmt.Errorf("seed gm account: %w", err)
+	}
+
+	actors := []struct {
+		id    int64
+		class string
+	}{
+		{s.ControllerID, s.ControllerClass},
+		{s.StateID, s.StateClass},
+		{s.PawnID, s.PawnClass},
+	}
+	for _, a := range actors {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO dune.actors (id, class, map, partition_id, dimension_index, gas_attributes, properties, owner_account_id, serial)
+			VALUES ($1, $2, $3, $4, $5, '{}'::jsonb, '{}'::jsonb, $6, 1)
+			ON CONFLICT DO NOTHING`,
+			a.id, a.class, s.Map, s.PartitionID, s.DimensionIndex, s.AccountID); err != nil {
+			return fmt.Errorf("seed gm actor %d: %w", a.id, err)
+		}
+	}
+
+	// server_id reuses a real one if any player has logged in (the game's lookup
+	// expects a valid server). NULL is acceptable on a never-populated DB.
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO dune.encrypted_player_state
+			(account_id, encrypted_character_name, life_state, online_status, is_coriolis_processed,
+			 server_id, player_controller_id, player_pawn_id, player_state_id, last_login_time)
+		VALUES ($1, dune.encrypt_user_data($2), $3::dune.playerlifestate, $4::dune.playerconnectionstatus, false,
+			(SELECT server_id FROM dune.encrypted_player_state WHERE server_id IS NOT NULL LIMIT 1),
+			$5, $6, $7, now())
+		ON CONFLICT DO NOTHING`,
+		s.AccountID, s.CharacterName, s.LifeState, s.OnlineStatus, s.ControllerID, s.PawnID, s.StateID); err != nil {
+		return fmt.Errorf("seed gm player_state: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit gm seed: %w", err)
+	}
+	return nil
+}
+
 func cmdGrantReturningPlayerAward(accountID int64) Cmd {
 	return func() Msg {
 		if globalDB == nil {
@@ -1116,7 +1274,8 @@ func cmdFetchOnlineState() Msg {
 		       COALESCE(to_char(ps.last_avatar_activity AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS'), '')
 		FROM dune.player_state ps
 		LEFT JOIN dune.actors a ON a.id = ps.player_controller_id
-		ORDER BY ps.online_status DESC, ps.last_avatar_activity DESC`)
+		WHERE ps.account_id <> $1
+		ORDER BY ps.online_status DESC, ps.last_avatar_activity DESC`, gmIdentityAccountID)
 	if err != nil {
 		return msgOnlineState{err: err}
 	}
@@ -4770,7 +4929,7 @@ func cmdListBases() Msg {
 // cmdFetchOnlineAccountIDs returns the account IDs of all players currently
 // marked Online in player_state. Used by the session poller.
 func cmdFetchOnlineAccountIDs(ctx context.Context, pool *pgxpool.Pool) ([]int64, error) {
-	rows, err := pool.Query(ctx, `SELECT account_id FROM dune.player_state WHERE online_status = 'Online'`)
+	rows, err := pool.Query(ctx, `SELECT account_id FROM dune.player_state WHERE online_status = 'Online' AND account_id <> $1`, gmIdentityAccountID)
 	if err != nil {
 		return nil, fmt.Errorf("fetch online account ids: %w", err)
 	}

--- a/cmd/dune-admin/db_gm_identity_test.go
+++ b/cmd/dune-admin/db_gm_identity_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGMSeedSpec locks the recon-derived seed values for the GM/Server persona:
+// the sentinel ids (collision-free per Phase 0 recon), the exact actor class paths
+// the live schema uses (or the game's player-info lookup fails and the sender never
+// renders), and the blast-radius-safe defaults (Offline status; the seed routine
+// leaves actors.transform NULL so the GM never plots on the live map).
+func TestGMSeedSpec(t *testing.T) {
+	t.Parallel()
+	s := gmSeedSpec()
+
+	if s.AccountID != gmIdentityAccountID {
+		t.Fatalf("AccountID = %d, want %d", s.AccountID, gmIdentityAccountID)
+	}
+	// Actor ids derive from the account id: 9000001 -> 900000101/02/03.
+	if s.ControllerID != 900000101 || s.StateID != 900000102 || s.PawnID != 900000103 {
+		t.Fatalf("actor ids wrong: %d/%d/%d", s.ControllerID, s.StateID, s.PawnID)
+	}
+	if !strings.Contains(s.ControllerClass, "BP_DunePlayerController") {
+		t.Fatalf("controller class wrong: %s", s.ControllerClass)
+	}
+	if !strings.Contains(s.StateClass, "DunePlayerState") {
+		t.Fatalf("state class wrong: %s", s.StateClass)
+	}
+	if !strings.Contains(s.PawnClass, "BP_DunePlayerCharacter") {
+		t.Fatalf("pawn class wrong: %s", s.PawnClass)
+	}
+	// Blast-radius: Offline keeps the GM out of the online pollers / welcome scanner.
+	if s.OnlineStatus != "Offline" {
+		t.Fatalf("OnlineStatus = %q, want Offline", s.OnlineStatus)
+	}
+	if s.LifeState != "Alive" {
+		t.Fatalf("LifeState = %q, want Alive", s.LifeState)
+	}
+	if s.FuncomID != "GM#0001" || s.CharacterName != "GM" {
+		t.Fatalf("persona wrong: funcom=%q char=%q", s.FuncomID, s.CharacterName)
+	}
+	if s.Map != "HaggaBasin" || s.PartitionID != 1 {
+		t.Fatalf("location wrong: map=%q partition=%d", s.Map, s.PartitionID)
+	}
+}

--- a/cmd/dune-admin/handlers_players_whisper_test.go
+++ b/cmd/dune-admin/handlers_players_whisper_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestProcessWhisper exercises the whisper orchestration with injected deps (no
+// DB/broker), mirroring the processGiveItems testing pattern. It asserts the
+// resolved GM sender + recipient identities flow into send in the right slots and
+// that each failure short-circuits the steps after it.
+func TestProcessWhisper(t *testing.T) {
+	t.Parallel()
+
+	okGM := func(context.Context) (gmIdentity, error) {
+		return gmIdentity{AccountID: gmIdentityAccountID, HexID: "GMHEX", FuncomID: "Server#0001"}, nil
+	}
+
+	t.Run("happy path passes resolved identities to send", func(t *testing.T) {
+		t.Parallel()
+		var got struct{ senderFuncom, senderHex, recipFuncom, recipName, msg string }
+		err := processWhisper(context.Background(), 42, "hello", whisperDeps{
+			getGM: okGM,
+			resolveRecip: func(_ context.Context, accountID int64) (string, string, error) {
+				if accountID != 42 {
+					t.Fatalf("resolveRecip got account %d, want 42", accountID)
+				}
+				return "Tester#1234", "Tester", nil
+			},
+			send: func(sf, sh, rf, rn, m string) error {
+				got.senderFuncom, got.senderHex, got.recipFuncom, got.recipName, got.msg = sf, sh, rf, rn, m
+				return nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.senderFuncom != "Server#0001" || got.senderHex != "GMHEX" {
+			t.Fatalf("sender identity wrong: %+v", got)
+		}
+		if got.recipFuncom != "Tester#1234" || got.recipName != "Tester" || got.msg != "hello" {
+			t.Fatalf("recipient/message wrong: %+v", got)
+		}
+	})
+
+	t.Run("gm not provisioned short-circuits before resolve/send", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		err := processWhisper(context.Background(), 42, "hi", whisperDeps{
+			getGM:        func(context.Context) (gmIdentity, error) { return gmIdentity{}, errGMNotProvisioned },
+			resolveRecip: func(context.Context, int64) (string, string, error) { called = true; return "", "", nil },
+			send:         func(string, string, string, string, string) error { called = true; return nil },
+		})
+		if !errors.Is(err, errGMNotProvisioned) {
+			t.Fatalf("want errGMNotProvisioned, got %v", err)
+		}
+		if called {
+			t.Fatal("resolve/send must not run when GM identity is missing")
+		}
+	})
+
+	t.Run("recipient resolve error short-circuits send", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("no such recipient")
+		sent := false
+		err := processWhisper(context.Background(), 42, "hi", whisperDeps{
+			getGM:        okGM,
+			resolveRecip: func(context.Context, int64) (string, string, error) { return "", "", boom },
+			send:         func(string, string, string, string, string) error { sent = true; return nil },
+		})
+		if !errors.Is(err, boom) {
+			t.Fatalf("want boom, got %v", err)
+		}
+		if sent {
+			t.Fatal("send must not run when recipient resolution fails")
+		}
+	})
+
+	t.Run("send error propagates", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("broker down")
+		err := processWhisper(context.Background(), 42, "hi", whisperDeps{
+			getGM:        okGM,
+			resolveRecip: func(context.Context, int64) (string, string, error) { return "r", "n", nil },
+			send:         func(string, string, string, string, string) error { return boom },
+		})
+		if !errors.Is(err, boom) {
+			t.Fatalf("want boom, got %v", err)
+		}
+	})
+}

--- a/cmd/dune-admin/handlers_rmq.go
+++ b/cmd/dune-admin/handlers_rmq.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -391,50 +393,78 @@ func handleRMQSpawnVehicle(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"ok": fmt.Sprintf("spawn %s command sent for %s", req.ClassName, req.FlsID)})
 }
 
-// @Summary Send whisper message to a player via RabbitMQ (experimental)
-// @Tags players
+// whisperDeps are the injected dependencies for processWhisper so the
+// orchestration can be unit-tested without a live DB or broker.
+type whisperDeps struct {
+	getGM        func(context.Context) (gmIdentity, error)
+	resolveRecip func(ctx context.Context, accountID int64) (funcomID, charName string, err error)
+	send         func(senderFuncomID, senderHexID, recipientFuncomID, recipientName, message string) error
+}
+
+// processWhisper resolves the GM/Server sender and the recipient identities, then
+// sends the whisper. The seeded GM persona is the sender (its funcom id and hex
+// FLS id); the recipient is looked up by account id. Returns the underlying error
+// so the handler can map errGMNotProvisioned to 503.
+func processWhisper(ctx context.Context, accountID int64, message string, d whisperDeps) error {
+	gm, err := d.getGM(ctx)
+	if err != nil {
+		return err
+	}
+	recipientFuncomID, recipientName, err := d.resolveRecip(ctx, accountID)
+	if err != nil {
+		return err
+	}
+	return d.send(gm.FuncomID, gm.HexID, recipientFuncomID, recipientName, message)
+}
+
+// @Summary Send a whisper to a player from the GM/Server persona
+// @Tags chat
 // @Accept json
 // @Produce json
-// @Param body body object true "Target FLS ID, target name, sender name, message, and optional impersonated FLS ID"
+// @Param body body object true "Recipient account id and message"
 // @Success 200 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
+// @Failure 503 {object} map[string]string
 // @Router /api/v1/chat/whisper [post]
-// GET /api/v1/players/{id}/player-ids
 // POST /api/v1/chat/whisper
 //
-// EXPERIMENTAL — first attempt at an external chat publish per Adain's
-// chat-and-courier.md. The wire format is reconstructed from IDA/DWARF
-// evidence; live external publish wasn't pinned by Adain, so the message
-// may be silently dropped by the game even though the broker accepts it.
-// Iterate based on what the target sees in-game.
+// Sends a private chat message to one player, shown in their Whispers tab and
+// attributed to the seeded GM/Server persona. The exact wire shape is pinned by
+// buildWhisperBody against the live-confirmed protocol.
 func handleRMQWhisper(w http.ResponseWriter, r *http.Request) {
+	if globalDB == nil {
+		jsonErr(w, fmt.Errorf("database not connected"), http.StatusServiceUnavailable)
+		return
+	}
 	var req struct {
-		TargetFlsID       string `json:"target_fls_id"`
-		TargetName        string `json:"target_name"`
-		SenderName        string `json:"sender_name"`
-		Message           string `json:"message"`
-		ImpersonatedFlsID string `json:"impersonated_fls_id,omitempty"`
+		AccountID int64  `json:"account_id"`
+		Message   string `json:"message"`
 	}
 	if err := decode(r, &req); err != nil {
 		jsonErr(w, err, 400)
 		return
 	}
-	if req.TargetFlsID == "" || req.Message == "" {
-		jsonErr(w, fmt.Errorf("target_fls_id and message required"), 400)
+	if req.AccountID == 0 || req.Message == "" {
+		jsonErr(w, fmt.Errorf("account_id and message required"), 400)
 		return
 	}
-	if req.SenderName == "" {
-		req.SenderName = "GM"
-	}
-	if err := rmqSendWhisper(req.TargetFlsID, req.TargetName, req.SenderName, req.Message, req.ImpersonatedFlsID); err != nil {
-		jsonErr(w, err, 500)
-		return
-	}
-	jsonOK(w, map[string]string{
-		"ok":   fmt.Sprintf("whisper sent to %s (broker accepted; in-game delivery is experimental)", req.TargetFlsID),
-		"note": "Adain's chat publish recipe is not live-tested externally — check the target's whispers tab to confirm delivery.",
+
+	err := processWhisper(r.Context(), req.AccountID, req.Message, whisperDeps{
+		getGM:        cmdGetGMIdentity,
+		resolveRecip: cmdResolveRecipientChatIdentity,
+		send:         rmqSendWhisper,
 	})
+	if errors.Is(err, errGMNotProvisioned) {
+		jsonErr(w, err, http.StatusServiceUnavailable)
+		return
+	}
+	if err != nil {
+		log.Printf("handleRMQWhisper: %v", err)
+		jsonErr(w, fmt.Errorf("failed to send whisper"), http.StatusInternalServerError)
+		return
+	}
+	jsonOK(w, map[string]string{"ok": fmt.Sprintf("whisper sent to account %d", req.AccountID)})
 }
 
 // @Summary Resolve actor ID to both ID forms and render a sample RMQ envelope

--- a/cmd/dune-admin/model.go
+++ b/cmd/dune-admin/model.go
@@ -22,6 +22,16 @@ type playerInfo struct {
 	OnlineStatus string `json:"online_status"`
 }
 
+// gmIdentity is the seeded "GM/Server" persona used as the sender for admin chat
+// (whisper, map announcement). HexID is the AMQP user_id (accounts."user") the
+// game resolves the visible sender name from; FuncomID is the chat id shown
+// in-game (m_FuncomIdFrom).
+type gmIdentity struct {
+	AccountID int64  `json:"account_id"`
+	HexID     string `json:"hex_id"`
+	FuncomID  string `json:"funcom_id"`
+}
+
 type journeyNode struct {
 	NodeID           string `json:"node_id"`
 	IsComplete       bool   `json:"is_complete"`

--- a/cmd/dune-admin/rmq_commands.go
+++ b/cmd/dune-admin/rmq_commands.go
@@ -63,94 +63,63 @@ func publishServerCommand(fields map[string]any) error {
 
 // ── courier (chat) publish ────────────────────────────────────────────────────
 
-// publishCourierMessage publishes a chat / courier message to the game broker.
-// Unlike publishServerCommand (which goes to exchange=heartbeats,
-// routingKey=notifications via the ServerCommand AuthToken-protected envelope),
-// courier messages are routed by exchange + routingKey directly — exchange is
-// chat-channel-specific (chat.whispers, chat.faction.{id}, ...) and routing key
-// varies by channel (target FLS for whispers, "" for faction broadcasts, etc.).
+// buildCourierPublishExpr builds the rabbitmqctl eval Erlang expression that
+// publishes a chat/courier message. Publishing via eval (rather than an AMQP
+// client) is what lets us set the P_basic user_id to an arbitrary sender FLS id —
+// the broker would otherwise force user_id to match the authenticated connection,
+// and a synthetic "fls" sender is silently dropped by the game.
 //
-// EXPERIMENTAL — Adain's chat-and-courier.md documents the wire format from
-// IDA/DWARF analysis but explicitly notes "live external publish recipe still
-// not pinned." This is the first attempt at sending one of these as an external
-// operator. If the game ignores the message or the broker rejects it, see
-// chat-and-courier.md and iterate the basic_properties or body shape.
-//
-// body should be the JSON-serialized FCourierMessageContent — caller's
-// responsibility. typeStr is the AMQP basic_properties `type` value, set to
-// "12" for text_chat per the FNotificationsSystemMessage type-byte mapping.
-func publishCourierMessage(exchange, routingKey string, body []byte, typeStr string) error {
-	bodyB64 := base64.StdEncoding.EncodeToString(body)
-	msgID := fmt.Sprintf("dune-admin-chat-%d", time.Now().UnixMilli())
-
-	// AMQP basic_properties P_basic record order:
-	//   content_type, content_encoding, headers, delivery_mode, priority,
-	//   correlation_id, reply_to, expiration, message_id, timestamp, type,
-	//   user_id, app_id, cluster_id
-	// We set type to the courier message-type byte string ("12") and reuse
-	// the fls / fls_backend user/app identity that the game expects.
-	erlang := fmt.Sprintf(
+// P_basic record order: content_type, content_encoding, headers, delivery_mode,
+// priority, correlation_id, reply_to, expiration, message_id, timestamp, type,
+// user_id, app_id, cluster_id. We set type to the notification type NAME (e.g.
+// "text_chat"), user_id to the sender's hex FLS id, and app_id to fls_backend.
+func buildCourierPublishExpr(exchange, routingKey, bodyB64, msgID, amqpType, userID string) string {
+	return fmt.Sprintf(
 		`Body = base64:decode(<<"%s">>),`+
 			`XName = rabbit_misc:r(<<"/">>, exchange, <<"%s">>),`+
 			`X = rabbit_exchange:lookup_or_die(XName),`+
 			`MsgId = <<"%s">>,`+
 			`P = {list_to_atom("P_basic"), <<"Content">>, undefined, [], undefined,`+
 			` undefined, undefined, undefined, undefined, MsgId, undefined,`+
-			` <<"%s">>, <<"fls">>, <<"fls_backend">>, undefined},`+
+			` <<"%s">>, <<"%s">>, <<"fls_backend">>, undefined},`+
 			`Content = rabbit_basic:build_content(P, Body),`+
 			`{ok, Msg} = rabbit_basic:message(XName, <<"%s">>, Content),`+
 			`rabbit_queue_type:publish_at_most_once(X, Msg).`,
-		bodyB64, exchange, msgID, typeStr, routingKey)
+		bodyB64, exchange, msgID, amqpType, userID, routingKey)
+}
 
+// publishCourierMessageAs publishes a chat/courier message to the game broker as
+// a specific sender identity. exchange + routingKey select the chat channel
+// (e.g. chat.whispers + recipient funcom id); amqpType is the notification type
+// name ("text_chat"); userID is the sender's hex FLS id (the GM/Server persona).
+// body is the already-serialized FCourierMessageContent envelope.
+func publishCourierMessageAs(exchange, routingKey string, body []byte, amqpType, userID string) error {
 	if globalControl == nil || globalExecutor == nil {
 		return fmt.Errorf("control plane not connected")
 	}
-	out, err := globalControl.EvalOnGameBroker(context.Background(), globalExecutor, erlang)
+	bodyB64 := base64.StdEncoding.EncodeToString(body)
+	msgID := fmt.Sprintf("dune-admin-chat-%d", time.Now().UnixMilli())
+	expr := buildCourierPublishExpr(exchange, routingKey, bodyB64, msgID, amqpType, userID)
+	out, err := globalControl.EvalOnGameBroker(context.Background(), globalExecutor, expr)
 	if err != nil {
 		return fmt.Errorf("publish courier message: %w (output: %s)", err, out)
 	}
 	return nil
 }
 
-// rmqSendWhisper sends a private chat message ("whisper") to one player.
-// The target sees it in their whispers chat tab; only they receive it.
-//
-// senderName is the display name shown on the whisper. impersonatedFlsID is
-// optional — if non-empty, the message appears to come from that FLS player
-// (admin-only feature, useful for "GM" personas). Leave empty for an unsigned
-// admin whisper.
-func rmqSendWhisper(targetFlsID, targetName, senderName, message, impersonatedFlsID string) error {
-	// FChatMessageData per chat-and-courier.md. JSON field names match the C++
-	// member names with the m_ prefix stripped (broadcast struct uses the same
-	// convention).
-	chatMsg := map[string]any{
-		"Id":                  fmt.Sprintf("%d", time.Now().UnixNano()),
-		"ChannelType":         "ETextChatChannelType::Whispers",
-		"FuncomIdFrom":        impersonatedFlsID,
-		"UserNameTo":          targetName,
-		"Message":             map[string]any{"Body": message},
-		"TimeStamp":           time.Now().UTC().Format(time.RFC3339),
-		"bUseSpoofedUserName": senderName != "",
-		"SpoofedUserNameFrom": map[string]any{"AuthorName": senderName},
-	}
-	chatJSON, err := json.Marshal(chatMsg)
+// rmqSendWhisper sends a private chat message ("whisper") to one player, shown in
+// the target's Whispers tab. The whisper is attributed to the seeded GM/Server
+// persona: senderFuncomID is that identity's funcom id (m_FuncomIdFrom) and
+// senderHexID is its hex FLS id (the AMQP user_id the game resolves the sender
+// name from). recipientFuncomID is the target's funcom id (m_SubChannelId and the
+// whisper routing key); recipientName is the target's character name
+// (m_UserNameTo). The exact wire shape is pinned by buildWhisperBody.
+func rmqSendWhisper(senderFuncomID, senderHexID, recipientFuncomID, recipientName, message string) error {
+	body, err := buildWhisperBody(newCourierMessageID(), senderFuncomID, recipientFuncomID, recipientName, message, time.Now())
 	if err != nil {
-		return fmt.Errorf("marshal chat message: %w", err)
+		return err
 	}
-
-	// FCourierMessageContent: outer wrapper with stringified inner Content +
-	// Type discriminator.
-	envelope := map[string]any{
-		"Content": string(chatJSON),
-		"Type":    "ECourierMessageType::TextChat",
-	}
-	envelopeJSON, err := json.Marshal(envelope)
-	if err != nil {
-		return fmt.Errorf("marshal courier envelope: %w", err)
-	}
-
-	// Whisper routing: exchange=chat.whispers, routing key=target's FLS id.
-	return publishCourierMessage("chat.whispers", targetFlsID, envelopeJSON, "12")
+	return publishCourierMessageAs("chat.whispers", recipientFuncomID, body, "text_chat", senderHexID)
 }
 
 // ── typed wrappers ────────────────────────────────────────────────────────────

--- a/cmd/dune-admin/rmq_courier_body.go
+++ b/cmd/dune-admin/rmq_courier_body.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// newCourierMessageID returns a fresh GUID string for a chat message m_Id. The
+// game treats m_Id as a per-message identifier; uniqueness is what matters.
+func newCourierMessageID() string {
+	return uuid.NewString()
+}
+
+// Courier (chat) message body builders. The wire shapes here are pinned against
+// the live-confirmed publishes documented in the dune-rmq-protocol research
+// (chat-and-courier.md). Each chat channel has its OWN serialized shape — field
+// casing, enum qualification, and even the outer envelope key differ between the
+// whisper and map channels — so the builders are deliberately NOT shared. Written
+// from scratch against the findings; never copy the research repo's content.
+
+// ── shared inner sub-structs ────────────────────────────────────────────────
+
+// localizedMessageData is FLocalizedMessageData. Empty for direct operator text.
+type localizedMessageData struct {
+	TableID    string   `json:"m_TableId"`
+	Key        string   `json:"m_Key"`
+	FormatArgs []string `json:"m_FormatArgs"`
+}
+
+// localizableMessage is FLocalizableMessageData. m_UnlocalizedMessage carries the
+// plain operator text — live-confirmed as the field the client actually renders.
+type localizableMessage struct {
+	Unlocalized string               `json:"m_UnlocalizedMessage"`
+	Localized   localizedMessageData `json:"m_LocalizedMessage"`
+}
+
+// vec3 is the FVector origin location. Operator chat uses the zero vector.
+type vec3 struct {
+	X float64 `json:"X"`
+	Y float64 `json:"Y"`
+	Z float64 `json:"Z"`
+}
+
+// newLocalizableMessage builds the message payload with a non-nil empty
+// FormatArgs so it serializes as [] (a nil slice would emit null).
+func newLocalizableMessage(text string) localizableMessage {
+	return localizableMessage{
+		Unlocalized: text,
+		Localized:   localizedMessageData{FormatArgs: []string{}},
+	}
+}
+
+// ── whisper (chat.whispers) ─────────────────────────────────────────────────
+
+// whisperSpoofedAuthor is FMessageAuthor for the whisper channel: {m_Id, m_DisplayName}.
+// (Map chat uses a different spoofed-author shape.)
+type whisperSpoofedAuthor struct {
+	ID          string `json:"m_Id"`
+	DisplayName string `json:"m_DisplayName"`
+}
+
+// whisperChatData is FChatMessageData for the Whispers channel. Field order
+// mirrors the live-confirmed body for readability; the game parses by name.
+type whisperChatData struct {
+	ID              string               `json:"m_Id"`
+	ChannelType     string               `json:"m_ChannelType"`
+	SubChannelID    string               `json:"m_SubChannelId"`
+	UseSpoofedName  bool                 `json:"m_bUseSpoofedUserName"`
+	SpoofedNameFrom whisperSpoofedAuthor `json:"m_SpoofedUserNameFrom"`
+	FuncomIDFrom    string               `json:"m_FuncomIdFrom"`
+	UserNameTo      string               `json:"m_UserNameTo"`
+	Message         localizableMessage   `json:"m_Message"`
+	TimeStamp       string               `json:"m_TimeStamp"`
+	OriginLocation  vec3                 `json:"m_OriginLocation"`
+	HasSeenMessage  bool                 `json:"m_HasSeenMessage"`
+}
+
+// courierEnvelope is FCourierMessageContent — the outer body the game parses for
+// the whisper channel: a stringified inner payload plus a Type discriminator.
+type courierEnvelope struct {
+	Content string `json:"Content"`
+	Type    string `json:"Type"`
+}
+
+// buildWhisperBody serializes a private (Whispers channel) chat message to the
+// exact live-confirmed wire body. The inner FChatMessageData is marshalled, then
+// embedded as a STRING inside the FCourierMessageContent envelope — the game
+// expects Content to be stringified JSON, not a nested object.
+//
+// senderFuncomID is the GM/Server persona's funcom id (m_FuncomIdFrom);
+// recipientFuncomID is the target's funcom id (m_SubChannelId + AMQP routing key);
+// recipientCharName is the target's character name (m_UserNameTo). The AMQP
+// user_id (sender hex FLS id) and routing key are applied at the publish layer.
+func buildWhisperBody(msgID, senderFuncomID, recipientFuncomID, recipientCharName, message string, ts time.Time) ([]byte, error) {
+	inner := whisperChatData{
+		ID:             msgID,
+		ChannelType:    "ETextChatChannelType::Whispers",
+		SubChannelID:   recipientFuncomID,
+		UseSpoofedName: false,
+		FuncomIDFrom:   senderFuncomID,
+		UserNameTo:     recipientCharName,
+		Message:        newLocalizableMessage(message),
+		TimeStamp:      ts.UTC().Format(time.RFC3339),
+		HasSeenMessage: false,
+	}
+	innerJSON, err := json.Marshal(inner)
+	if err != nil {
+		return nil, fmt.Errorf("marshal whisper chat data: %w", err)
+	}
+	body, err := json.Marshal(courierEnvelope{
+		Content: string(innerJSON),
+		Type:    "ECourierMessageType::TextChat",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal whisper courier envelope: %w", err)
+	}
+	return body, nil
+}

--- a/cmd/dune-admin/rmq_courier_body_test.go
+++ b/cmd/dune-admin/rmq_courier_body_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestBuildWhisperBody_GoldenShape pins the exact whisper wire body against the
+// live-confirmed shape in dune-rmq-protocol/chat-and-courier.md (whisper publish,
+// 2026-05-28). This golden assertion is the regression guard for the four bugs in
+// the previous best-guess implementation:
+//
+//  1. fields carry the m_ prefix (m_ChannelType, m_FuncomIdFrom, ...)
+//  2. m_Message uses {m_UnlocalizedMessage, m_LocalizedMessage{...}} (NOT {Body})
+//  3. m_SubChannelId (recipient funcom id) is present
+//  4. enum/channel strings are fully qualified for the whisper channel
+//
+// user_id / routing key are AMQP-envelope concerns, asserted at the publish layer.
+func TestBuildWhisperBody_GoldenShape(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 5, 31, 19, 49, 58, 0, time.UTC)
+	body, err := buildWhisperBody(
+		"11111111-1111-1111-1111-111111111111", // msg id (caller-generated GUID)
+		"Server#0001",                          // sender (GM) funcom id
+		"Tester#1234",                          // recipient funcom id
+		"Tester",                               // recipient character name
+		"Hello from the server",                // visible whisper text
+		ts,
+	)
+	if err != nil {
+		t.Fatalf("buildWhisperBody: %v", err)
+	}
+
+	// Outer courier envelope for the whisper channel: capitalized "Content" key,
+	// fully-qualified "Type". (Map chat uses a different outer shape — kept apart.)
+	var outer struct {
+		Content string `json:"Content"`
+		Type    string `json:"Type"`
+	}
+	if err := json.Unmarshal(body, &outer); err != nil {
+		t.Fatalf("unmarshal outer envelope: %v", err)
+	}
+	if outer.Type != "ECourierMessageType::TextChat" {
+		t.Fatalf("outer Type = %q, want ECourierMessageType::TextChat", outer.Type)
+	}
+
+	const wantInner = `{"m_Id":"11111111-1111-1111-1111-111111111111",` +
+		`"m_ChannelType":"ETextChatChannelType::Whispers",` +
+		`"m_SubChannelId":"Tester#1234",` +
+		`"m_bUseSpoofedUserName":false,` +
+		`"m_SpoofedUserNameFrom":{"m_Id":"","m_DisplayName":""},` +
+		`"m_FuncomIdFrom":"Server#0001",` +
+		`"m_UserNameTo":"Tester",` +
+		`"m_Message":{"m_UnlocalizedMessage":"Hello from the server",` +
+		`"m_LocalizedMessage":{"m_TableId":"","m_Key":"","m_FormatArgs":[]}},` +
+		`"m_TimeStamp":"2026-05-31T19:49:58Z",` +
+		`"m_OriginLocation":{"X":0,"Y":0,"Z":0},` +
+		`"m_HasSeenMessage":false}`
+
+	if outer.Content != wantInner {
+		t.Fatalf("inner FChatMessageData mismatch:\n got: %s\nwant: %s", outer.Content, wantInner)
+	}
+}
+
+// TestBuildWhisperBody_EscapesMessage guards the stringified-inner escaping: the
+// inner FChatMessageData is carried as a JSON string inside the outer envelope, so
+// quotes/newlines in operator text must survive a round trip without corrupting
+// the body. A naive string concat would break here.
+func TestBuildWhisperBody_EscapesMessage(t *testing.T) {
+	t.Parallel()
+
+	msg := "line1\nsay \"hi\"\tend"
+	body, err := buildWhisperBody("id", "Server#0001", "Tester#1234", "Tester", msg, time.Unix(0, 0).UTC())
+	if err != nil {
+		t.Fatalf("buildWhisperBody: %v", err)
+	}
+
+	var outer struct {
+		Content string `json:"Content"`
+	}
+	if err := json.Unmarshal(body, &outer); err != nil {
+		t.Fatalf("unmarshal outer: %v", err)
+	}
+	var inner struct {
+		Message struct {
+			Unlocalized string `json:"m_UnlocalizedMessage"`
+		} `json:"m_Message"`
+	}
+	if err := json.Unmarshal([]byte(outer.Content), &inner); err != nil {
+		t.Fatalf("unmarshal inner content string: %v", err)
+	}
+	if inner.Message.Unlocalized != msg {
+		t.Fatalf("message did not round-trip:\n got: %q\nwant: %q", inner.Message.Unlocalized, msg)
+	}
+}

--- a/cmd/dune-admin/rmq_courier_publish_test.go
+++ b/cmd/dune-admin/rmq_courier_publish_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildCourierPublishExpr_InjectsUserIDAndType locks the two publish-layer
+// fixes that the live-confirmed whisper recipe requires:
+//
+//   - AMQP user_id must be the SENDER's hex FLS id (so the game's player-info
+//     lookup resolves a real identity). The previous code hardcoded <<"fls">>,
+//     which the game silently drops.
+//   - AMQP type must be the notification type NAME "text_chat", not the byte
+//     string "12" the previous code sent.
+//
+// The expr publishes via rabbitmqctl eval, which builds the P_basic record
+// directly and so may set user_id freely (AMQP clients cannot).
+func TestBuildCourierPublishExpr_InjectsUserIDAndType(t *testing.T) {
+	t.Parallel()
+
+	expr := buildCourierPublishExpr("chat.whispers", "Tester#1234", "Qk9EWQ==", "msg-1", "text_chat", "GMHEXUSER")
+
+	// type, user_id, app_id must occupy adjacent P_basic slots in that order.
+	if !strings.Contains(expr, `<<"text_chat">>, <<"GMHEXUSER">>, <<"fls_backend">>`) {
+		t.Fatalf("type/user_id/app_id slots wrong:\n%s", expr)
+	}
+
+	for _, want := range []string{
+		`<<"chat.whispers">>`,          // exchange
+		`<<"Tester#1234">>`,            // routing key
+		`base64:decode(<<"Qk9EWQ==">>`, // body
+		`<<"msg-1">>`,                  // message id
+	} {
+		if !strings.Contains(expr, want) {
+			t.Fatalf("expr missing %q:\n%s", want, expr)
+		}
+	}
+
+	// Regression: the old code hardcoded fls as the user_id.
+	if strings.Contains(expr, `<<"fls">>, <<"fls_backend">>`) {
+		t.Fatalf("user_id still hardcoded to fls:\n%s", expr)
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -714,19 +714,11 @@ export const api = {
   },
 
   chat: {
-    // EXPERIMENTAL — first attempt at sending a chat whisper from outside the
-    // game per Adain's chat-and-courier.md. Broker should accept the publish;
-    // in-game delivery is unverified.
-    whisper: (
-      target_fls_id: string,
-      target_name: string,
-      sender_name: string,
-      message: string,
-      impersonated_fls_id?: string,
-    ) =>
-      req<MutateResult & { note?: string }>('POST', '/chat/whisper', {
-        target_fls_id, target_name, sender_name, message, impersonated_fls_id,
-      }),
+    // Whisper a single player from the seeded GM/Server persona. Identified by
+    // recipient account id; the backend resolves the chat identity and attributes
+    // the message to the GM persona.
+    whisper: (account_id: number, message: string) =>
+      req<MutateResult>('POST', '/chat/whisper', { account_id, message }),
   },
 
   contracts: {

--- a/web/src/tabs/PlayersTab/modals/PlayerActionsModal.tsx
+++ b/web/src/tabs/PlayersTab/modals/PlayerActionsModal.tsx
@@ -1771,12 +1771,7 @@ export function PlayerActionsModal({ player, open, onClose }: Props) {
                               onPress={() =>
                                 run(
                                   () =>
-                                    api.chat.whisper(
-                                      player.fls_id,
-                                      player.name,
-                                      whisperSenderName.trim() || 'GM',
-                                      whisperText.trim(),
-                                    ),
+                                    api.chat.whisper(player.account_id, whisperText.trim()),
                                   t('players.actions.admin.whisperSent', { player: player.name }),
                                 ).then(() => setWhisperText(''))}
                             >

--- a/web/src/tabs/PlayersTab/views/ActionsView.tsx
+++ b/web/src/tabs/PlayersTab/views/ActionsView.tsx
@@ -1656,12 +1656,7 @@ export function ActionsView({ player }: Props) {
                       onPress={() =>
                         run(
                           () =>
-                            api.chat.whisper(
-                              player.fls_id,
-                              player.name,
-                              whisperSenderName.trim() || 'GM',
-                              whisperText.trim(),
-                            ),
+                            api.chat.whisper(player.account_id, whisperText.trim()),
                           t('players.actions.admin.whisperSent', { player: player.name }),
                         ).then(() => setWhisperText(''))}
                     >


### PR DESCRIPTION
## What

Adds a reusable **"GM/Server" chat persona** and rewrites the player **whisper** path to the live-confirmed RabbitMQ courier wire shape, so an operator can DM a player from a clean admin identity instead of the previous experimental whisper that never rendered in-game.

### GM/Server identity (foundation)
- Idempotently seeds a synthetic sender identity on DB connect: a row in `encrypted_accounts`, three linked `actors` rows (controller/state/pawn — required for the game's `GetPlayerInfo` lookup to resolve the sender), and an `encrypted_player_state` row. Names go through `dune.encrypt_user_data`, so it stays correct if user-data encryption is enabled.
- Kept **out of operator views**: `actors.transform` is left NULL (never plots on the live map) and a sentinel-account-id exclusion is added to the players-list, online-state, online-account poller, and welcome-kit scanner queries.

### Whisper (correct wire shape)
The previous whisper was a static-analysis guess that never rendered. Fixed against the live-confirmed protocol:
- `m_`-prefixed `FChatMessageData` fields; `m_Message` = `{m_UnlocalizedMessage, m_LocalizedMessage{…}}` (was `{Body}` → blank row); added `m_SubChannelId`.
- AMQP `user_id` = the sender's hex FLS id (was hardcoded `"fls"`, which the game silently drops); `type` = `"text_chat"` (was `"12"`); routed by the recipient's funcom id.
- Sourced from the seeded GM persona. Handler takes `{account_id, message}`; the Players-tab UI callers are updated.

## Tests
- Golden-JSON assertion pinning the exact whisper body.
- Publish-expression test asserting the `user_id`/`type` substitution.
- `processWhisper` orchestration (happy path + 3 failure short-circuits).
- GM seed spec (sentinel ids, class paths, blast-radius-safe defaults).

`go build`, `go vet`, `golangci-lint`, `gosec`, `govulncheck`, `eslint`, `tsc` all clean locally (race suite runs on CI — needs cgo).

## Not in this PR / follow-ups
- **In-game verification** of the seeded-GM whisper is still pending (needs a live server + online player). The GM seeds as `online_status=Offline`; if a chat sender must be Online to render, that's a one-line default flip.
- Map-chat server announcement (`chat.map`) reuses the same identity — deferred until whisper is verified in-game.
- Minor UI cleanup of the now-obsolete "Whisper from [GM]" sender-name field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
