### PR TITLE
fix(i18n): apply language switch immediately across all tabs

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -104,7 +104,7 @@ const AppCore: React.FC<AppCoreProps> = ({ isSignedIn }) => {
   const status = useStatus()
   const location = useLocation()
   const navigate = useNavigate()
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const [reconnecting, setReconnecting] = useState(false)
 
   const DB_SECTIONS: { key: string, label: string, depth: number }[] = [
@@ -256,7 +256,11 @@ const AppCore: React.FC<AppCoreProps> = ({ isSignedIn }) => {
   )
 
   return (
-    <div className="h-screen flex flex-col overflow-hidden bg-background">
+    // Keyed on the active language so switching language remounts the content
+    // subtree once. The module-level memo() tabs stay mounted and otherwise keep
+    // stale-language text on a language change (their props don't change), until
+    // an unrelated local state update forces them to re-render (#123).
+    <div key={i18n.language} className="h-screen flex flex-col overflow-hidden bg-background">
       <Toast.Provider />
 
       {/* Header */}


### PR DESCRIPTION
Fixes #123.

Switching language only updated some components until a manual reload (F5) or an unrelated local state change. The top-level tabs are module-level `memo()` and stay mounted, so on a `languageChanged` event `AppCore` re-renders but the memo'd tabs see unchanged props and skip re-rendering — keeping stale-language text. (Matches the report: switching Players sub-tabs forces the update, switching top-level tabs doesn't.)

**Fix:** key `AppCore`'s content subtree on `i18n.language`, so a language switch remounts it once and the new language propagates everywhere. The remount happens only on the (rare, deliberate) language change, not on normal renders, so the memo perf optimization is preserved.

**Test plan:** tsc + eslint + i18n parity (10/10) pass. Manual: switch language, confirm header + all tabs update without F5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
