### PR TITLE
fix(market-bot): fall back to search when the item-data path is unusable (#136)

### DIFF
--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -556,6 +556,7 @@ func runCleanMarketMode() error {
 	defer cancel()
 
 	cacheDB, itemDataForBot, _ := resolveEmbeddedMarketBotPaths(loadedConfig, itemDataPath)
+	itemDataForBot = usableItemDataPath(itemDataForBot)
 	inst, err := marketbot.Run(ctx, marketbot.BotConfig{
 		DBPool:       globalDB,
 		DBHost:       dbHost,
@@ -679,6 +680,39 @@ func resolveEmbeddedMarketBotPaths(cfg appConfig, fallbackItemDataPath string) (
 	return cacheDB, itemDataForBot, statePath
 }
 
+// itemDataPathResolvable reports whether path points to (or contains) a readable
+// item-data.json, mirroring marketbot.loadCatalog's resolution (a directory is
+// resolved to item-data.json inside it).
+func itemDataPathResolvable(path string) bool {
+	if path == "" {
+		return false
+	}
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		path = filepath.Join(path, "item-data.json")
+	}
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// usableItemDataPath returns configured if it resolves to a readable
+// item-data.json; otherwise it falls back to the standard search locations so a
+// stale or mistyped market_bot_item_data (e.g. "optional", #136) doesn't crash
+// bot startup with a cryptic "open <path>" error. If item-data.json can't be
+// found anywhere either, the original value is returned so loadCatalog surfaces
+// a clear not-found error.
+func usableItemDataPath(configured string) string {
+	if itemDataPathResolvable(configured) {
+		return configured
+	}
+	if fb := resolveItemDataPath(); itemDataPathResolvable(fb) {
+		if configured != "" {
+			log.Printf("market-bot: item-data path %q not found; falling back to %q", configured, fb)
+		}
+		return fb
+	}
+	return configured
+}
+
 func startEmbeddedMarketBotIfEnabled(cfg appConfig) context.CancelFunc {
 	if !marketBotEnabled(cfg) {
 		return nil
@@ -686,6 +720,7 @@ func startEmbeddedMarketBotIfEnabled(cfg appConfig) context.CancelFunc {
 	embeddedBotConfigured = true
 	botCtx, botCancel := context.WithCancel(context.Background())
 	cacheDB, itemDataForBot, statePath := resolveEmbeddedMarketBotPaths(cfg, itemDataPath)
+	itemDataForBot = usableItemDataPath(itemDataForBot)
 	inst, err := marketbot.Run(botCtx, marketbot.BotConfig{
 		DBPool:       globalDB,
 		DBHost:       dbHost,

--- a/cmd/dune-admin/main_marketbot_paths_test.go
+++ b/cmd/dune-admin/main_marketbot_paths_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -60,4 +61,58 @@ func TestResolveEmbeddedMarketBotPaths(t *testing.T) {
 			t.Error("marketBotEnabled should return false when explicitly set to false")
 		}
 	})
+}
+
+func TestItemDataPathResolvable(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	file := filepath.Join(dir, "item-data.json")
+	if err := os.WriteFile(file, []byte(`{"items":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"empty", "", false},
+		{"existing file", file, true},
+		{"directory containing item-data.json", dir, true},
+		{"directory without item-data.json", t.TempDir(), false},
+		{"nonexistent path", filepath.Join(dir, "nope.json"), false},
+		{"bogus value like the #136 report", "optional", false},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := itemDataPathResolvable(tt.path); got != tt.want {
+				t.Fatalf("itemDataPathResolvable(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// #136: a stale/typo'd market_bot_item_data (e.g. "optional") must not crash bot
+// startup — usableItemDataPath falls back to the standard search locations.
+// Not parallel: mutates the itemDataPath global that resolveItemDataPath reads.
+func TestUsableItemDataPath(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "item-data.json")
+	if err := os.WriteFile(good, []byte(`{"items":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := itemDataPath
+	itemDataPath = good // makes resolveItemDataPath() return good
+	t.Cleanup(func() { itemDataPath = orig })
+
+	if got := usableItemDataPath(good); got != good {
+		t.Fatalf("usable configured path: got %q, want %q (used as-is)", got, good)
+	}
+	if got := usableItemDataPath("optional"); got != good {
+		t.Fatalf("bogus configured path: got %q, want fallback %q", got, good)
+	}
+	if got := usableItemDataPath(""); got != good {
+		t.Fatalf("empty path: got %q, want fallback %q", got, good)
+	}
 }


### PR DESCRIPTION
## Don't crash market-bot startup on a bad/missing item-data path

Fixes #136. A reporter's bot failed to start with:
```
market-bot: startup failed: marketbot: load catalog: open optional: The system cannot find the file specified.
```
and showed PAUSE. Their `market_bot_item_data` was the literal string `optional`
— most likely typed from the setup wizard's *"Bot item-data.json path (optional)"*
prompt, or a stale value. Either way, a bad or missing item-data path shouldn't
crash bot startup with a cryptic `open <path>` error.

### Fix
- `usableItemDataPath(configured)`: if `configured` doesn't resolve to a readable
  `item-data.json` (`itemDataPathResolvable` mirrors `loadCatalog`'s directory→file
  resolution), fall back to the standard search locations (`~/.dune-admin`, next to
  the binary, `./`) — logging the substitution. If `item-data.json` can't be found
  anywhere either, the original value is kept so `loadCatalog` still surfaces a
  clear not-found error.
- Applied at both embedded-bot start paths. `resolveEmbeddedMarketBotPaths` stays a
  pure resolver (its existing contract/tests are unchanged).

### Verification (live, on an AMP deployment)
Set `market_bot_item_data: optional` (reproducing the report) and restarted:
```
market-bot: item-data path "optional" not found; falling back to "/opt/dune-admin/item-data.json"
market-bot catalog: 1397 listable items
market-bot exchange ready
```
The bot starts instead of failing. Restoring a valid path loads normally. Unit
tests cover `itemDataPathResolvable` (file / dir-with-json / dir-without /
nonexistent / bogus) and `usableItemDataPath` (valid passes through, bogus + empty
fall back). Gates: `go build`/`vet`/`gofmt`, `gosec` (high/high, 0), `go test`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
