### PR TITLE
fix(events): retry partial event grants without duplication

### DIFF
--- a/cmd/dune-admin/event_store.go
+++ b/cmd/dune-admin/event_store.go
@@ -261,18 +261,17 @@ func (s *eventStore) listClaims(eventID int64) ([]eventClaimRecord, error) {
 	return out, rows.Err()
 }
 
-func (s *eventStore) claimExists(eventID int64, version int, accountID int64) (bool, error) {
-	var one int
-	err := s.db.QueryRow(
-		`SELECT 1 FROM event_award_claims WHERE event_id = ? AND version = ? AND account_id = ? LIMIT 1`,
-		eventID, version, accountID).Scan(&one)
+func (s *eventStore) getClaimStatus(eventID int64, version int, accountID int64) (status string, lastError string, exists bool, err error) {
+	err = s.db.QueryRow(
+		`SELECT status, last_error FROM event_award_claims WHERE event_id = ? AND version = ? AND account_id = ? LIMIT 1`,
+		eventID, version, accountID).Scan(&status, &lastError)
 	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
+		return "", "", false, nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("claim exists: %w", err)
+		return "", "", false, fmt.Errorf("get claim status: %w", err)
 	}
-	return true, nil
+	return status, lastError, true, nil
 }
 
 func (s *eventStore) recordGranted(eventID int64, version int, accountID int64) error {

--- a/cmd/dune-admin/events_engine.go
+++ b/cmd/dune-admin/events_engine.go
@@ -271,16 +271,63 @@ func applyEventOutcomes(ctx context.Context, deps eventDeps, store *eventStore, 
 	return nil
 }
 
+func sliceRewardSpec(reward *rewardSpec, lastErr string) *rewardSpec {
+	if reward == nil {
+		return nil
+	}
+	if lastErr == "" || strings.HasPrefix(lastErr, "grant currency:") {
+		return reward
+	}
+
+	rem := &rewardSpec{}
+
+	itemFailedIdx := -1
+	for i, item := range reward.Items {
+		prefix := fmt.Sprintf("grant item %q:", item.Template)
+		if strings.HasPrefix(lastErr, prefix) {
+			itemFailedIdx = i
+			break
+		}
+	}
+
+	if itemFailedIdx != -1 {
+		rem.Items = reward.Items[itemFailedIdx:]
+		rem.XP = reward.XP
+		return rem
+	}
+
+	xpFailedIdx := -1
+	for i, xp := range reward.XP {
+		prefix := fmt.Sprintf("grant xp track %q:", xp.Track)
+		if strings.HasPrefix(lastErr, prefix) {
+			xpFailedIdx = i
+			break
+		}
+	}
+
+	if xpFailedIdx != -1 {
+		rem.XP = reward.XP[xpFailedIdx:]
+		return rem
+	}
+
+	return reward
+}
+
 // applyOneOutcome applies a single outcome: checks the claim ledger, grants the
 // reward, optionally announces, then records the claim.
 func applyOneOutcome(ctx context.Context, deps eventDeps, store *eventStore, def eventDefinition, o eventOutcome, announce bool) {
-	claimed, err := store.claimExists(def.ID, def.Version, o.AccountID)
+	status, lastErr, exists, err := store.getClaimStatus(def.ID, def.Version, o.AccountID)
 	if err != nil {
-		log.Printf("events: claimExists %d/%d/%d: %v", def.ID, def.Version, o.AccountID, err)
+		log.Printf("events: getClaimStatus %d/%d/%d: %v", def.ID, def.Version, o.AccountID, err)
 		return
 	}
-	if claimed {
-		return
+	if exists {
+		if status == "granted" {
+			return
+		}
+		if status == "failed" {
+			o.RewardSpec = sliceRewardSpec(o.RewardSpec, lastErr)
+		}
 	}
 	if o.RewardSpec != nil {
 		if err := grantEventReward(ctx, deps, o.RewardSpec, o.ControllerID, o.ActorID); err != nil {

--- a/cmd/dune-admin/events_engine_test.go
+++ b/cmd/dune-admin/events_engine_test.go
@@ -451,9 +451,9 @@ func TestApplyEventOutcomes_AnnounceFalse_NoAnnounce(t *testing.T) {
 	}
 
 	// But the claim IS recorded so a later live tick doesn't re-fire
-	exists, err := store.claimExists(def.ID, def.Version, 101)
+	_, _, exists, err := store.getClaimStatus(def.ID, def.Version, 101)
 	if err != nil {
-		t.Fatalf("claimExists: %v", err)
+		t.Fatalf("getClaimStatus: %v", err)
 	}
 	if !exists {
 		t.Fatal("want claim recorded after silent backfill")
@@ -491,9 +491,9 @@ func TestReconcileEvent_SilentBackfill_NoAward(t *testing.T) {
 	}
 
 	// Claim is sealed
-	exists, err := store.claimExists(def.ID, def.Version, 101)
+	_, _, exists, err := store.getClaimStatus(def.ID, def.Version, 101)
 	if err != nil {
-		t.Fatalf("claimExists: %v", err)
+		t.Fatalf("getClaimStatus: %v", err)
 	}
 	if !exists {
 		t.Fatal("want claim sealed by reconcile")
@@ -585,6 +585,133 @@ func TestReconcileEvent_AlreadySealed_NoReprocess(t *testing.T) {
 	}
 	if grantCount != 0 {
 		t.Fatalf("pre-sealed claim: want 0 re-grants, got %d", grantCount)
+	}
+}
+
+func TestSliceRewardSpec(t *testing.T) {
+	reward := &rewardSpec{
+		Currency: 100,
+		Items: []rewardItem{
+			{Template: "ItemA", Qty: 1},
+			{Template: "ItemB", Qty: 2},
+		},
+		XP: []rewardXP{
+			{Track: "TrackA", Amount: 50},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		lastErr string
+		want    *rewardSpec
+	}{
+		{"nil reward", "", nil},
+		{"empty error", "", reward},
+		{"currency error", "grant currency: some error", reward},
+		{"item A error", "grant item \"ItemA\": inventory full", &rewardSpec{
+			Items: []rewardItem{{Template: "ItemA", Qty: 1}, {Template: "ItemB", Qty: 2}},
+			XP:    []rewardXP{{Track: "TrackA", Amount: 50}},
+		}},
+		{"item B error", "grant item \"ItemB\": inventory full", &rewardSpec{
+			Items: []rewardItem{{Template: "ItemB", Qty: 2}},
+			XP:    []rewardXP{{Track: "TrackA", Amount: 50}},
+		}},
+		{"xp error", "grant xp track \"TrackA\": generic error", &rewardSpec{
+			XP: []rewardXP{{Track: "TrackA", Amount: 50}},
+		}},
+		{"unknown error", "some random db error", reward},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var input *rewardSpec
+			if tt.name != "nil reward" {
+				input = reward
+			}
+			got := sliceRewardSpec(input, tt.lastErr)
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("want nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("want %+v, got nil", tt.want)
+			}
+			if got.Currency != tt.want.Currency || len(got.Items) != len(tt.want.Items) || len(got.XP) != len(tt.want.XP) {
+				t.Fatalf("slice mismatch: want %+v, got %+v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestApplyEventOutcomes_RetryPartialClaim(t *testing.T) {
+	t.Parallel()
+	store := openMemEventStore(t)
+	def := mustCreateEvent(t, store, "partial_retry", eventTypeZoneRace)
+
+	var grantCurrencyCount int
+	var grantedItems []string
+
+	deps := noopDeps()
+	deps.grantCurrency = func(_ context.Context, _, _ int64) error {
+		grantCurrencyCount++
+		return nil
+	}
+	deps.grantItem = func(_ context.Context, _ int64, tmpl string, _, _ int64) error {
+		if tmpl == "ItemFail" {
+			return errors.New("inventory full")
+		}
+		grantedItems = append(grantedItems, tmpl)
+		return nil
+	}
+
+	reward := &rewardSpec{
+		Currency: 100,
+		Items: []rewardItem{
+			{Template: "ItemOK"},
+			{Template: "ItemFail"},
+			{Template: "ItemSkipped"},
+		},
+	}
+
+	outcomes := []eventOutcome{
+		{AccountID: 101, PlayerName: "Alice", RewardSpec: reward},
+	}
+
+	// First tick: succeeds up to ItemFail, then aborts.
+	if err := applyEventOutcomes(context.Background(), deps, store, def, outcomes, true); err != nil {
+		t.Fatalf("apply tick 1: %v", err)
+	}
+
+	if grantCurrencyCount != 1 {
+		t.Fatalf("want 1 currency grant, got %d", grantCurrencyCount)
+	}
+	if len(grantedItems) != 1 || grantedItems[0] != "ItemOK" {
+		t.Fatalf("want [ItemOK], got %v", grantedItems)
+	}
+
+	// Now fix the issue so ItemFail succeeds
+	deps.grantItem = func(_ context.Context, _ int64, tmpl string, _, _ int64) error {
+		grantedItems = append(grantedItems, tmpl)
+		return nil
+	}
+
+	// Second tick: should resume from ItemFail
+	if err := applyEventOutcomes(context.Background(), deps, store, def, outcomes, true); err != nil {
+		t.Fatalf("apply tick 2: %v", err)
+	}
+
+	// Currency should NOT be granted again
+	if grantCurrencyCount != 1 {
+		t.Fatalf("want 1 currency grant after retry, got %d", grantCurrencyCount)
+	}
+	// ItemOK should NOT be granted again, but ItemFail and ItemSkipped should be
+	if len(grantedItems) != 3 {
+		t.Fatalf("want 3 items total granted, got %v", grantedItems)
+	}
+	if grantedItems[1] != "ItemFail" || grantedItems[2] != "ItemSkipped" {
+		t.Fatalf("want ItemFail then ItemSkipped, got %v", grantedItems[1:])
 	}
 }
 


### PR DESCRIPTION
#198 

When an event grant fails (e.g., due to a full inventory), Dune-Admin records the failure (status = 'failed') along with a detailed error message in the database (e.g., grant item "SandbikeChassis_1": inventory full).

Previously, the events engine refused to retry failed claims. This PR adds the ability to retry failed claims without duplicating components (like currency or earlier items) that successfully granted before the failure occurred.

Because grantEventReward processes rewards sequentially (Currency -> Items -> XP), we now use the deterministic error string in last_error to accurately "slice" the remaining RewardSpec. The engine will resume the grant exactly where it stopped on the next live tick.

This approach requires no database schema migrations and perfectly supports the legacy failed claims already existing in the live dune-admin.db file.
