### PR TITLE
feat(web): add GitHub issue-tracker link to header

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -317,6 +317,16 @@ const AppCore: React.FC<AppCoreProps> = ({ isSignedIn }) => {
             </span>
           )}
 
+          <a
+            href="https://github.com/Icehunter/dune-admin/issues"
+            target="_blank"
+            rel="noreferrer"
+            aria-label={t('app.reportIssue')}
+            title={t('app.reportIssue')}
+            className="inline-flex items-center justify-center size-8 rounded text-muted hover:text-foreground hover:bg-surface-secondary transition-colors"
+          >
+            <Icon name="github" />
+          </a>
           <LanguageSelector />
           <ToggleButtonGroup
             selectionMode="single"

--- a/web/src/locales/de/translation.json
+++ b/web/src/locales/de/translation.json
@@ -1,5 +1,6 @@
 {
   "app": {
+    "reportIssue": "Ein Problem auf GitHub melden",
     "changesNote": "Änderungen auf allen Tabs werden gemeinsam gespeichert.",
     "checkUpdates": "Nach Updates suchen",
     "configureBackend": "Backend konfigurieren",

--- a/web/src/locales/en-US/translation.json
+++ b/web/src/locales/en-US/translation.json
@@ -1,5 +1,6 @@
 {
   "app": {
+    "reportIssue": "Report an issue on GitHub",
     "changesNote": "Changes on all tabs are saved together.",
     "checkUpdates": "Check for Updates",
     "configureBackend": "Configure backend",

--- a/web/src/locales/es/translation.json
+++ b/web/src/locales/es/translation.json
@@ -1,5 +1,6 @@
 {
   "app": {
+    "reportIssue": "Informar de un problema en GitHub",
     "changesNote": "Los cambios en todas las pestañas se guardan juntos.",
     "checkUpdates": "Buscar actualizaciones",
     "configureBackend": "Configurar backend",

--- a/web/src/locales/fr/translation.json
+++ b/web/src/locales/fr/translation.json
@@ -1,5 +1,6 @@
 {
   "app": {
+    "reportIssue": "Signaler un problème sur GitHub",
     "changesNote": "Les modifications de tous les onglets sont enregistrées ensemble.",
     "checkUpdates": "Vérifier les mises à jour",
     "configureBackend": "Configurer le backend",

--- a/web/src/locales/ja/translation.json
+++ b/web/src/locales/ja/translation.json
@@ -1,5 +1,6 @@
 {
   "app": {
+    "reportIssue": "GitHub で問題を報告",
     "changesNote": "すべてのタブの変更はまとめて保存されます。",
     "checkUpdates": "更新を確認",
     "configureBackend": "バックエンドの設定",

--- a/web/src/locales/pl/translation.json
+++ b/web/src/locales/pl/translation.json
@@ -1,5 +1,6 @@
 {
   "app": {
+    "reportIssue": "Zgłoś problem na GitHubie",
     "changesNote": "Zmiany na wszystkich kartach są zapisywane razem.",
     "checkUpdates": "Sprawdź aktualizacje",
     "configureBackend": "Konfiguruj backend",

--- a/web/src/locales/pt-BR/translation.json
+++ b/web/src/locales/pt-BR/translation.json
@@ -1,5 +1,6 @@
 {
   "app": {
+    "reportIssue": "Relatar um problema no GitHub",
     "changesNote": "As alterações em todas as abas são salvas juntas.",
     "checkUpdates": "Verificar atualizações",
     "configureBackend": "Configurar backend",

--- a/web/src/locales/ru/translation.json
+++ b/web/src/locales/ru/translation.json
@@ -1,5 +1,6 @@
 {
   "app": {
+    "reportIssue": "Сообщить о проблеме на GitHub",
     "changesNote": "Изменения на всех вкладках сохраняются вместе.",
     "checkUpdates": "Проверить обновления",
     "configureBackend": "Настроить бэкенд",

--- a/web/src/locales/tr/translation.json
+++ b/web/src/locales/tr/translation.json
@@ -1,5 +1,6 @@
 {
   "app": {
+    "reportIssue": "GitHub'da sorun bildir",
     "changesNote": "Tüm sekmelerdeki değişiklikler birlikte kaydedilir.",
     "checkUpdates": "Güncellemeleri Kontrol Et",
     "configureBackend": "Arka ucu yapılandır",

--- a/web/src/locales/zh-CN/translation.json
+++ b/web/src/locales/zh-CN/translation.json
@@ -1,5 +1,6 @@
 {
   "app": {
+    "reportIssue": "在 GitHub 上报告问题",
     "changesNote": "所有选项卡上的更改将一起保存。",
     "checkUpdates": "检查更新",
     "configureBackend": "配置后端",


### PR DESCRIPTION
Adds a GitHub icon button to the header toolbar that opens the project issue tracker in a new tab, so operators can report panel/executable issues without hunting for the repo URL.

- Uses the existing external-link anchor pattern (`target=_blank`, `rel=noreferrer`) already used for the release-notes link.
- Adds the `app.reportIssue` label across all 10 locales.

Closes #138

**Testing:** `tsc --noEmit`, `eslint --max-warnings 0`, and the i18n parity test all green. Deployed and live-verified on a test instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
