### PR TITLE
fix(install): run install.sh under bash regardless of caller shell

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,6 +55,16 @@
 #   ./install.sh --no-patches
 #   ./install.sh --help
 
+# Re-exec under bash when started by another shell (`sh install.sh`, `sh -c …`,
+# `zsh install.sh`) so the bash-only features below — arrays, [[ … ]],
+# `set -o pipefail`, ${BASH_SOURCE} — work regardless of the caller's shell (#76).
+# POSIX-safe test, and placed after the comment header so it stays out of the
+# `sed -n '2,30p'` range that usage() prints. The README's `curl … | bash`
+# already runs under bash, so the guard is a no-op there.
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+
 set -euo pipefail
 
 # ── Defaults (override via flags) ─────────────────────────────────────────────


### PR DESCRIPTION
Fixes #76.

`scripts/install.sh` is a bash script (arrays, `[[ ]]`, `set -o pipefail`, `${BASH_SOURCE}`) but those break when it is invoked via `sh install.sh` / `sh -c …` (POSIX dash) or zsh.

**Fix:** a POSIX-safe re-exec guard right after the comment header — if `BASH_VERSION` is unset, `exec bash "$0" "$@"`. The README's `curl … | bash` already runs under bash, so the guard is a no-op there.

**Test plan:** on Ubuntu 24.04 (`/bin/sh` = dash), both `sh scripts/install.sh --help` and `bash scripts/install.sh --help` print usage and exit 0. Pre-guard, dash aborted on `set -o pipefail`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
