### PR TITLE
feat(discord): redesign server status embed layout

### DIFF
--- a/cmd/dune-admin/discord_status.go
+++ b/cmd/dune-admin/discord_status.go
@@ -54,6 +54,7 @@ type mapPlayerCount struct {
 // produced by collectStatusData and consumed by buildStatusEmbed; keeping them
 // separate makes the builder a pure, unit-testable function.
 type statusEmbedData struct {
+	ServerTitle   string
 	State         serverState
 	Maps          []mapPlayerCount
 	CurrentOnline int   // players currently online (best-effort)
@@ -72,32 +73,36 @@ func buildStatusEmbed(data statusEmbedData, now time.Time) *discordgo.MessageEmb
 		Color:     statusColor(data.State),
 		Timestamp: now.UTC().Format(time.RFC3339),
 		Footer: &discordgo.MessageEmbedFooter{
-			Text: "Auto-updated by dune-admin",
+			Text: "Auto-updated by Dune-Admin",
 		},
+		Fields:    []*discordgo.MessageEmbedField{},
 	}
 
+	// Assemble everything into the Description for precise top-to-bottom layout
 	var desc strings.Builder
-	fmt.Fprintf(&desc, "**Status:** %s %s\n", statusEmoji(data.State), data.State)
-	if data.State == serverStateOnline {
-		fmt.Fprintf(&desc, "**Players online:** %d", data.CurrentOnline)
-		if data.TotalPlayers > 0 {
-			fmt.Fprintf(&desc, " / %d total", data.TotalPlayers)
-		}
-		desc.WriteString("\n")
+
+	// 1. Server Status
+	fmt.Fprintf(&desc, "%s **Server Status:** %s\n\u200B\n", statusEmoji(data.State), data.State)
+
+	// 2. Active Maps
+	desc.WriteString("🌍 **Active Maps**\n")
+	if len(data.Maps) > 0 {
+		desc.WriteString(formatMapLines(data.Maps))
+	} else {
+		desc.WriteString("*Nobody is currently online.*")
 	}
-	fmt.Fprintf(&desc, "**Unique players (24h):** %d", data.UniquePlayers)
+	desc.WriteString("\n\u200B\n")
+
+	// 3. Population Footer
+	fmt.Fprintf(&desc, "👥 **%d Online** | **%d Total** | **%d Unique (24h)**",
+		data.CurrentOnline, data.TotalPlayers, data.UniquePlayers)
+
 	embed.Description = desc.String()
 
-	if len(data.Maps) > 0 {
-		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:  "Active maps",
-			Value: formatMapLines(data.Maps),
-		})
-	}
 	return embed
 }
 
-// formatMapLines renders one "• Map — N players" line per map.
+// formatMapLines renders one "• **Map** — N players" line per map.
 func formatMapLines(maps []mapPlayerCount) string {
 	var sb strings.Builder
 	for _, m := range maps {
@@ -105,6 +110,7 @@ func formatMapLines(maps []mapPlayerCount) string {
 		if name == "" {
 			name = "Unknown"
 		}
+		// Fika style: "• **MapName** — N player(s)"
 		fmt.Fprintf(&sb, "• **%s** — %d player(s)\n", name, m.Players)
 	}
 	return strings.TrimRight(sb.String(), "\n")
@@ -158,7 +164,10 @@ func deriveServerState(status *BattlegroupStatus, err error) serverState {
 func aggregateMapCounts(servers []ServerRow) []mapPlayerCount {
 	totals := map[string]int{}
 	for _, s := range servers {
-		name := s.Map
+		name := prettyRegionName(s.Map)
+		if name == "" {
+			name = prettyRegionName(s.Sietch)
+		}
 		if name == "" {
 			name = "Unknown"
 		}
@@ -467,6 +476,10 @@ func applyControlStatus(ctx context.Context, data *statusEmbedData) {
 	data.State = deriveServerState(status, err)
 	if err != nil || status == nil {
 		return
+	}
+	data.ServerTitle = status.Title
+	if data.ServerTitle == "" {
+		data.ServerTitle = status.Name
 	}
 	data.Maps = aggregateMapCounts(status.Servers)
 	for _, m := range data.Maps {

--- a/cmd/dune-admin/region_broadcast.go
+++ b/cmd/dune-admin/region_broadcast.go
@@ -38,20 +38,50 @@ type regionAnnouncement struct {
 	sourcePlayer string
 }
 
-// prettyRegionName turns an internal map key (e.g. "HaggaBasin", "Map_TheShield")
+// prettyRegionName turns an internal map key (e.g. "HaggaBasin", "Map_TheShield", "Survival_1")
 // into a human-readable label ("Hagga Basin", "The Shield"). It strips a leading
-// "Map_" prefix, then inserts spaces before interior capitals that begin a new
-// word. Single-word and all-caps inputs pass through unchanged.
+// "Map_" and trailing "_0", handles specific hardcoded aliases, then inserts spaces.
 func prettyRegionName(region string) string {
 	region = strings.TrimSpace(region)
 	region = strings.TrimPrefix(region, "Map_")
+	region = strings.TrimPrefix(region, "SH_")
+
+	// Strip trailing _0, _1, etc.
+	if idx := strings.LastIndexByte(region, '_'); idx != -1 {
+		hasDigit := false
+		onlyDigits := true
+		for i := idx + 1; i < len(region); i++ {
+			if region[i] >= '0' && region[i] <= '9' {
+				hasDigit = true
+			} else {
+				onlyDigits = false
+				break
+			}
+		}
+		if hasDigit && onlyDigits {
+			region = region[:idx]
+		}
+	}
+
+	// Hardcoded region aliases
+	switch strings.ToLower(region) {
+	case "survival":
+		return "Hagga Basin"
+	case "overmap":
+		return "Overland"
+	case "deepdesert":
+		return "Deep Desert"
+	}
+
 	if region == "" {
 		return ""
 	}
+
+	// Auto-format CamelCase to Camel Case
 	runes := []rune(region)
 	var b strings.Builder
 	for i, r := range runes {
-		if i > 0 && unicode.IsUpper(r) && !unicode.IsUpper(runes[i-1]) {
+		if i > 0 && unicode.IsUpper(r) && !unicode.IsUpper(runes[i-1]) && runes[i-1] != ' ' {
 			b.WriteRune(' ')
 		}
 		b.WriteRune(r)

--- a/cmd/dune-admin/region_broadcast_test.go
+++ b/cmd/dune-admin/region_broadcast_test.go
@@ -14,11 +14,14 @@ func TestPrettyRegionName(t *testing.T) {
 	}{
 		{"HaggaBasin", "Hagga Basin"},
 		{"TheShield", "The Shield"},
+		{"Deepdesert", "Deep Desert"},
 		{"VermillionWells", "Vermillion Wells"},
 		{"", ""},
-		{"Deepdesert", "Deepdesert"},      // single word unchanged
-		{"ARRAKEEN", "ARRAKEEN"},          // all-caps acronym left intact
+		{"OVERMAP", "Overland"},
+		{"ARRAKEEN", "ARRAKEEN"},
 		{"Map_HaggaBasin", "Hagga Basin"}, // strips a leading Map_ prefix
+		{"Survival_1", "Hagga Basin"}, // aliases and trims numbers
+		{"DeepDesert_0", "Deep Desert"}, // trims numbers
 	}
 	for _, tt := range tests {
 		if got := prettyRegionName(tt.in); got != tt.want {


### PR DESCRIPTION
## Summary
- **Discord Status Embed** — Refactored layout to use description-only formatting for precise markdown control.
- **Sietch Names** — Normalized map names, mapped Survival_1 to Hagga Basin, and stripped internal Map_/SH_ prefixes.

<img width="309" height="276" alt="image" src="https://github.com/user-attachments/assets/7756d726-466c-4dcc-9ec4-2c6796e23d29" />

## Test plan
- [x] `make verify` passes
- [x] Verified embed structure in Go snapshot tests
- [x] Verified Discord webhook payload spacing and markdown formatting

🤖 Generated with Antigravity