### PR TITLE
fix(marketbot): accept a directory path for item-data

### DIFF
--- a/internal/marketbot/catalog.go
+++ b/internal/marketbot/catalog.go
@@ -3,6 +3,7 @@ package marketbot
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -61,6 +62,13 @@ func normalizeRarity(r string) string {
 func loadCatalog(itemDataPath string) ([]CatalogItem, error) {
 	if itemDataPath == "" {
 		itemDataPath = "item-data.json"
+	}
+	// A configured path may point at the directory that holds item-data.json
+	// (e.g. the install/working dir) rather than the file itself. Reading a
+	// directory as a file fails cryptically — "is a directory" on Linux,
+	// "Incorrect function" on Windows (#116) — so resolve to the file inside.
+	if info, statErr := os.Stat(itemDataPath); statErr == nil && info.IsDir() {
+		itemDataPath = filepath.Join(itemDataPath, "item-data.json")
 	}
 	dataRaw, err := os.ReadFile(itemDataPath)
 	if err != nil {

--- a/internal/marketbot/catalog_test.go
+++ b/internal/marketbot/catalog_test.go
@@ -1,0 +1,47 @@
+package marketbot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// loadCatalog must accept a path that points at the DIRECTORY containing
+// item-data.json (e.g. the install/working dir), not only the file itself.
+// Reading a directory as a file fails cryptically — "is a directory" on Linux,
+// "Incorrect function" on Windows (issue #116) — so a directory path should
+// resolve to item-data.json inside it.
+func TestLoadCatalog_AcceptsDirectoryPath(t *testing.T) {
+	dir := t.TempDir()
+	const itemJSON = `{"items":{"Foo_Item":{"name":"Foo","category":"items/weapons","stack_max":10}}}`
+	if err := os.WriteFile(filepath.Join(dir, "item-data.json"), []byte(itemJSON), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	t.Run("directory path resolves item-data.json inside it", func(t *testing.T) {
+		cat, err := loadCatalog(dir)
+		if err != nil {
+			t.Fatalf("loadCatalog(dir): unexpected error: %v", err)
+		}
+		if len(cat) != 1 || cat[0].TemplateID != "Foo_Item" {
+			t.Fatalf("got %+v, want exactly Foo_Item", cat)
+		}
+	})
+
+	t.Run("explicit file path still works", func(t *testing.T) {
+		cat, err := loadCatalog(filepath.Join(dir, "item-data.json"))
+		if err != nil {
+			t.Fatalf("loadCatalog(file): unexpected error: %v", err)
+		}
+		if len(cat) != 1 {
+			t.Fatalf("got %d items, want 1", len(cat))
+		}
+	})
+
+	t.Run("directory without item-data.json returns a normal not-found error", func(t *testing.T) {
+		empty := t.TempDir()
+		if _, err := loadCatalog(empty); err == nil {
+			t.Fatal("expected an error for a directory lacking item-data.json, got nil")
+		}
+	})
+}


### PR DESCRIPTION
Fixes #116.

On Windows the bot failed at startup with `market-bot: startup failed: marketbot: load catalog: read D:\Dune\DuneAdmin: Incorrect function` — that's the OS error for reading a **directory** as a file. The configured item-data path (`market_bot_item_data` / `-itemdata` / the resolved default) can point at the directory that holds `item-data.json` rather than the file itself; `os.ReadFile` on a directory returns "Incorrect function" on Windows ("is a directory" on Linux).

**Fix:** `loadCatalog` now stats the path and, when it's a directory, resolves to `item-data.json` inside it. Explicit file paths are unchanged; a directory missing the file now yields a normal not-found error instead of the cryptic one.

**Test plan:** `TestLoadCatalog_AcceptsDirectoryPath` (directory / file / missing cases). Verified on Windows (the actual failure platform — would hit "Incorrect function" pre-fix) and `go test -race ./internal/marketbot/` clean on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
