### PR TITLE
fix(server-health): auto Director link + configurable web interfaces, timezone dropdown (#155, #156)

### DIFF
--- a/cmd/dune-admin/handlers_web_interfaces.go
+++ b/cmd/dune-admin/handlers_web_interfaces.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+// @Summary List configured web interfaces
+// @Tags web-interfaces
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Router /api/v1/web-interfaces [get]
+func handleGetWebInterfaces(w http.ResponseWriter, _ *http.Request) {
+	jsonOK(w, map[string]any{"interfaces": getWebInterfaces()})
+}
+
+// @Summary Replace the configured web interfaces
+// @Tags web-interfaces
+// @Accept json
+// @Produce json
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Router /api/v1/web-interfaces [put]
+func handleUpdateWebInterfaces(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Interfaces []webInterface `json:"interfaces"`
+	}
+	if err := decode(r, &body); err != nil {
+		jsonErr(w, err, http.StatusBadRequest)
+		return
+	}
+	if err := validateWebInterfaces(body.Interfaces); err != nil {
+		jsonErr(w, err, http.StatusBadRequest)
+		return
+	}
+	if err := saveWebInterfaces(body.Interfaces); err != nil {
+		log.Printf("handleUpdateWebInterfaces: %v", err)
+		jsonErr(w, fmt.Errorf("could not save web interfaces"), http.StatusInternalServerError)
+		return
+	}
+	jsonOK(w, map[string]string{"ok": "web interfaces saved"})
+}

--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -771,6 +771,9 @@ func main() {
 	loadScheduledBackupConfig()
 	go runBackupScheduler(context.Background())
 
+	// Web interfaces (#155): load the operator-configured Server Health links.
+	loadWebInterfaces()
+
 	initLocationStore()
 	initGivePacksStore()
 

--- a/cmd/dune-admin/server.go
+++ b/cmd/dune-admin/server.go
@@ -129,6 +129,10 @@ func startServer(addr string) {
 	mux.HandleFunc("GET /api/v1/scheduled-backups", handleGetScheduledBackups)
 	mux.HandleFunc("PUT /api/v1/scheduled-backups", handleUpdateScheduledBackups)
 
+	// Web interfaces (#155) — operator-configurable links for the Server Health card.
+	mux.HandleFunc("GET /api/v1/web-interfaces", handleGetWebInterfaces)
+	mux.HandleFunc("PUT /api/v1/web-interfaces", handleUpdateWebInterfaces)
+
 	// ── battlegroup ───────────────────────────────────────────────────────────
 	mux.HandleFunc("GET /api/v1/battlegroup/status", handleBGStatus)
 	mux.HandleFunc("POST /api/v1/battlegroup/exec", handleBGExec)

--- a/cmd/dune-admin/web_interfaces.go
+++ b/cmd/dune-admin/web_interfaces.go
@@ -11,11 +11,11 @@ import (
 )
 
 // ── Web interfaces (#155) ────────────────────────────────────────────────────
-// A configurable, deployment-agnostic list of labeled links the Server Health
-// "Web Interfaces" card renders (Director, AMP panel, file browser, anything the
-// operator runs). Persisted as a small JSON file in configDir, mirroring the
-// scheduled-restarts store. Seeded from director_url so existing installs keep
-// their proxied Director link; fully editable thereafter.
+// A configurable, deployment-agnostic list of operator-defined web links (AMP
+// panel, file browser, etc.) the Server Health "Web Interfaces" card renders.
+// Persisted as a small JSON file in configDir, mirroring the scheduled-restarts
+// store. The Battlegroup Director is NOT stored here — the card shows it
+// automatically from director_url (via the /director/ proxy) when configured.
 
 type webInterface struct {
 	Label string `json:"label"`
@@ -42,28 +42,19 @@ func webInterfacesPath() string {
 	return filepath.Join(configDir(), "web-interfaces.json")
 }
 
-// seedWebInterfaces returns the default list for a fresh install: the proxied
-// Director link when a director_url is configured, otherwise empty.
-func seedWebInterfaces() []webInterface {
-	if loadedConfig.DirectorURL != "" {
-		return []webInterface{{Label: "Director", URL: "/director/"}}
-	}
-	return []webInterface{}
-}
-
 func loadWebInterfaces() {
 	webIfaceMu.Lock()
 	defer webIfaceMu.Unlock()
 	webIfaceLoaded = true
 	data, err := os.ReadFile(webInterfacesPath())
 	if err != nil {
-		webIfaces = seedWebInterfaces() // no file yet → seed (in memory only)
+		webIfaces = []webInterface{} // no file yet → empty (the Director shows automatically)
 		return
 	}
 	var list []webInterface
 	if err := json.Unmarshal(data, &list); err != nil {
 		log.Printf("web-interfaces: config parse: %v", err)
-		webIfaces = seedWebInterfaces()
+		webIfaces = []webInterface{}
 		return
 	}
 	webIfaces = list

--- a/cmd/dune-admin/web_interfaces.go
+++ b/cmd/dune-admin/web_interfaces.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// ── Web interfaces (#155) ────────────────────────────────────────────────────
+// A configurable, deployment-agnostic list of labeled links the Server Health
+// "Web Interfaces" card renders (Director, AMP panel, file browser, anything the
+// operator runs). Persisted as a small JSON file in configDir, mirroring the
+// scheduled-restarts store. Seeded from director_url so existing installs keep
+// their proxied Director link; fully editable thereafter.
+
+type webInterface struct {
+	Label string `json:"label"`
+	URL   string `json:"url"`
+}
+
+const (
+	maxWebInterfaces  = 20
+	maxWebIfaceLabel  = 64
+	maxWebIfaceURLLen = 512
+)
+
+var (
+	webIfaceMu     sync.RWMutex
+	webIfaces      []webInterface
+	webIfaceLoaded bool
+	webIfacePath   string // overridable in tests
+)
+
+func webInterfacesPath() string {
+	if webIfacePath != "" {
+		return webIfacePath
+	}
+	return filepath.Join(configDir(), "web-interfaces.json")
+}
+
+// seedWebInterfaces returns the default list for a fresh install: the proxied
+// Director link when a director_url is configured, otherwise empty.
+func seedWebInterfaces() []webInterface {
+	if loadedConfig.DirectorURL != "" {
+		return []webInterface{{Label: "Director", URL: "/director/"}}
+	}
+	return []webInterface{}
+}
+
+func loadWebInterfaces() {
+	webIfaceMu.Lock()
+	defer webIfaceMu.Unlock()
+	webIfaceLoaded = true
+	data, err := os.ReadFile(webInterfacesPath())
+	if err != nil {
+		webIfaces = seedWebInterfaces() // no file yet → seed (in memory only)
+		return
+	}
+	var list []webInterface
+	if err := json.Unmarshal(data, &list); err != nil {
+		log.Printf("web-interfaces: config parse: %v", err)
+		webIfaces = seedWebInterfaces()
+		return
+	}
+	webIfaces = list
+}
+
+func getWebInterfaces() []webInterface {
+	webIfaceMu.RLock()
+	if !webIfaceLoaded {
+		webIfaceMu.RUnlock()
+		loadWebInterfaces()
+		webIfaceMu.RLock()
+	}
+	defer webIfaceMu.RUnlock()
+	out := make([]webInterface, len(webIfaces))
+	copy(out, webIfaces)
+	return out
+}
+
+// validateWebInterfaces enforces non-empty fields, a safe URL scheme (only
+// http(s):// or a same-origin "/path", so a "javascript:" URL can't be smuggled
+// into a link target), and sane caps.
+func validateWebInterfaces(list []webInterface) error {
+	if len(list) > maxWebInterfaces {
+		return fmt.Errorf("too many web interfaces (max %d)", maxWebInterfaces)
+	}
+	for _, w := range list {
+		label := strings.TrimSpace(w.Label)
+		url := strings.TrimSpace(w.URL)
+		if label == "" || url == "" {
+			return fmt.Errorf("each web interface needs a label and a URL")
+		}
+		if len(label) > maxWebIfaceLabel || len(url) > maxWebIfaceURLLen {
+			return fmt.Errorf("web interface label or URL too long")
+		}
+		if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") && !strings.HasPrefix(url, "/") {
+			return fmt.Errorf("web interface URL %q must start with http://, https:// or /", url)
+		}
+	}
+	return nil
+}
+
+func saveWebInterfaces(list []webInterface) error {
+	if err := validateWebInterfaces(list); err != nil {
+		return err
+	}
+	clean := make([]webInterface, len(list))
+	for i, w := range list {
+		clean[i] = webInterface{Label: strings.TrimSpace(w.Label), URL: strings.TrimSpace(w.URL)}
+	}
+	data, err := json.MarshalIndent(clean, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(configDir(), 0o750); err != nil {
+		return err
+	}
+	if err := os.WriteFile(webInterfacesPath(), data, 0o600); err != nil {
+		return err
+	}
+	webIfaceMu.Lock()
+	webIfaces = clean
+	webIfaceLoaded = true
+	webIfaceMu.Unlock()
+	return nil
+}

--- a/cmd/dune-admin/web_interfaces_test.go
+++ b/cmd/dune-admin/web_interfaces_test.go
@@ -1,0 +1,57 @@
+package main
+
+import "testing"
+
+func TestValidateWebInterfaces(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   []webInterface
+		ok   bool
+	}{
+		{"valid mix", []webInterface{{Label: "Director", URL: "/director/"}, {Label: "AMP", URL: "http://host:8080"}}, true},
+		{"https ok", []webInterface{{Label: "Panel", URL: "https://example.com/x"}}, true},
+		{"empty list ok", []webInterface{}, true},
+		{"empty label", []webInterface{{Label: "", URL: "/x"}}, false},
+		{"empty url", []webInterface{{Label: "X", URL: ""}}, false},
+		{"javascript scheme rejected", []webInterface{{Label: "X", URL: "javascript:alert(1)"}}, false},
+		{"bare host rejected", []webInterface{{Label: "X", URL: "host:8080"}}, false},
+		{"ftp rejected", []webInterface{{Label: "X", URL: "ftp://h/x"}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateWebInterfaces(tt.in)
+			if tt.ok && err != nil {
+				t.Fatalf("validateWebInterfaces(%v) = %v, want nil", tt.in, err)
+			}
+			if !tt.ok && err == nil {
+				t.Fatalf("validateWebInterfaces(%v) = nil, want error", tt.in)
+			}
+		})
+	}
+
+	// too many entries rejected
+	many := make([]webInterface, maxWebInterfaces+1)
+	for i := range many {
+		many[i] = webInterface{Label: "L", URL: "/x"}
+	}
+	if validateWebInterfaces(many) == nil {
+		t.Fatalf("expected error for > %d entries", maxWebInterfaces)
+	}
+}
+
+func TestSeedWebInterfaces(t *testing.T) {
+	prev := loadedConfig
+	t.Cleanup(func() { loadedConfig = prev })
+
+	loadedConfig = appConfig{DirectorURL: "http://127.0.0.1:11717"}
+	seed := seedWebInterfaces()
+	if len(seed) != 1 || seed[0].Label != "Director" || seed[0].URL != "/director/" {
+		t.Fatalf("with director_url set, seed = %+v, want one Director→/director/ entry", seed)
+	}
+
+	loadedConfig = appConfig{DirectorURL: ""}
+	if len(seedWebInterfaces()) != 0 {
+		t.Fatalf("with no director_url, seed should be empty")
+	}
+}

--- a/cmd/dune-admin/web_interfaces_test.go
+++ b/cmd/dune-admin/web_interfaces_test.go
@@ -39,19 +39,3 @@ func TestValidateWebInterfaces(t *testing.T) {
 		t.Fatalf("expected error for > %d entries", maxWebInterfaces)
 	}
 }
-
-func TestSeedWebInterfaces(t *testing.T) {
-	prev := loadedConfig
-	t.Cleanup(func() { loadedConfig = prev })
-
-	loadedConfig = appConfig{DirectorURL: "http://127.0.0.1:11717"}
-	seed := seedWebInterfaces()
-	if len(seed) != 1 || seed[0].Label != "Director" || seed[0].URL != "/director/" {
-		t.Fatalf("with director_url set, seed = %+v, want one Director→/director/ entry", seed)
-	}
-
-	loadedConfig = appConfig{DirectorURL: ""}
-	if len(seedWebInterfaces()) != 0 {
-		t.Fatalf("with no director_url, seed should be empty")
-	}
-}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -357,6 +357,10 @@ export type ScheduledBackups = {
   last_fired: number
   next_backup?: string
 }
+export type WebInterface = {
+  label: string
+  url: string
+}
 export type GuildSummary = {
   guild_id: number
   name: string
@@ -993,6 +997,10 @@ export const api = {
     get: () => req<ScheduledBackups>('GET', '/scheduled-backups'),
     update: (body: { enabled: boolean, timezone: string, rules: BackupRule[], keep_n: number }) =>
       req<MutateResult>('PUT', '/scheduled-backups', body),
+  },
+  webInterfaces: {
+    get: () => req<{ interfaces: WebInterface[] }>('GET', '/web-interfaces'),
+    update: (interfaces: WebInterface[]) => req<MutateResult>('PUT', '/web-interfaces', { interfaces }),
   },
   guilds: {
     list: () => req<GuildSummary[]>('GET', '/guilds'),

--- a/web/src/components/ScheduledRestartsCard.tsx
+++ b/web/src/components/ScheduledRestartsCard.tsx
@@ -5,6 +5,7 @@ import { Button, Spinner, toast } from '@heroui/react'
 import { api } from '../api/client'
 import type { ScheduledRestarts, RestartRule } from '../api/client'
 import { Panel, SectionLabel, Icon } from '../dune-ui'
+import { TimezoneSelect } from './TimezoneSelect'
 
 const DOW = [0, 1, 2, 3, 4, 5, 6] // Sun..Sat
 
@@ -151,12 +152,7 @@ export const ScheduledRestartsCard: React.FC = () => {
                 </label>
                 <label className="flex items-center gap-2 flex-1 min-w-[160px]">
                   {t('restarts.timezone')}
-                  <input
-                    value={timezone}
-                    placeholder={t('restarts.tzPlaceholder')}
-                    onChange={(e) => setTimezone(e.target.value)}
-                    className={`${inputCls} flex-1`}
-                  />
+                  <TimezoneSelect value={timezone} onChange={setTimezone} className="flex-1" />
                 </label>
               </div>
 

--- a/web/src/components/TimezoneSelect.tsx
+++ b/web/src/components/TimezoneSelect.tsx
@@ -1,0 +1,41 @@
+import type React from 'react'
+import { useTranslation } from 'react-i18next'
+
+// IANA timezone names from the browser when available (Chrome 99+/modern), with
+// a small fallback for older runtimes. Computed once at module load.
+function tzList(): string[] {
+  const fn = (Intl as { supportedValuesOf?: (k: string) => string[] }).supportedValuesOf
+  try {
+    if (typeof fn === 'function') return fn('timeZone')
+  }
+  catch { /* fall through to fallback */ }
+  return [
+    'UTC', 'America/New_York', 'America/Chicago', 'America/Denver', 'America/Los_Angeles',
+    'America/Sao_Paulo', 'Europe/London', 'Europe/Berlin', 'Europe/Paris', 'Europe/Moscow',
+    'Asia/Tokyo', 'Asia/Shanghai', 'Asia/Kolkata', 'Australia/Sydney',
+  ]
+}
+
+const ZONES = tzList()
+
+// TimezoneSelect is a native dropdown of IANA timezones with an empty "host
+// local" option (the backend treats "" as the server's local time). Native
+// <select> gives free type-to-search over the ~400-entry list.
+export const TimezoneSelect: React.FC<{
+  value: string
+  onChange: (v: string) => void
+  className?: string
+}> = ({ value, onChange, className }) => {
+  const { t } = useTranslation()
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      aria-label={t('common.timezone')}
+      className={`bg-surface text-foreground border border-border rounded px-2 py-1 text-sm ${className ?? ''}`}
+    >
+      <option value="">{t('common.tzHostLocal')}</option>
+      {ZONES.map((z) => <option key={z} value={z}>{z}</option>)}
+    </select>
+  )
+}

--- a/web/src/locales/de/translation.json
+++ b/web/src/locales/de/translation.json
@@ -45,6 +45,14 @@
     }
   },
   "serverHealth": {
+    "ifaceLoadFailed": "Web-Oberflächen konnten nicht geladen werden: {{message}}",
+    "ifaceSaveFailed": "Speichern fehlgeschlagen: {{message}}",
+    "ifaceLabel": "Bezeichnung",
+    "ifaceUrl": "URL (http:// oder /Pfad)",
+    "editInterfaces": "Web-Oberflächen bearbeiten",
+    "removeInterface": "Entfernen",
+    "addInterface": "Oberfläche hinzufügen",
+    "saveInterfaces": "Speichern",
     "title": "Serverzustand",
     "subtitle": "Live-Status von VM, Kampfgruppe und Ports.",
     "gamePorts": "Spiel (UDP)",
@@ -327,6 +335,8 @@
     "title_other": "Baupläne ({{count}})"
   },
   "common": {
+    "timezone": "Zeitzone",
+    "tzHostLocal": "Host-lokal",
     "add": "Hinzufügen",
     "cancel": "Abbrechen",
     "checking": "Wird geprüft…",

--- a/web/src/locales/de/translation.json
+++ b/web/src/locales/de/translation.json
@@ -45,6 +45,7 @@
     }
   },
   "serverHealth": {
+    "directorProxied": "(via Proxy)",
     "ifaceLoadFailed": "Web-Oberflächen konnten nicht geladen werden: {{message}}",
     "ifaceSaveFailed": "Speichern fehlgeschlagen: {{message}}",
     "ifaceLabel": "Bezeichnung",

--- a/web/src/locales/en-US/translation.json
+++ b/web/src/locales/en-US/translation.json
@@ -45,6 +45,14 @@
     }
   },
   "serverHealth": {
+    "ifaceLoadFailed": "Failed to load web interfaces: {{message}}",
+    "ifaceSaveFailed": "Save failed: {{message}}",
+    "ifaceLabel": "Label",
+    "ifaceUrl": "URL (http:// or /path)",
+    "editInterfaces": "Edit web interfaces",
+    "removeInterface": "Remove",
+    "addInterface": "Add interface",
+    "saveInterfaces": "Save",
     "title": "Server Health",
     "subtitle": "Live VM, battlegroup, and port status.",
     "gamePorts": "Game (UDP)",
@@ -327,6 +335,8 @@
     "title_other": "Blueprints ({{count}})"
   },
   "common": {
+    "timezone": "Timezone",
+    "tzHostLocal": "Host local",
     "add": "Add",
     "cancel": "Cancel",
     "checking": "Checking…",

--- a/web/src/locales/en-US/translation.json
+++ b/web/src/locales/en-US/translation.json
@@ -45,6 +45,7 @@
     }
   },
   "serverHealth": {
+    "directorProxied": "(proxied)",
     "ifaceLoadFailed": "Failed to load web interfaces: {{message}}",
     "ifaceSaveFailed": "Save failed: {{message}}",
     "ifaceLabel": "Label",

--- a/web/src/locales/es/translation.json
+++ b/web/src/locales/es/translation.json
@@ -45,6 +45,14 @@
     }
   },
   "serverHealth": {
+    "ifaceLoadFailed": "Error al cargar las interfaces web: {{message}}",
+    "ifaceSaveFailed": "Error al guardar: {{message}}",
+    "ifaceLabel": "Etiqueta",
+    "ifaceUrl": "URL (http:// o /ruta)",
+    "editInterfaces": "Editar interfaces web",
+    "removeInterface": "Eliminar",
+    "addInterface": "Añadir interfaz",
+    "saveInterfaces": "Guardar",
     "title": "Estado del servidor",
     "subtitle": "Estado en vivo de la VM, el grupo de batalla y los puertos.",
     "gamePorts": "Juego (UDP)",
@@ -329,6 +337,8 @@
     "title_other": "Planos ({{count}})"
   },
   "common": {
+    "timezone": "Zona horaria",
+    "tzHostLocal": "Local del host",
     "add": "Añadir",
     "cancel": "Cancelar",
     "checking": "Comprobando…",

--- a/web/src/locales/es/translation.json
+++ b/web/src/locales/es/translation.json
@@ -45,6 +45,7 @@
     }
   },
   "serverHealth": {
+    "directorProxied": "(con proxy)",
     "ifaceLoadFailed": "Error al cargar las interfaces web: {{message}}",
     "ifaceSaveFailed": "Error al guardar: {{message}}",
     "ifaceLabel": "Etiqueta",

--- a/web/src/locales/fr/translation.json
+++ b/web/src/locales/fr/translation.json
@@ -45,6 +45,14 @@
     }
   },
   "serverHealth": {
+    "ifaceLoadFailed": "Échec du chargement des interfaces web : {{message}}",
+    "ifaceSaveFailed": "Échec de l'enregistrement : {{message}}",
+    "ifaceLabel": "Libellé",
+    "ifaceUrl": "URL (http:// ou /chemin)",
+    "editInterfaces": "Modifier les interfaces web",
+    "removeInterface": "Supprimer",
+    "addInterface": "Ajouter une interface",
+    "saveInterfaces": "Enregistrer",
     "title": "État du serveur",
     "subtitle": "État en direct de la VM, du groupe de combat et des ports.",
     "gamePorts": "Jeu (UDP)",
@@ -329,6 +337,8 @@
     "title_other": "Schémas ({{count}})"
   },
   "common": {
+    "timezone": "Fuseau horaire",
+    "tzHostLocal": "Local hôte",
     "add": "Ajouter",
     "cancel": "Annuler",
     "checking": "Vérification…",

--- a/web/src/locales/fr/translation.json
+++ b/web/src/locales/fr/translation.json
@@ -45,6 +45,7 @@
     }
   },
   "serverHealth": {
+    "directorProxied": "(via proxy)",
     "ifaceLoadFailed": "Échec du chargement des interfaces web : {{message}}",
     "ifaceSaveFailed": "Échec de l'enregistrement : {{message}}",
     "ifaceLabel": "Libellé",

--- a/web/src/locales/ja/translation.json
+++ b/web/src/locales/ja/translation.json
@@ -45,6 +45,7 @@
     }
   },
   "serverHealth": {
+    "directorProxied": "(プロキシ経由)",
     "ifaceLoadFailed": "Web インターフェースの読み込みに失敗しました: {{message}}",
     "ifaceSaveFailed": "保存に失敗しました: {{message}}",
     "ifaceLabel": "ラベル",

--- a/web/src/locales/ja/translation.json
+++ b/web/src/locales/ja/translation.json
@@ -45,6 +45,14 @@
     }
   },
   "serverHealth": {
+    "ifaceLoadFailed": "Web インターフェースの読み込みに失敗しました: {{message}}",
+    "ifaceSaveFailed": "保存に失敗しました: {{message}}",
+    "ifaceLabel": "ラベル",
+    "ifaceUrl": "URL (http:// または /path)",
+    "editInterfaces": "Web インターフェースを編集",
+    "removeInterface": "削除",
+    "addInterface": "インターフェースを追加",
+    "saveInterfaces": "保存",
     "title": "サーバーの状態",
     "subtitle": "VM・バトルグループ・ポートのライブ状態。",
     "gamePorts": "ゲーム (UDP)",
@@ -327,6 +335,8 @@
     "title_other": "ブループリント ({{count}})"
   },
   "common": {
+    "timezone": "タイムゾーン",
+    "tzHostLocal": "ホストのローカル",
     "add": "追加",
     "cancel": "キャンセル",
     "checking": "確認中…",

--- a/web/src/locales/pl/translation.json
+++ b/web/src/locales/pl/translation.json
@@ -45,6 +45,14 @@
     }
   },
   "serverHealth": {
+    "ifaceLoadFailed": "Nie udało się załadować interfejsów webowych: {{message}}",
+    "ifaceSaveFailed": "Zapis nie powiódł się: {{message}}",
+    "ifaceLabel": "Etykieta",
+    "ifaceUrl": "URL (http:// lub /ścieżka)",
+    "editInterfaces": "Edytuj interfejsy webowe",
+    "removeInterface": "Usuń",
+    "addInterface": "Dodaj interfejs",
+    "saveInterfaces": "Zapisz",
     "title": "Stan serwera",
     "subtitle": "Stan na żywo VM, grupy bojowej i portów.",
     "gamePorts": "Gra (UDP)",
@@ -331,6 +339,8 @@
     "title_other": "Plany ({{count}})"
   },
   "common": {
+    "timezone": "Strefa czasowa",
+    "tzHostLocal": "Lokalna hosta",
     "add": "Dodaj",
     "cancel": "Anuluj",
     "checking": "Sprawdzanie…",

--- a/web/src/locales/pl/translation.json
+++ b/web/src/locales/pl/translation.json
@@ -45,6 +45,7 @@
     }
   },
   "serverHealth": {
+    "directorProxied": "(przez proxy)",
     "ifaceLoadFailed": "Nie udało się załadować interfejsów webowych: {{message}}",
     "ifaceSaveFailed": "Zapis nie powiódł się: {{message}}",
     "ifaceLabel": "Etykieta",

--- a/web/src/locales/pt-BR/translation.json
+++ b/web/src/locales/pt-BR/translation.json
@@ -45,6 +45,14 @@
     }
   },
   "serverHealth": {
+    "ifaceLoadFailed": "Falha ao carregar as interfaces web: {{message}}",
+    "ifaceSaveFailed": "Falha ao salvar: {{message}}",
+    "ifaceLabel": "Rótulo",
+    "ifaceUrl": "URL (http:// ou /caminho)",
+    "editInterfaces": "Editar interfaces web",
+    "removeInterface": "Remover",
+    "addInterface": "Adicionar interface",
+    "saveInterfaces": "Salvar",
     "title": "Saúde do servidor",
     "subtitle": "Status ao vivo da VM, do grupo de batalha e das portas.",
     "gamePorts": "Jogo (UDP)",
@@ -329,6 +337,8 @@
     "title_other": "Plantas ({{count}})"
   },
   "common": {
+    "timezone": "Fuso horário",
+    "tzHostLocal": "Local do host",
     "add": "Adicionar",
     "cancel": "Cancelar",
     "checking": "Verificando…",

--- a/web/src/locales/pt-BR/translation.json
+++ b/web/src/locales/pt-BR/translation.json
@@ -45,6 +45,7 @@
     }
   },
   "serverHealth": {
+    "directorProxied": "(via proxy)",
     "ifaceLoadFailed": "Falha ao carregar as interfaces web: {{message}}",
     "ifaceSaveFailed": "Falha ao salvar: {{message}}",
     "ifaceLabel": "Rótulo",

--- a/web/src/locales/ru/translation.json
+++ b/web/src/locales/ru/translation.json
@@ -45,6 +45,14 @@
     }
   },
   "serverHealth": {
+    "ifaceLoadFailed": "Не удалось загрузить веб-интерфейсы: {{message}}",
+    "ifaceSaveFailed": "Не удалось сохранить: {{message}}",
+    "ifaceLabel": "Метка",
+    "ifaceUrl": "URL (http:// или /путь)",
+    "editInterfaces": "Редактировать веб-интерфейсы",
+    "removeInterface": "Удалить",
+    "addInterface": "Добавить интерфейс",
+    "saveInterfaces": "Сохранить",
     "title": "Состояние сервера",
     "subtitle": "Состояние ВМ, боевой группы и портов в реальном времени.",
     "gamePorts": "Игра (UDP)",
@@ -331,6 +339,8 @@
     "title_other": "Чертежи ({{count}})"
   },
   "common": {
+    "timezone": "Часовой пояс",
+    "tzHostLocal": "Локальное хоста",
     "add": "Добавить",
     "cancel": "Отмена",
     "checking": "Проверка…",

--- a/web/src/locales/ru/translation.json
+++ b/web/src/locales/ru/translation.json
@@ -45,6 +45,7 @@
     }
   },
   "serverHealth": {
+    "directorProxied": "(через прокси)",
     "ifaceLoadFailed": "Не удалось загрузить веб-интерфейсы: {{message}}",
     "ifaceSaveFailed": "Не удалось сохранить: {{message}}",
     "ifaceLabel": "Метка",

--- a/web/src/locales/tr/translation.json
+++ b/web/src/locales/tr/translation.json
@@ -45,6 +45,7 @@
     }
   },
   "serverHealth": {
+    "directorProxied": "(proxy üzerinden)",
     "ifaceLoadFailed": "Web arayüzleri yüklenemedi: {{message}}",
     "ifaceSaveFailed": "Kaydetme başarısız: {{message}}",
     "ifaceLabel": "Etiket",

--- a/web/src/locales/tr/translation.json
+++ b/web/src/locales/tr/translation.json
@@ -45,6 +45,14 @@
     }
   },
   "serverHealth": {
+    "ifaceLoadFailed": "Web arayüzleri yüklenemedi: {{message}}",
+    "ifaceSaveFailed": "Kaydetme başarısız: {{message}}",
+    "ifaceLabel": "Etiket",
+    "ifaceUrl": "URL (http:// veya /yol)",
+    "editInterfaces": "Web arayüzlerini düzenle",
+    "removeInterface": "Kaldır",
+    "addInterface": "Arayüz ekle",
+    "saveInterfaces": "Kaydet",
     "title": "Sunucu Durumu",
     "subtitle": "Canlı VM, savaş grubu ve port durumu.",
     "gamePorts": "Oyun (UDP)",
@@ -327,6 +335,8 @@
     "title_other": "Planlar ({{count}})"
   },
   "common": {
+    "timezone": "Saat dilimi",
+    "tzHostLocal": "Ana makine yereli",
     "add": "Ekle",
     "cancel": "İptal",
     "checking": "Kontrol ediliyor…",

--- a/web/src/locales/zh-CN/translation.json
+++ b/web/src/locales/zh-CN/translation.json
@@ -45,6 +45,14 @@
     }
   },
   "serverHealth": {
+    "ifaceLoadFailed": "加载 Web 界面失败：{{message}}",
+    "ifaceSaveFailed": "保存失败：{{message}}",
+    "ifaceLabel": "标签",
+    "ifaceUrl": "URL（http:// 或 /path）",
+    "editInterfaces": "编辑 Web 界面",
+    "removeInterface": "移除",
+    "addInterface": "添加界面",
+    "saveInterfaces": "保存",
     "title": "服务器健康",
     "subtitle": "VM、战斗群和端口的实时状态。",
     "gamePorts": "游戏 (UDP)",
@@ -327,6 +335,8 @@
     "title_other": "蓝图 ({{count}})"
   },
   "common": {
+    "timezone": "时区",
+    "tzHostLocal": "主机本地",
     "add": "添加",
     "cancel": "取消",
     "checking": "检查中…",

--- a/web/src/locales/zh-CN/translation.json
+++ b/web/src/locales/zh-CN/translation.json
@@ -45,6 +45,7 @@
     }
   },
   "serverHealth": {
+    "directorProxied": "(经代理)",
     "ifaceLoadFailed": "加载 Web 界面失败：{{message}}",
     "ifaceSaveFailed": "保存失败：{{message}}",
     "ifaceLabel": "标签",

--- a/web/src/tabs/BattlegroupTab/components/ServerHealth.tsx
+++ b/web/src/tabs/BattlegroupTab/components/ServerHealth.tsx
@@ -161,13 +161,44 @@ const InterfaceRow: React.FC<{ item: WebInterface }> = ({ item }) => {
   )
 }
 
-export const WebInterfacesCard: React.FC = () => {
+// DirectorRow is the automatic, read-only entry shown when director_url is set:
+// the Director usually binds to loopback on the host, so "Open" goes through the
+// same-origin /director/ reverse proxy. The configured target is shown for context.
+const DirectorRow: React.FC<{ directorURL: string }> = ({ directorURL }) => {
+  const { t } = useTranslation()
+  const copy = () => {
+    copyText(`${window.location.origin}/director/`).then((ok) =>
+      (ok ? toast.success(t('serverHealth.copied')) : toast.danger(t('serverHealth.copyFailed'))))
+  }
+  return (
+    <div className="flex items-center gap-2">
+      <Icon name="external-link" className="size-4 text-accent" />
+      <div className="flex flex-col min-w-0 flex-1">
+        <span className="text-sm font-semibold">
+          {t('serverHealth.director')}
+          {' '}
+          <span className="text-xs font-normal text-muted">{t('serverHealth.directorProxied')}</span>
+        </span>
+        <span className="text-xs text-muted font-mono truncate">{directorURL}</span>
+      </div>
+      <Button size="sm" variant="ghost" isIconOnly aria-label={t('serverHealth.copy')} onPress={copy}>
+        <Icon name="copy" />
+      </Button>
+      <Button size="sm" variant="outline" onPress={() => window.open('/director/', '_blank', 'noopener')}>
+        {t('serverHealth.open')}
+      </Button>
+    </div>
+  )
+}
+
+export const WebInterfacesCard: React.FC<{ status: Status | null }> = ({ status }) => {
   const { t } = useTranslation()
   const [items, setItems] = useState<WebInterface[]>([])
   const [draft, setDraft] = useState<WebInterface[]>([])
   const [editing, setEditing] = useState(false)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
+  const director = status?.director_url
 
   const load = useCallback(() => {
     Promise.resolve()
@@ -214,6 +245,8 @@ export const WebInterfacesCard: React.FC = () => {
     <HealthCard title={t('serverHealth.webInterfaces')} icon="layout" accessory={!editing && !loading ? editBtn : undefined}>
       {loading && <div className="py-2 flex justify-center"><Spinner size="sm" color="current" /></div>}
 
+      {!loading && director && <DirectorRow directorURL={director} />}
+
       {!loading && editing && (
         <div className="flex flex-col gap-2">
           {draft.map((row, i) => (
@@ -256,7 +289,7 @@ export const WebInterfacesCard: React.FC = () => {
         </div>
       )}
 
-      {!loading && !editing && items.length === 0 && (
+      {!loading && !editing && !director && items.length === 0 && (
         <div className="flex items-center justify-between gap-2">
           <span className="text-sm text-muted">{t('serverHealth.noInterfaces')}</span>
           <Button size="sm" variant="outline" onPress={startEdit}>

--- a/web/src/tabs/BattlegroupTab/components/ServerHealth.tsx
+++ b/web/src/tabs/BattlegroupTab/components/ServerHealth.tsx
@@ -1,10 +1,12 @@
 import type React from 'react'
 import type { ReactNode } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Button, Chip, toast } from '@heroui/react'
+import { Button, Chip, Spinner, toast } from '@heroui/react'
 import { Icon, SectionLabel } from '../../../dune-ui'
 import { copyText } from '../../../utils/clipboard'
-import type { Status } from '../../../api/client'
+import { api } from '../../../api/client'
+import type { Status, WebInterface } from '../../../api/client'
 import type { BGInfo, ServerRow } from '../types'
 import { phaseColor, phaseChipColor, bgUptimeSeconds, allServersReady } from '../helpers'
 import { formatUptime, portRange } from '../uptime'
@@ -133,36 +135,143 @@ export const GameReadyCard: React.FC<{ bg?: BGInfo, servers: ServerRow[] }> = ({
   )
 }
 
-// ── Web interfaces ────────────────────────────────────────────────────────────
-const InterfaceRow: React.FC<{ label: string, url: string, href: string }> = ({ label, url, href }) => {
+// ── Web interfaces (#155: operator-configurable list) ────────────────────────
+const ifaceInputCls = 'bg-surface text-foreground border border-border rounded px-2 py-1 text-sm'
+
+const InterfaceRow: React.FC<{ item: WebInterface }> = ({ item }) => {
   const { t } = useTranslation()
   const copy = () => {
-    copyText(url).then((ok) => (ok ? toast.success(t('serverHealth.copied')) : toast.danger(t('serverHealth.copyFailed'))))
+    copyText(item.url).then((ok) =>
+      (ok ? toast.success(t('serverHealth.copied')) : toast.danger(t('serverHealth.copyFailed'))))
   }
   return (
     <div className="flex items-center gap-2">
       <Icon name="external-link" className="size-4 text-accent" />
       <div className="flex flex-col min-w-0 flex-1">
-        <span className="text-sm font-semibold">{label}</span>
-        <span className="text-xs text-muted font-mono truncate">{url}</span>
+        <span className="text-sm font-semibold">{item.label}</span>
+        <span className="text-xs text-muted font-mono truncate">{item.url}</span>
       </div>
       <Button size="sm" variant="ghost" isIconOnly aria-label={t('serverHealth.copy')} onPress={copy}>
         <Icon name="copy" />
       </Button>
-      <Button size="sm" variant="outline" onPress={() => window.open(href, '_blank', 'noopener')}>
+      <Button size="sm" variant="outline" onPress={() => window.open(item.url, '_blank', 'noopener')}>
         {t('serverHealth.open')}
       </Button>
     </div>
   )
 }
 
-export const WebInterfacesCard: React.FC<{ status: Status | null }> = ({ status }) => {
+export const WebInterfacesCard: React.FC = () => {
   const { t } = useTranslation()
+  const [items, setItems] = useState<WebInterface[]>([])
+  const [draft, setDraft] = useState<WebInterface[]>([])
+  const [editing, setEditing] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+
+  const load = useCallback(() => {
+    Promise.resolve()
+      .then(() => setLoading(true))
+      .then(() => api.webInterfaces.get())
+      .then((res) => setItems(res.interfaces ?? []))
+      .catch((e: unknown) =>
+        toast.danger(t('serverHealth.ifaceLoadFailed', { message: e instanceof Error ? e.message : String(e) })))
+      .finally(() => setLoading(false))
+  }, [t])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const startEdit = () => {
+    setDraft(items.length ? items.map((i) => ({ ...i })) : [{ label: '', url: '' }])
+    setEditing(true)
+  }
+  const setField = (i: number, key: 'label' | 'url', v: string) =>
+    setDraft((d) => d.map((row, idx) => (idx === i ? { ...row, [key]: v } : row)))
+
+  const save = () => {
+    const clean = draft.filter((r) => r.label.trim() && r.url.trim())
+    setSaving(true)
+    api.webInterfaces.update(clean)
+      .then((res) => {
+        toast.success(res.ok)
+        setEditing(false)
+        load()
+      })
+      .catch((e: unknown) =>
+        toast.danger(t('serverHealth.ifaceSaveFailed', { message: e instanceof Error ? e.message : String(e) })))
+      .finally(() => setSaving(false))
+  }
+
+  const editBtn = (
+    <Button size="sm" variant="ghost" isIconOnly aria-label={t('serverHealth.editInterfaces')} onPress={startEdit}>
+      <Icon name="pencil" />
+    </Button>
+  )
+
   return (
-    <HealthCard title={t('serverHealth.webInterfaces')} icon="layout">
-      {status?.director_url
-        ? <InterfaceRow label={t('serverHealth.director')} url={status.director_url} href="/director/" />
-        : <div className="text-sm text-muted">{t('serverHealth.noInterfaces')}</div>}
+    <HealthCard title={t('serverHealth.webInterfaces')} icon="layout" accessory={!editing && !loading ? editBtn : undefined}>
+      {loading && <div className="py-2 flex justify-center"><Spinner size="sm" color="current" /></div>}
+
+      {!loading && editing && (
+        <div className="flex flex-col gap-2">
+          {draft.map((row, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <input
+                value={row.label}
+                placeholder={t('serverHealth.ifaceLabel')}
+                onChange={(e) => setField(i, 'label', e.target.value)}
+                className={`${ifaceInputCls} w-32`}
+              />
+              <input
+                value={row.url}
+                placeholder={t('serverHealth.ifaceUrl')}
+                onChange={(e) => setField(i, 'url', e.target.value)}
+                className={`${ifaceInputCls} flex-1 font-mono`}
+              />
+              <Button
+                size="sm"
+                variant="ghost"
+                isIconOnly
+                aria-label={t('serverHealth.removeInterface')}
+                onPress={() => setDraft((d) => d.filter((_, idx) => idx !== i))}
+              >
+                <Icon name="trash-2" />
+              </Button>
+            </div>
+          ))}
+          <div className="flex items-center gap-2">
+            <Button size="sm" variant="outline" onPress={() => setDraft((d) => [...d, { label: '', url: '' }])}>
+              <Icon name="plus" />
+              {' '}
+              {t('serverHealth.addInterface')}
+            </Button>
+            <div className="flex-1" />
+            <Button size="sm" variant="ghost" onPress={() => setEditing(false)}>{t('common.cancel')}</Button>
+            <Button size="sm" onPress={save} isDisabled={saving}>
+              {saving ? <Spinner size="sm" color="current" /> : t('serverHealth.saveInterfaces')}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {!loading && !editing && items.length === 0 && (
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-sm text-muted">{t('serverHealth.noInterfaces')}</span>
+          <Button size="sm" variant="outline" onPress={startEdit}>
+            <Icon name="plus" />
+            {' '}
+            {t('serverHealth.addInterface')}
+          </Button>
+        </div>
+      )}
+
+      {!loading && !editing && items.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {items.map((it) => <InterfaceRow key={`${it.label}|${it.url}`} item={it} />)}
+        </div>
+      )}
     </HealthCard>
   )
 }

--- a/web/src/tabs/BattlegroupTab/index.tsx
+++ b/web/src/tabs/BattlegroupTab/index.tsx
@@ -158,7 +158,7 @@ export const BattlegroupTab: React.FC<BattlegroupTabProps> = ({ isActive = false
           <BgVmCard bg={bg} servers={servers} />
           <GameReadyCard bg={bg} servers={servers} />
           <ComponentHealthCard bg={bg} servers={servers} status={connStatus} />
-          <WebInterfacesCard status={connStatus} />
+          <WebInterfacesCard />
         </div>
 
         {/* Game servers */}

--- a/web/src/tabs/BattlegroupTab/index.tsx
+++ b/web/src/tabs/BattlegroupTab/index.tsx
@@ -158,7 +158,7 @@ export const BattlegroupTab: React.FC<BattlegroupTabProps> = ({ isActive = false
           <BgVmCard bg={bg} servers={servers} />
           <GameReadyCard bg={bg} servers={servers} />
           <ComponentHealthCard bg={bg} servers={servers} status={connStatus} />
-          <WebInterfacesCard />
+          <WebInterfacesCard status={connStatus} />
         </div>
 
         {/* Game servers */}

--- a/web/src/tabs/DatabaseTab/components/BackupsView.tsx
+++ b/web/src/tabs/DatabaseTab/components/BackupsView.tsx
@@ -5,6 +5,7 @@ import { Button, Spinner, toast } from '@heroui/react'
 import { api } from '../../../api/client'
 import type { DBBackupFile, ScheduledBackups, BackupRule } from '../../../api/client'
 import { Panel, SectionLabel, PageHeader, Icon, ConfirmDialog } from '../../../dune-ui'
+import { TimezoneSelect } from '../../../components/TimezoneSelect'
 
 const DOW = [0, 1, 2, 3, 4, 5, 6] // Sun..Sat
 
@@ -158,12 +159,7 @@ const ScheduleCard: React.FC = () => {
                 </label>
                 <label className="flex items-center gap-2 flex-1 min-w-[160px]">
                   {t('backups.schedule.timezone')}
-                  <input
-                    value={timezone}
-                    placeholder={t('backups.schedule.tzPlaceholder')}
-                    onChange={(e) => setTimezone(e.target.value)}
-                    className={`${inputCls} flex-1`}
-                  />
+                  <TimezoneSelect value={timezone} onChange={setTimezone} className="flex-1" />
                 </label>
               </div>
 

--- a/web/src/tabs/DirectorTab.tsx
+++ b/web/src/tabs/DirectorTab.tsx
@@ -1,10 +1,65 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import type React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button, Spinner, toast } from '@heroui/react'
 import { api, ApiError } from '../api/client'
 import type { DirectorConfig } from '../api/client'
 import { PageHeader, Panel, SectionLabel, Icon } from '../dune-ui'
+
+// ── field-type inference (#157) ──────────────────────────────────────────────
+// The director config is untyped INI text, so we infer an editor from the value
+// + comment (data-driven, no hardcoded enum tables): booleans → a dropdown,
+// numbers → a number input, and enums from either a "Alternatives: a, b, c"
+// comment or the distinct values used across the [InstancingModes] section.
+const fieldCls = 'w-full bg-surface text-foreground border border-border rounded px-2 py-1 text-sm'
+const numberRe = /^-?\d+(\.\d+)?$/
+
+function parseAlternatives(comment?: string): string[] {
+  const m = comment?.match(/alternatives?:\s*(.+)/i)
+  return m ? m[1].split(',').map((s) => s.trim()).filter(Boolean) : []
+}
+
+type FieldKind = { kind: 'bool' } | { kind: 'number' } | { kind: 'enum', options: string[] } | { kind: 'text' }
+
+function fieldKind(
+  section: string, value: string, comment: string | undefined, instancingOptions: string[],
+): FieldKind {
+  if (section === 'InstancingModes' && instancingOptions.length > 1) return { kind: 'enum', options: instancingOptions }
+  const alt = parseAlternatives(comment)
+  if (alt.length > 1) return { kind: 'enum', options: alt }
+  const v = value.trim().toLowerCase()
+  if (v === 'true' || v === 'false') return { kind: 'bool' }
+  if (numberRe.test(value.trim())) return { kind: 'number' }
+  return { kind: 'text' }
+}
+
+const DirectorEditor: React.FC<{
+  kind: FieldKind
+  value: string
+  onChange: (v: string) => void
+}> = ({ kind, value, onChange }) => {
+  if (kind.kind === 'bool') {
+    return (
+      <select className={fieldCls} value={value.trim().toLowerCase()} onChange={(e) => onChange(e.target.value)}>
+        <option value="true">true</option>
+        <option value="false">false</option>
+      </select>
+    )
+  }
+  if (kind.kind === 'enum') {
+    // Keep the current value selectable even if it isn't in the derived option set.
+    const opts = kind.options.includes(value) ? kind.options : [value, ...kind.options]
+    return (
+      <select className={fieldCls} value={value} onChange={(e) => onChange(e.target.value)}>
+        {opts.map((o) => <option key={o} value={o}>{o}</option>)}
+      </select>
+    )
+  }
+  if (kind.kind === 'number') {
+    return <input type="number" className={fieldCls} value={value} onChange={(e) => onChange(e.target.value)} />
+  }
+  return <input className={fieldCls} value={value} onChange={(e) => onChange(e.target.value)} />
+}
 
 // DirectorTab (#147): view/edit the Battlegroup Director config
 // (director_config.ini). [InstancingModes] controls map persistence; [Database]
@@ -40,6 +95,14 @@ export const DirectorTab: React.FC = () => {
   useEffect(() => {
     load()
   }, [load])
+
+  // The [InstancingModes] section's keys all share one enum domain (map →
+  // instancing mode), so its distinct values ARE the option set for each key.
+  const instancingOptions = useMemo(() => {
+    const sec = data?.sections.find((s) => s.name === 'InstancingModes')
+    if (!sec) return []
+    return Array.from(new Set(sec.lines.map((l) => l.value.trim()).filter(Boolean)))
+  }, [data])
 
   const pk = (section: string, key: string) => `${section}|${key}`
   const setVal = (section: string, key: string, value: string) =>
@@ -141,10 +204,10 @@ export const DirectorTab: React.FC = () => {
                     </div>
                     {editable
                       ? (
-                          <input
-                            className="w-full bg-surface text-foreground border border-border rounded px-2 py-1 text-sm"
+                          <DirectorEditor
+                            kind={fieldKind(sec.name, line.value, line.comment, instancingOptions)}
                             value={cur}
-                            onChange={(e) => setVal(sec.name, line.key, e.target.value)}
+                            onChange={(v) => setVal(sec.name, line.key, v)}
                           />
                         )
                       : <span className="text-muted font-mono truncate">{line.secret ? '••••••••' : line.value}</span>}

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -18,8 +18,13 @@ const THEME_KEY = 'dune_admin_theme'
 
 // Every token any preset may override — cleared before applying a new theme so
 // switching back to 'spice' (which overrides nothing) reverts to the :root values.
+// Covers the full surface ramp (background → surface → elevated panels) + borders
+// + accent family, so the whole UI (page, cards, modals, inputs) tints with the
+// theme rather than just the accent. --foreground is left at the :root cream for
+// readability on every dark tint.
 const OVERRIDE_KEYS = [
   '--accent', '--accent-foreground', '--focus', '--link',
+  '--background', '--surface', '--surface-alt', '--overlay', '--field-background',
   '--surface-secondary', '--surface-tertiary', '--surface-hover',
   '--border', '--separator', '--field-border',
   '--accent-soft-bg', '--accent-soft-border', '--scrollbar', '--muted',
@@ -29,18 +34,24 @@ const PALETTES: Record<ThemeId, Record<string, string>> = {
   spice: {},
   atreides: {
     '--accent': '#2f9e5e', '--accent-foreground': '#06140c', '--focus': '#46c47e', '--link': '#46c47e',
+    '--background': '#07120b', '--surface': '#0f1c14', '--surface-alt': '#0b160f',
+    '--overlay': '#0f1c14', '--field-background': '#07120b',
     '--surface-secondary': '#13241b', '--surface-tertiary': '#1c4631', '--surface-hover': '#13241b',
     '--border': '#1c4631', '--separator': '#13241b', '--field-border': '#2b6b48',
     '--accent-soft-bg': '#13241b', '--accent-soft-border': '#2b6b48', '--scrollbar': '#2b6b48', '--muted': '#7c917f',
   },
   harkonnen: {
     '--accent': '#cf2b2b', '--accent-foreground': '#ffffff', '--focus': '#e85555', '--link': '#e85555',
+    '--background': '#120707', '--surface': '#1c0f0f', '--surface-alt': '#160b0b',
+    '--overlay': '#1c0f0f', '--field-background': '#120707',
     '--surface-secondary': '#241010', '--surface-tertiary': '#4a1818', '--surface-hover': '#241010',
     '--border': '#4a1818', '--separator': '#241010', '--field-border': '#6b2b2b',
     '--accent-soft-bg': '#241010', '--accent-soft-border': '#6b2b2b', '--scrollbar': '#6b2b2b', '--muted': '#9a7a7a',
   },
   fremen: {
     '--accent': '#2f88c9', '--accent-foreground': '#06121c', '--focus': '#4aa6e8', '--link': '#4aa6e8',
+    '--background': '#07101a', '--surface': '#0f1a26', '--surface-alt': '#0b1420',
+    '--overlay': '#0f1a26', '--field-background': '#07101a',
     '--surface-secondary': '#101e2a', '--surface-tertiary': '#18374e', '--surface-hover': '#101e2a',
     '--border': '#18374e', '--separator': '#101e2a', '--field-border': '#2b577b',
     '--accent-soft-bg': '#101e2a', '--accent-soft-border': '#2b577b', '--scrollbar': '#2b577b', '--muted': '#708a9a',


### PR DESCRIPTION
## Server Health review fixes (#155–#158)

Follow-up to #154 (v0.31.0) — addresses the four issues @Icehunter filed during
review. Live-verified on an AMP deployment; all gates pass locally
(`go build`/`vet`/`gosec` 0/`gocognit` ≤15, `pnpm tsc`/`lint --max-warnings 0`/
`build`, i18n parity across all 10 locales).

### #155 — Web Interfaces card
The card was hardcoded to a single Director link and went blank when no
`director_url` was set. Reworked into two clear pieces:
- **The Battlegroup Director is now an automatic, read-only row** shown whenever
  `director_url` is configured. "Open" goes through the same-origin `/director/`
  reverse proxy (the Director typically binds to loopback, so the proxy is the
  only browser-reachable path); the configured target is shown for context.
- **A configurable, deployment-agnostic list of operator links** (AMP panel,
  file browser, anything) — a small JSON store (`web-interfaces.json`) with
  `GET`/`PUT /api/v1/web-interfaces`, edited inline on the card. URLs are
  validated to `http(s)://` or `/path`, so a `javascript:` target can't be
  injected into a link.

### #156 — Timezone picker
Replaced the free-text timezone field on both the scheduled-restarts and
scheduled-backups cards with a shared `TimezoneSelect` dropdown (IANA zones from
`Intl.supportedValuesOf('timeZone')`, with a "Host local" default).

### #157 — Director field types
The Director config editor rendered every field as raw text. It now infers an
editor from the value + comment (data-driven, no hardcoded enum tables):
- **booleans** (`true`/`false`) → dropdown,
- **numeric values** → number input,
- **enums** → dropdown, sourced from either an `Alternatives: a, b, c` comment
  (e.g. `Logging.level`) or the distinct values across the `[InstancingModes]`
  section (`ClassicalInstancing`/`Dimension`/`SingleServer`).

The current value is always kept selectable. Fields with no discoverable option
set (e.g. `ScalingResourceTarget`) remain text. (On a real config that's ~45
bool dropdowns, ~90 number inputs, ~38 enum dropdowns.)

> Minor pre-existing note unrelated to this change: a few fields whose INI line
> carries an inline `; comment` (e.g. `AcceptOutgoingCharacterTransfers`) keep
> the comment in the value and so stay text — happy to fix the inline-comment
> parsing in a follow-up if you'd like.

### #158 — Themes extend to surfaces
The presets only recolored the accent + elevated panels, leaving the page
background, primary surfaces, modals and inputs on the default amber. Each
palette (Atreides/Harkonnen/Fremen) now also sets `--background`, `--surface`,
`--surface-alt`, `--overlay` and `--field-background`, so the whole UI tints
with the theme. `--foreground` stays cream for readability on every tint.

New strings (#155/#156) localized across all 10 locales.

Closes #155
Closes #156
Closes #157
Closes #158

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
