### PR TITLE
fix(server-settings): read curated AMP values back from AMP's live config (#173)

### DIFF
--- a/cmd/dune-admin/control_amp.go
+++ b/cmd/dune-admin/control_amp.go
@@ -667,6 +667,32 @@ func (c *ampControl) writeServerSettings(_ context.Context, exec Executor, updat
 	return nil
 }
 
+// readServerSettings reads the current value of each curated FieldName back from
+// AMP's live config (Core/GetConfig on node "Meta.GenericModule.<FieldName>").
+// AMP — not the INI files — is the source of truth for these settings, so this
+// lets the read path reflect values saved through the AMP API immediately,
+// without waiting for AMP to regenerate UserEngine.ini / UserGame.ini on the
+// next game restart. Implements serverSettingsReader. The session is reused
+// across fields (login happens once on the first GetConfig).
+func (c *ampControl) readServerSettings(_ context.Context, exec Executor, fields []string) (map[string]string, error) {
+	if len(fields) == 0 {
+		return map[string]string{}, nil
+	}
+	if c.apiUser == "" || c.apiPass == "" {
+		return nil, fmt.Errorf("amp api credentials not configured — set amp_api_user and amp_api_pass to read server settings under AMP")
+	}
+	client := newAMPAPIClient(exec, c.wrapInContainer, c.apiUser, c.apiPass, c.apiPort)
+	out := make(map[string]string, len(fields))
+	for _, field := range fields {
+		v, err := client.getConfig("Meta.GenericModule." + field)
+		if err != nil {
+			return nil, fmt.Errorf("read server setting %s: %w", field, err)
+		}
+		out[field] = v
+	}
+	return out, nil
+}
+
 // ── INI discovery ─────────────────────────────────────────────────────────────
 
 // gameOverridePath returns the file AMP appends to UserGame.ini at boot:

--- a/cmd/dune-admin/control_amp_reader_test.go
+++ b/cmd/dune-admin/control_amp_reader_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// newAmpReadExec routes Core/Login and Core/GetConfig, returning canned
+// CurrentValue responses keyed by the requested node, and counts logins.
+func newAmpReadExec(t *testing.T, loginOK bool, values map[string]string, logins *int) *fnExecutor {
+	return &fnExecutor{fn: func(cmd string) (string, error) {
+		switch {
+		case strings.Contains(cmd, "Core/Login"):
+			*logins++
+			if !loginOK {
+				return `{"success":false,"resultReason":"bad creds"}`, nil
+			}
+			return `{"success":true,"sessionID":"sess"}`, nil
+		case strings.Contains(cmd, "Core/GetConfig"):
+			var p struct {
+				Node string `json:"node"`
+			}
+			decodePipedPayload(t, cmd, &p)
+			b, _ := json.Marshal(values[p.Node])
+			return `{"CurrentValue":` + string(b) + `}`, nil
+		default:
+			t.Fatalf("unexpected AMP API endpoint in cmd: %q", cmd)
+			return "", nil
+		}
+	}}
+}
+
+func TestAmpReadServerSettings_LoginOnceThenGetPerField(t *testing.T) {
+	t.Parallel()
+	logins := 0
+	values := map[string]string{
+		"Meta.GenericModule.ConsoleVariables.Dune.GlobalMiningOutputMultiplier": "5.000000",
+		"Meta.GenericModule.WorldTitle":                                         "My Sietch",
+	}
+	exec := newAmpReadExec(t, true, values, &logins)
+
+	got, err := ampSettingsControl().readServerSettings(context.Background(), exec, []string{
+		"ConsoleVariables.Dune.GlobalMiningOutputMultiplier",
+		"WorldTitle",
+	})
+	if err != nil {
+		t.Fatalf("readServerSettings: %v", err)
+	}
+	if logins != 1 {
+		t.Errorf("logins = %d, want 1 (session reused across reads)", logins)
+	}
+	if got["ConsoleVariables.Dune.GlobalMiningOutputMultiplier"] != "5.000000" {
+		t.Errorf("mining = %q, want 5.000000 (got: %v)", got["ConsoleVariables.Dune.GlobalMiningOutputMultiplier"], got)
+	}
+	if got["WorldTitle"] != "My Sietch" {
+		t.Errorf("title = %q, want My Sietch", got["WorldTitle"])
+	}
+}
+
+func TestAmpReadServerSettings_EmptyFieldsIsNoOp(t *testing.T) {
+	t.Parallel()
+	logins := 0
+	exec := newAmpReadExec(t, true, nil, &logins)
+	got, err := ampSettingsControl().readServerSettings(context.Background(), exec, nil)
+	if err != nil {
+		t.Fatalf("readServerSettings: %v", err)
+	}
+	if len(got) != 0 || logins != 0 {
+		t.Errorf("empty fields must not contact AMP: got=%v logins=%d", got, logins)
+	}
+}
+
+func TestAmpReadServerSettings_MissingCredentialsErrors(t *testing.T) {
+	t.Parallel()
+	called := false
+	exec := &fnExecutor{fn: func(string) (string, error) { called = true; return "", nil }}
+	c := &ampControl{useContainer: true, container: "AMP_X", ampUser: "amp", containerRuntime: "docker"} // no api creds
+	_, err := c.readServerSettings(context.Background(), exec, []string{"WorldTitle"})
+	if err == nil {
+		t.Fatal("expected error when AMP API credentials are not configured")
+	}
+	if called {
+		t.Error("must not contact the AMP API without credentials")
+	}
+}
+
+func TestAmpReadServerSettings_GetConfigFailurePropagates(t *testing.T) {
+	t.Parallel()
+	exec := &fnExecutor{fn: func(cmd string) (string, error) {
+		if strings.Contains(cmd, "Core/Login") {
+			return `{"success":true,"sessionID":"s"}`, nil
+		}
+		return "not json", nil // GetConfig garbage → decode error
+	}}
+	_, err := ampSettingsControl().readServerSettings(context.Background(), exec, []string{"WorldTitle"})
+	if err == nil {
+		t.Fatal("expected a GetConfig decode failure to propagate")
+	}
+}
+
+// Compile-time guard that ampControl satisfies the optional reader interface the
+// settings GET handler routes on.
+func TestAmpControl_ImplementsServerSettingsReader(t *testing.T) {
+	t.Parallel()
+	var _ serverSettingsReader = (*ampControl)(nil)
+}

--- a/cmd/dune-admin/handlers_server_settings.go
+++ b/cmd/dune-admin/handlers_server_settings.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	pathpkg "path"
@@ -453,6 +454,64 @@ type serverSettingsWriter interface {
 	// writeServerSettings applies fieldName→value updates through the control
 	// plane's own configuration API.
 	writeServerSettings(ctx context.Context, exec Executor, updates map[string]string) error
+}
+
+// serverSettingsReader is implemented by control planes that own the curated
+// settings in their own config (AMP) rather than the INI files. It lets the GET
+// path read current values back from the control plane so the UI reflects values
+// saved through the control plane's API immediately, without waiting for a game
+// restart to regenerate the INIs (#173). Control planes that don't implement it
+// fall back to the INI-derived values.
+type serverSettingsReader interface {
+	// readServerSettings returns current fieldName→value for the given curated
+	// FieldNames, read from the control plane's own configuration API.
+	readServerSettings(ctx context.Context, exec Executor, fields []string) (map[string]string, error)
+}
+
+// ampSettingsSource marks a curated setting whose current value was read back
+// from the AMP control plane's live config (rather than an INI file).
+const ampSettingsSource = "amp"
+
+// curatedFieldNamesFrom collects the AMP FieldNames present in the built
+// settings (curated settings carry a FieldName; discovered ones don't).
+func curatedFieldNamesFrom(settings []ServerSetting) []string {
+	out := make([]string, 0, len(settings))
+	for _, s := range settings {
+		if s.FieldName != "" {
+			out = append(out, s.FieldName)
+		}
+	}
+	return out
+}
+
+// overlayAMPSettings makes the control plane's live config authoritative for
+// curated settings: each setting whose FieldName is in ampValues takes that
+// value as its Current. When the value differs from the schema default it is
+// also marked overridden and recorded as the top-priority "amp" layer, so the
+// detail view and the "modified" filter stay consistent. A value equal to the
+// default leaves the source/layers untouched (the setting is unconfigured).
+// A nil/empty map is a no-op, so non-AMP planes are unaffected.
+func overlayAMPSettings(settings []ServerSetting, ampValues map[string]string) []ServerSetting {
+	if len(ampValues) == 0 {
+		return settings
+	}
+	for i := range settings {
+		fn := settings[i].FieldName
+		if fn == "" {
+			continue
+		}
+		v, ok := ampValues[fn]
+		if !ok {
+			continue
+		}
+		settings[i].Current = v
+		settings[i].IsOverride = v != settings[i].Default
+		if v != settings[i].Default {
+			settings[i].Source = ampSettingsSource
+			settings[i].Layers = append(settings[i].Layers, SettingLayer{Source: ampSettingsSource, Value: v})
+		}
+	}
+	return settings
 }
 
 // splitCuratedFromINI partitions normalized (section→key→value) updates into
@@ -956,6 +1015,19 @@ func handleGetServerSettings(w http.ResponseWriter, r *http.Request) {
 	discovered := discoverUnknownSettings(layerSources, schemaKeys)
 	settings = append(settings, buildDiscoveredSettings(discovered, layerSources, schemaKeys)...)
 	raw := buildServerSettingsRawSections(defaultGameContent, defaultEngineContent, gameContent, engineContent, overridesContent, schemaKeys)
+
+	// AMP-style planes own curated settings in their own config and regenerate
+	// the INIs on restart, so read current values back from the control plane to
+	// reflect saved values immediately rather than showing stale/default INI
+	// values until the next restart (#173). Degrade gracefully: on error, keep
+	// the INI-derived values.
+	if reader, ok := globalControl.(serverSettingsReader); ok {
+		if amp, err := reader.readServerSettings(r.Context(), globalExecutor, curatedFieldNamesFrom(settings)); err != nil {
+			log.Printf("handleGetServerSettings: amp settings read-back: %v", err)
+		} else {
+			settings = overlayAMPSettings(settings, amp)
+		}
+	}
 
 	controlName := ""
 	if globalControl != nil {

--- a/cmd/dune-admin/handlers_server_settings_reader_test.go
+++ b/cmd/dune-admin/handlers_server_settings_reader_test.go
@@ -1,0 +1,93 @@
+package main
+
+import "testing"
+
+func TestOverlayAMPSettings(t *testing.T) {
+	t.Parallel()
+	settings := []ServerSetting{
+		{
+			Key: "GlobalMiningOutputMultiplier", Default: "1.0", Current: "1.0",
+			FieldName: "ConsoleVariables.Dune.GlobalMiningOutputMultiplier",
+			Source:    "defaultEngine",
+			Layers:    []SettingLayer{{Source: "defaultEngine", Value: "1.0"}},
+		},
+		{Key: "ServerName", Default: "", Current: "OldName", FieldName: "WorldTitle"},
+		{Key: "SomeIniThing", Default: "x", Current: "x"}, // no FieldName — untouched
+	}
+	amp := map[string]string{
+		"ConsoleVariables.Dune.GlobalMiningOutputMultiplier": "5.0",
+		"WorldTitle":    "My Server",
+		"NotInSettings": "ignored",
+	}
+	out := overlayAMPSettings(settings, amp)
+
+	// Mining: AMP value wins, overridden (5.0 != 1.0), amp source + top layer.
+	if out[0].Current != "5.0" || !out[0].IsOverride || out[0].Source != ampSettingsSource {
+		t.Fatalf("mining overlay = %+v", out[0])
+	}
+	last := out[0].Layers[len(out[0].Layers)-1]
+	if last != (SettingLayer{Source: ampSettingsSource, Value: "5.0"}) {
+		t.Fatalf("mining top layer = %+v, want amp/5.0", last)
+	}
+	// ServerName: default "" so "My Server" is an override.
+	if out[1].Current != "My Server" || !out[1].IsOverride || out[1].Source != ampSettingsSource {
+		t.Fatalf("servername overlay = %+v", out[1])
+	}
+	// Non-curated (no FieldName): untouched.
+	if out[2].Current != "x" || out[2].Source == ampSettingsSource {
+		t.Fatalf("non-curated should be untouched: %+v", out[2])
+	}
+}
+
+// When AMP holds the schema default, the setting is current=default and NOT
+// marked overridden — and gets no amp layer, so the "modified" filter is honest.
+func TestOverlayAMPSettings_DefaultValueNotOverridden(t *testing.T) {
+	t.Parallel()
+	settings := []ServerSetting{{
+		Default: "1.0", Current: "9.0", // stale INI value
+		FieldName: "X",
+		Source:    "userEngine",
+		Layers:    []SettingLayer{{Source: "userEngine", Value: "9.0"}},
+	}}
+	out := overlayAMPSettings(settings, map[string]string{"X": "1.0"})
+	if out[0].Current != "1.0" {
+		t.Fatalf("current = %q, want AMP's authoritative 1.0", out[0].Current)
+	}
+	if out[0].IsOverride {
+		t.Fatal("value == default must not be flagged overridden")
+	}
+	for _, l := range out[0].Layers {
+		if l.Source == ampSettingsSource {
+			t.Fatalf("no amp layer expected when value == default: %+v", out[0].Layers)
+		}
+	}
+}
+
+func TestOverlayAMPSettings_EmptyMapIsNoOp(t *testing.T) {
+	t.Parallel()
+	settings := []ServerSetting{{Current: "a", Source: "userGame", FieldName: "X"}}
+	out := overlayAMPSettings(settings, nil)
+	if out[0].Current != "a" || out[0].Source != "userGame" {
+		t.Fatalf("empty amp map must be a no-op: %+v", out[0])
+	}
+}
+
+func TestCuratedFieldNamesFrom(t *testing.T) {
+	t.Parallel()
+	settings := []ServerSetting{
+		{FieldName: "A"},
+		{FieldName: ""}, // discovered/non-curated
+		{FieldName: "B"},
+	}
+	got := curatedFieldNamesFrom(settings)
+	if len(got) != 2 {
+		t.Fatalf("want 2 curated field names, got %v", got)
+	}
+	seen := map[string]bool{}
+	for _, f := range got {
+		seen[f] = true
+	}
+	if !seen["A"] || !seen["B"] {
+		t.Fatalf("missing expected field names: %v", got)
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -86,7 +86,7 @@ export type ServerSetting = {
   category: string
   current: string
   is_overridden: boolean
-  source: 'userGame' | 'userGameOverrides' | 'userEngine' | 'defaultGame' | 'defaultEngine' | ''
+  source: 'userGame' | 'userGameOverrides' | 'userEngine' | 'defaultGame' | 'defaultEngine' | 'amp' | ''
   layers: SettingLayer[]
   // Present for curated settings only — its presence marks the setting as
   // AMP-managed (written via the AMP API under the AMP control plane).

--- a/web/src/tabs/ServerSettingsTab/constants.ts
+++ b/web/src/tabs/ServerSettingsTab/constants.ts
@@ -97,6 +97,8 @@ const SOURCE_FILE: Record<string, string> = {
   userGame: 'UserGame.ini',
   userEngine: 'UserEngine.ini',
   userGameOverrides: 'UserOverrides.ini',
+  // AMP-managed curated settings: read back from AMP's live config (#173).
+  amp: 'AMP config',
 }
 
 const LAYER_STYLE: Record<string, { cls: string }> = {
@@ -105,11 +107,12 @@ const LAYER_STYLE: Record<string, { cls: string }> = {
   userEngine: { cls: 'text-foreground/70' },
   userGame: { cls: 'text-foreground/70' },
   userGameOverrides: { cls: 'text-warning' },
+  amp: { cls: 'text-warning' },
 }
 
-const SOURCE_PRIORITY = ['defaultGame', 'defaultEngine', 'userEngine', 'userGame', 'userGameOverrides'] as const
+const SOURCE_PRIORITY = ['defaultGame', 'defaultEngine', 'userEngine', 'userGame', 'userGameOverrides', 'amp'] as const
 
-const USER_SOURCES = new Set(['userGame', 'userEngine', 'userGameOverrides'])
+const USER_SOURCES = new Set(['userGame', 'userEngine', 'userGameOverrides', 'amp'])
 
 export {
   CATEGORY_ORDER, CATEGORY_ICONS, CATEGORY_LABELS, ADVANCED_CATEGORIES, COMMON_KEYS,


### PR DESCRIPTION
## Read curated AMP server settings back from AMP's live config

Fixes #173. On the AMP control plane, curated server settings show default/stale
values in the UI and changes don't appear to persist after a refresh.

### Root cause
Curated settings (those with a `field_name`) are **written** through the AMP Web
API (`Core/SetConfig`), because AMP regenerates `UserEngine.ini` / `UserGame.ini`
from its own config on the next game start — a direct INI edit gets clobbered.
But the settings **GET read** current values **only from the INI files**. So a
value saved through the UI isn't reflected on refresh until AMP regenerates the
INIs on a restart. (It looks correct on already-restarted servers because the
value is baked into `UserEngine.ini` — which is why it's intermittent.)

### Fix
- `serverSettingsReader` — an optional control-plane capability — plus
  `ampControl.readServerSettings`, which reads each curated `FieldName` back via
  the existing `Core/GetConfig` (node `Meta.GenericModule.<FieldName>`), reusing
  one login session across fields.
- `handleGetServerSettings` overlays those values onto the curated settings'
  `current`; when a value differs from the schema default it's also marked
  overridden and recorded as the top-priority `amp` layer, so the detail view and
  the "modified" filter stay consistent. **Degrades gracefully** — if the
  read-back fails (no creds / API down), the INI-derived values are kept.
- Frontend registers the `amp` source (label "AMP config", style, modified-filter,
  layer priority) and adds it to the `ServerSetting.source` union.

Non-AMP planes don't implement the reader, so they're unaffected (the overlay is
a no-op).

### Verification (live, on an AMP deployment)
Set the mining multiplier via the API (which routes to `Core/SetConfig`, **not**
the INI, with no restart) and confirmed the GET immediately returned the new
value:

```
mining current=5.000000 source=amp
after API set 7.0 (no restart) -> current=7.000000 source=amp overridden=True
restored -> current=5.000000
```

Gates: `go build`/`vet`/`gofmt`, `gosec` (high/high, 0), `go test` (new reader +
overlay unit tests, race-clean on the VM), `tsc --noEmit`, `eslint`. The settings
GET takes ~2.7s on AMP with the read-back (21 curated `getConfig` calls); a batch
read is a sensible follow-up if that's too slow.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
