### PR TITLE
feat: OS-ssh command-mode executor + game-server auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ Config is loaded in this order (first match wins per field):
 | `CONTROL` | `-control` | *(auto)* | Control plane: `amp`, `kubectl`, `docker`, or `local` |
 | `SSH_HOST` | `-host` | - | VM `host:port`, tunnels all connections through SSH when set |
 | `SSH_USER` | `-user` | `dune` | SSH user |
-| `SSH_KEY` | `-key` | *(auto-detected)* | SSH private key path |
+| `SSH_KEY` | `-key` | *(auto-detected)* | SSH private key path (library mode only) |
+| `SSH_MODE` | `-ssh-mode` | `library` | SSH transport: `library` (golang.org/x/crypto/ssh) or `command` (shells out to the OS `ssh` client — honours `~/.ssh/config`, ProxyJump and ssh-agent; never reads a private key) |
+| `SSH_EXTRA_OPTS` | `-ssh-extra-opts` | - | Extra `ssh -o` options for command mode (space-separated) |
 | `DB_HOST` | `-dbhost` | `127.0.0.1` | PostgreSQL host or Docker DNS name |
 | `DB_PORT` | `-dbport` | `15432` | PostgreSQL port |
 | `DB_USER` | `-dbuser` | `dune` | PostgreSQL user |
@@ -122,6 +124,7 @@ Config is loaded in this order (first match wins per field):
 | `DB_NAME` | `-dbname` | `dune` | PostgreSQL database name |
 | `DB_SCHEMA` | `-schema` | `dune` | PostgreSQL schema |
 | `CONTROL_NAMESPACE` | `-control-ns` | *(auto-discovered)* | K8s namespace (kubectl only) |
+| `AUTO_DISCOVER` | `-auto-discover` | `false` | Fill empty DB/RMQ/Director fields from the running game-server process args at connect time (command mode + kubectl). Explicit config always wins |
 | `BROKER_GAME_ADDR` | `-broker-game` | - | mq-game broker `host:port` |
 | `BROKER_ADMIN_ADDR` | `-broker-admin` | - | mq-admin broker `host:port` |
 | `BACKUP_DIR` | `-backup-dir` | - | Backup directory path |

--- a/cmd/dune-admin/connection.go
+++ b/cmd/dune-admin/connection.go
@@ -162,9 +162,10 @@ func applyAutoDiscovery(cfg *appConfig, exec Executor, ctrl string) {
 	log.Printf("connectAll: auto-discover filled DB user=%s name=%s (pass %s)",
 		cfg.DBUser, cfg.DBName, maskSecret(cfg.DBPass))
 	if ctrl == "kubectl" {
-		gameIP := resolveServicePodIP(exec, "mq-game")
-		adminIP := resolveServicePodIP(exec, "mq-admin")
-		directorIP := resolveServicePodIP(exec, "bgd")
+		pods := fetchClusterPodIPs(exec)
+		gameIP := podIPByPattern(pods, "mq-game")
+		adminIP := podIPByPattern(pods, "mq-admin")
+		directorIP := podIPByPattern(pods, "bgd")
 		applyDiscoveredEndpoints(cfg, g, gameIP, adminIP, directorIP)
 		brokerGameAddr, brokerAdminAddr, brokerTLS = cfg.BrokerGameAddr, cfg.BrokerAdminAddr, cfg.BrokerTLS
 	}

--- a/cmd/dune-admin/connection.go
+++ b/cmd/dune-admin/connection.go
@@ -47,6 +47,9 @@ func connectAll() error {
 	cfg.SSHHost = sshHost
 	cfg.SSHUser = sshUser
 	cfg.SSHKey = resolveKeyPath()
+	cfg.SSHMode = sshMode
+	cfg.SSHExtraOpts = sshExtraOpts
+	cfg.AutoDiscover = autoDiscover
 	cfg.DBHost = dbHost
 	cfg.DBPort = dbPort
 	cfg.DBUser = dbUser
@@ -61,7 +64,7 @@ func connectAll() error {
 	cfg.BackupDir = backupDir
 	cfg.ServerIniDir = serverIniDir
 
-	exec, err := newExecutor(cfg.SSHHost, cfg.SSHUser, cfg.SSHKey)
+	exec, err := newExecutor(cfg.SSHHost, cfg.SSHUser, cfg.SSHKey, cfg.SSHMode, cfg.SSHExtraOpts)
 	if err != nil {
 		return fmt.Errorf("executor: %w", err)
 	}
@@ -75,6 +78,12 @@ func connectAll() error {
 		exec = &ampExecutor{Executor: exec, ampUser: user}
 	}
 	globalExecutor = exec
+
+	// Auto-discovery: fill empty DB/RMQ/Director fields from the running
+	// game-server args. Best-effort and self-contained in applyAutoDiscovery.
+	if cfg.AutoDiscover {
+		applyAutoDiscovery(&cfg, exec, ctrl)
+	}
 
 	// kubectl needs DB-pod discovery (via the executor, not the DB) to learn the
 	// namespace before the control plane and DB connect. A discovery failure is
@@ -135,6 +144,40 @@ func ensureDBSchema(pool *pgxpool.Pool) {
 	}
 }
 
+// applyAutoDiscovery runs game-server discovery and gap-fills cfg in place,
+// propagating the filled values into the connection globals the DB/broker
+// connect paths read. Best-effort: a discovery failure is logged and ignored
+// (the operator may have set everything explicitly). The password is never
+// logged in clear text. Extracted from connectAll to keep its cognitive
+// complexity within the project gate.
+func applyAutoDiscovery(cfg *appConfig, exec Executor, ctrl string) {
+	g, err := discoverGameConfig(exec)
+	if err != nil {
+		log.Printf("connectAll: auto-discover: %v", err)
+		return
+	}
+	applyDiscovered(cfg, g)
+	// Propagate into the globals the DB connect path reads.
+	dbUser, dbPass, dbName = cfg.DBUser, cfg.DBPass, cfg.DBName
+	log.Printf("connectAll: auto-discover filled DB user=%s name=%s (pass %s)",
+		cfg.DBUser, cfg.DBName, maskSecret(cfg.DBPass))
+	if ctrl == "kubectl" {
+		gameIP := resolveServicePodIP(exec, "mq-game")
+		adminIP := resolveServicePodIP(exec, "mq-admin")
+		directorIP := resolveServicePodIP(exec, "bgd")
+		applyDiscoveredEndpoints(cfg, g, gameIP, adminIP, directorIP)
+		brokerGameAddr, brokerAdminAddr, brokerTLS = cfg.BrokerGameAddr, cfg.BrokerAdminAddr, cfg.BrokerTLS
+	}
+	if discoverWrite {
+		if werr := writeConfigFile(*cfg); werr != nil {
+			log.Printf("connectAll: discover-write: %v", werr)
+		} else {
+			loadedConfig = *cfg
+			log.Printf("connectAll: discover-write persisted config.yaml")
+		}
+	}
+}
+
 // cmdConnect wraps connectAll in the legacy Msg return type.
 func cmdConnect() Msg {
 	if err := connectAll(); err != nil {
@@ -192,7 +235,7 @@ func connectDB(ctx context.Context, user, pass string) (*pgxpool.Pool, error) {
 		return []string{globalPodIP}, nil
 	}
 	poolCfg.ConnConfig.DialFunc = func(_ context.Context, _, _ string) (net.Conn, error) {
-		return globalSSH.Dial("tcp", fmt.Sprintf("%s:%d", globalPodIP, dbPort))
+		return globalExecutor.Dial("tcp", fmt.Sprintf("%s:%d", globalPodIP, dbPort))
 	}
 	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
 	if err != nil {

--- a/cmd/dune-admin/discover.go
+++ b/cmd/dune-admin/discover.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// gameServerArgs holds the connection-relevant values parsed from a running
+// DuneSandboxServer command line.
+type gameServerArgs struct {
+	DBUser, DBPass, DBName     string
+	RMQGameHost, RMQGamePort   string
+	RMQAdminHost, RMQAdminPort string
+	RMQTLS                     bool
+	DirectorURL                string
+}
+
+// argValue extracts the value of `flag=value` or `flag value` from a command
+// line. Flags use one or two leading dashes. Returns "" when absent.
+func argValue(cmdline, flag string) string {
+	re := regexp.MustCompile(`(?:^|\s)-{1,2}` + regexp.QuoteMeta(flag) + `[= ]([^\s]+)`)
+	m := re.FindStringSubmatch(cmdline)
+	if len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
+
+// parseGameServerArgs extracts DB/RMQ/Director values from a command line.
+// Pure — no I/O.
+func parseGameServerArgs(cmdline string) gameServerArgs {
+	return gameServerArgs{
+		DBUser:       argValue(cmdline, "DatabaseUser"),
+		DBPass:       argValue(cmdline, "DatabasePassword"),
+		DBName:       argValue(cmdline, "DatabaseName"),
+		RMQGameHost:  argValue(cmdline, "RMQGameHostname"),
+		RMQGamePort:  argValue(cmdline, "RMQGamePort"),
+		RMQAdminHost: argValue(cmdline, "RMQAdminHostname"),
+		RMQAdminPort: argValue(cmdline, "RMQAdminPort"),
+		RMQTLS:       strings.EqualFold(argValue(cmdline, "RMQGameTlsEnabled"), "true"),
+		DirectorURL:  argValue(cmdline, "battlegroup-director-url"),
+	}
+}
+
+// fillIfEmpty sets *dst to src only when *dst is empty (gap-fill precedence:
+// explicit config always wins).
+func fillIfEmpty(dst *string, src string) {
+	if *dst == "" && src != "" {
+		*dst = src
+	}
+}
+
+// applyDiscovered fills empty cfg fields from discovered game-server args.
+// Host fields (DB/RMQ/Director hosts) are resolved separately — see
+// resolveServicePodIP — because the raw values are cluster-internal DNS.
+func applyDiscovered(cfg *appConfig, g gameServerArgs) {
+	fillIfEmpty(&cfg.DBUser, g.DBUser)
+	fillIfEmpty(&cfg.DBPass, g.DBPass)
+	fillIfEmpty(&cfg.DBName, g.DBName)
+}
+
+// fetchGameServerCmdline returns the command line of a running DuneSandboxServer
+// process carrying the connection args, read through the executor. The pgrep
+// pattern uses the `[D]uneSandboxServer` bracket trick so it does not match its
+// own shell-wrapper process (whose command line contains the literal pattern),
+// which would otherwise return the pipeline itself instead of the game server.
+func fetchGameServerCmdline(exec Executor) (string, error) {
+	out, err := exec.Exec("pgrep -af '[D]uneSandboxServer' 2>/dev/null | grep -- '-DatabasePassword=' | head -1")
+	if err != nil {
+		return "", fmt.Errorf("pgrep game server: %w", err)
+	}
+	line := strings.TrimSpace(out)
+	if line == "" {
+		return "", fmt.Errorf("no running DuneSandboxServer process found")
+	}
+	return line, nil
+}
+
+// discoverGameConfig fetches the game-server command line and parses it.
+func discoverGameConfig(exec Executor) (gameServerArgs, error) {
+	cmdline, err := fetchGameServerCmdline(exec)
+	if err != nil {
+		return gameServerArgs{}, err
+	}
+	return parseGameServerArgs(cmdline), nil
+}
+
+// maskSecret renders a secret as a short non-revealing token for logs.
+func maskSecret(s string) string {
+	if s == "" {
+		return "(empty)"
+	}
+	return fmt.Sprintf("set, %d chars", len(s))
+}
+
+// portOf returns the ":port" suffix of a host:port string, or "" if none.
+func portOf(hostPort string) string {
+	if i := strings.LastIndex(hostPort, ":"); i >= 0 {
+		return hostPort[i+1:]
+	}
+	return ""
+}
+
+// applyDiscoveredEndpoints fills empty broker/director fields using resolved
+// pod IPs plus the ports/TLS parsed from the args. Empty resolved IPs are
+// skipped (no usable endpoint). DirectorURL's port comes from the discovered
+// director host:port in the args.
+func applyDiscoveredEndpoints(cfg *appConfig, g gameServerArgs, gameIP, adminIP, directorIP string) {
+	if gameIP != "" && g.RMQGamePort != "" {
+		fillIfEmpty(&cfg.BrokerGameAddr, gameIP+":"+g.RMQGamePort)
+	}
+	if adminIP != "" && g.RMQAdminPort != "" {
+		fillIfEmpty(&cfg.BrokerAdminAddr, adminIP+":"+g.RMQAdminPort)
+	}
+	if g.RMQTLS && !cfg.BrokerTLS {
+		cfg.BrokerTLS = true
+	}
+	if directorIP != "" {
+		if p := portOf(g.DirectorURL); p != "" {
+			fillIfEmpty(&cfg.DirectorURL, "http://"+directorIP+":"+p)
+		}
+	}
+}
+
+// persistDiscoveredConfig returns a copy of cfg with discovered DB + endpoint
+// gaps filled. Pure — the caller persists/applies the result.
+func persistDiscoveredConfig(cfg appConfig, g gameServerArgs, gameIP, adminIP, directorIP string) appConfig {
+	applyDiscovered(&cfg, g)
+	applyDiscoveredEndpoints(&cfg, g, gameIP, adminIP, directorIP)
+	return cfg
+}
+
+// resolveServicePodIP returns the pod IP of the first pod whose name matches
+// grepPattern, via kubectl through the executor (like discoverDBPod). Returns
+// "" (no error) when not found, so callers can skip that endpoint.
+func resolveServicePodIP(exec Executor, grepPattern string) string {
+	kctl := kubectlCLI(exec)
+	out, err := exec.Exec(fmt.Sprintf( // #nosec G204,G702 -- grepPattern is a constant service substring, not user input
+		`%s get pods -A -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.podIP}{"\n"}{end}' 2>/dev/null | grep %s | head -1`,
+		kctl, grepPattern))
+	if err != nil {
+		return ""
+	}
+	parts := strings.Fields(strings.TrimSpace(out))
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[1]
+}

--- a/cmd/dune-admin/discover.go
+++ b/cmd/dune-admin/discover.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 )
 
@@ -16,13 +15,25 @@ type gameServerArgs struct {
 	DirectorURL                string
 }
 
-// argValue extracts the value of `flag=value` or `flag value` from a command
-// line. Flags use one or two leading dashes. Returns "" when absent.
+// argValue extracts the value of `-flag=value` or `-flag value` from a command
+// line (one or two leading dashes). Returns "" when absent. A plain field scan
+// avoids recompiling a regex on every call — argValue runs many times per
+// discovery. A flag matches only when the whole token (after stripping leading
+// dashes) equals `flag` or starts with `flag=`, so a shorter flag never matches
+// a longer one that contains it as a prefix.
 func argValue(cmdline, flag string) string {
-	re := regexp.MustCompile(`(?:^|\s)-{1,2}` + regexp.QuoteMeta(flag) + `[= ]([^\s]+)`)
-	m := re.FindStringSubmatch(cmdline)
-	if len(m) == 2 {
-		return m[1]
+	fields := strings.Fields(cmdline)
+	for i, f := range fields {
+		name := strings.TrimLeft(f, "-")
+		if name == flag {
+			if i+1 < len(fields) {
+				return fields[i+1]
+			}
+			return ""
+		}
+		if strings.HasPrefix(name, flag+"=") {
+			return name[len(flag)+1:]
+		}
 	}
 	return ""
 }
@@ -131,20 +142,32 @@ func persistDiscoveredConfig(cfg appConfig, g gameServerArgs, gameIP, adminIP, d
 	return cfg
 }
 
-// resolveServicePodIP returns the pod IP of the first pod whose name matches
-// grepPattern, via kubectl through the executor (like discoverDBPod). Returns
-// "" (no error) when not found, so callers can skip that endpoint.
-func resolveServicePodIP(exec Executor, grepPattern string) string {
+// fetchClusterPodIPs returns a "name ip" listing of all pods, via kubectl
+// through the executor (one call). Empty on error. Callers resolve every
+// service from this single listing instead of one kubectl call per service.
+func fetchClusterPodIPs(exec Executor) string {
 	kctl := kubectlCLI(exec)
-	out, err := exec.Exec(fmt.Sprintf( // #nosec G204,G702 -- grepPattern is a constant service substring, not user input
-		`%s get pods -A -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.podIP}{"\n"}{end}' 2>/dev/null | grep %s | head -1`,
-		kctl, grepPattern))
+	out, err := exec.Exec(fmt.Sprintf( // #nosec G204,G702 -- constant kubectl command, no user input
+		`%s get pods -A -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.podIP}{"\n"}{end}' 2>/dev/null`,
+		kctl))
 	if err != nil {
 		return ""
 	}
-	parts := strings.Fields(strings.TrimSpace(out))
-	if len(parts) < 2 {
-		return ""
+	return out
+}
+
+// podIPByPattern returns the IP of the first pod whose name contains pattern,
+// from a "name ip" listing. "" when not found, so callers skip that endpoint.
+// Pure.
+func podIPByPattern(podList, pattern string) string {
+	for _, line := range strings.Split(podList, "\n") {
+		if !strings.Contains(line, pattern) {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) >= 2 {
+			return parts[1]
+		}
 	}
-	return parts[1]
+	return ""
 }

--- a/cmd/dune-admin/discover_test.go
+++ b/cmd/dune-admin/discover_test.go
@@ -18,16 +18,33 @@ func TestAppConfigAutoDiscoverRoundTrip(t *testing.T) {
 }
 
 func TestNeedsSetupAutoDiscoverAware(t *testing.T) {
-	origPass, origAuto := dbPass, autoDiscover
-	defer func() { dbPass, autoDiscover = origPass, origAuto }()
+	origPass, origAuto, origCtrl := dbPass, autoDiscover, controlPlane
+	defer func() { dbPass, autoDiscover, controlPlane = origPass, origAuto, origCtrl }()
 
-	dbPass, autoDiscover = "", true
+	// auto-discover + kubectl + empty pass → no setup (discovery supplies it).
+	dbPass, autoDiscover, controlPlane = "", true, "kubectl"
 	if needsSetupConfigured() {
-		t.Errorf("auto_discover=true + empty dbPass: want no setup")
+		t.Errorf("auto_discover=true + kubectl + empty dbPass: want no setup")
 	}
-	dbPass, autoDiscover = "", false
+	// auto-discover on but not kubectl → setup still required.
+	dbPass, autoDiscover, controlPlane = "", true, "local"
+	if !needsSetupConfigured() {
+		t.Errorf("auto_discover=true + non-kubectl + empty dbPass: want setup")
+	}
+	// auto-discover off → setup required.
+	dbPass, autoDiscover, controlPlane = "", false, "kubectl"
 	if !needsSetupConfigured() {
 		t.Errorf("auto_discover=false + empty dbPass: want setup")
+	}
+}
+
+func TestPodIPByPattern(t *testing.T) {
+	list := "ns-mq-game-svc-0 10.0.0.5\nns-mq-admin-svc-0 10.0.0.6\nns-bgd-svc-0 10.0.0.7\nns-db-dbdepl-sts-0 10.0.0.8\n"
+	cases := map[string]string{"mq-game": "10.0.0.5", "mq-admin": "10.0.0.6", "bgd": "10.0.0.7", "nope": ""}
+	for pattern, want := range cases {
+		if got := podIPByPattern(list, pattern); got != want {
+			t.Errorf("podIPByPattern(%q) = %q, want %q", pattern, got, want)
+		}
 	}
 }
 

--- a/cmd/dune-admin/discover_test.go
+++ b/cmd/dune-admin/discover_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestAppConfigAutoDiscoverRoundTrip(t *testing.T) {
+	var cfg appConfig
+	if err := yaml.Unmarshal([]byte("auto_discover: true\n"), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !cfg.AutoDiscover {
+		t.Errorf("AutoDiscover = false, want true")
+	}
+}
+
+func TestNeedsSetupAutoDiscoverAware(t *testing.T) {
+	origPass, origAuto := dbPass, autoDiscover
+	defer func() { dbPass, autoDiscover = origPass, origAuto }()
+
+	dbPass, autoDiscover = "", true
+	if needsSetupConfigured() {
+		t.Errorf("auto_discover=true + empty dbPass: want no setup")
+	}
+	dbPass, autoDiscover = "", false
+	if !needsSetupConfigured() {
+		t.Errorf("auto_discover=false + empty dbPass: want setup")
+	}
+}
+
+const sampleCmdline = `su dune -c ./DuneSandboxServer.sh Overmap -FarmRegion=Europe ` +
+	`-ini:engine:[FuncomLiveServices]:ServiceAuthToken=eyJTOKEN -RMQGameTlsEnabled=true ` +
+	`ServerName=sh-xxx -MultiHome=192.168.33.65 -DatabaseName=dune ` +
+	`-DatabaseHost=ns-db-dbdepl-svc:15432 -DatabaseUser=dune -DatabasePassword=SECRET123 ` +
+	`-PartitionIndex=2 -battlegroup-director-url=ns-bgd-svc:11717 ` +
+	`--RMQGameHostname=ns-mq-game-svc --RMQGamePort=5672 ` +
+	`--RMQAdminHostname=ns-mq-admin-svc --RMQAdminPort=5672`
+
+func TestParseGameServerArgs(t *testing.T) {
+	g := parseGameServerArgs(sampleCmdline)
+	checks := map[string]string{
+		"DBUser": g.DBUser, "DBPass": g.DBPass, "DBName": g.DBName,
+		"RMQGameHost": g.RMQGameHost, "RMQGamePort": g.RMQGamePort,
+		"RMQAdminHost": g.RMQAdminHost, "RMQAdminPort": g.RMQAdminPort,
+		"DirectorURL": g.DirectorURL,
+	}
+	want := map[string]string{
+		"DBUser": "dune", "DBPass": "SECRET123", "DBName": "dune",
+		"RMQGameHost": "ns-mq-game-svc", "RMQGamePort": "5672",
+		"RMQAdminHost": "ns-mq-admin-svc", "RMQAdminPort": "5672",
+		"DirectorURL": "ns-bgd-svc:11717",
+	}
+	for k, v := range want {
+		if checks[k] != v {
+			t.Errorf("%s = %q, want %q", k, checks[k], v)
+		}
+	}
+	if !g.RMQTLS {
+		t.Errorf("RMQTLS = false, want true")
+	}
+}
+
+func TestParseGameServerArgsMissing(t *testing.T) {
+	g := parseGameServerArgs("DuneSandboxServer -DatabaseUser=dune")
+	if g.DBUser != "dune" {
+		t.Errorf("DBUser = %q, want dune", g.DBUser)
+	}
+	if g.DBPass != "" || g.RMQGameHost != "" || g.RMQTLS {
+		t.Errorf("absent fields should be zero values: %+v", g)
+	}
+}
+
+func TestApplyDiscoveredFillsGapsOnly(t *testing.T) {
+	g := gameServerArgs{DBUser: "dune", DBPass: "SECRET123", DBName: "dune"}
+
+	cfg := appConfig{}
+	applyDiscovered(&cfg, g)
+	if cfg.DBUser != "dune" || cfg.DBPass != "SECRET123" || cfg.DBName != "dune" {
+		t.Errorf("empty config not filled: %+v", cfg)
+	}
+
+	cfg2 := appConfig{DBUser: "admin", DBPass: "manual"}
+	applyDiscovered(&cfg2, g)
+	if cfg2.DBUser != "admin" || cfg2.DBPass != "manual" {
+		t.Errorf("explicit values overwritten: %+v", cfg2)
+	}
+	if cfg2.DBName != "dune" {
+		t.Errorf("empty DBName should still be filled: %+v", cfg2)
+	}
+}
+
+func TestApplyDiscoveredRMQDirector(t *testing.T) {
+	g := gameServerArgs{
+		RMQGamePort: "5672", RMQAdminPort: "5672", RMQTLS: true,
+		DirectorURL: "ns-bgd-svc:11717",
+	}
+	cfg := appConfig{}
+	applyDiscoveredEndpoints(&cfg, g, "10.0.0.5", "10.0.0.6", "10.0.0.7")
+	if cfg.BrokerGameAddr != "10.0.0.5:5672" {
+		t.Errorf("BrokerGameAddr = %q", cfg.BrokerGameAddr)
+	}
+	if cfg.BrokerAdminAddr != "10.0.0.6:5672" {
+		t.Errorf("BrokerAdminAddr = %q", cfg.BrokerAdminAddr)
+	}
+	if !cfg.BrokerTLS {
+		t.Errorf("BrokerTLS = false, want true")
+	}
+	if cfg.DirectorURL != "http://10.0.0.7:11717" {
+		t.Errorf("DirectorURL = %q", cfg.DirectorURL)
+	}
+
+	cfg2 := appConfig{BrokerGameAddr: "manual:1234"}
+	applyDiscoveredEndpoints(&cfg2, g, "10.0.0.5", "10.0.0.6", "10.0.0.7")
+	if cfg2.BrokerGameAddr != "manual:1234" {
+		t.Errorf("explicit BrokerGameAddr overwritten: %q", cfg2.BrokerGameAddr)
+	}
+}
+
+func TestPersistDiscoveredWritesGaps(t *testing.T) {
+	g := gameServerArgs{DBUser: "dune", DBPass: "SECRET123", DBName: "dune"}
+	cfg := appConfig{DBUser: "keep"}
+	out := persistDiscoveredConfig(cfg, g, "", "", "")
+	if out.DBUser != "keep" {
+		t.Errorf("explicit DBUser overwritten: %q", out.DBUser)
+	}
+	if out.DBPass != "SECRET123" || out.DBName != "dune" {
+		t.Errorf("gaps not filled: %+v", out)
+	}
+}
+
+// Integration: requires a reachable command-mode target running the game server.
+//
+//	SSH_CMD_TARGET=vm-dune-01 go test -run TestDiscoverGameConfigIntegration ./...
+func TestDiscoverGameConfigIntegration(t *testing.T) {
+	target := os.Getenv("SSH_CMD_TARGET")
+	if target == "" {
+		t.Skip("set SSH_CMD_TARGET to run the discovery integration test")
+	}
+	exec, err := newSSHCommandExecutor(target, "", "", "")
+	if err != nil {
+		t.Fatalf("executor: %v", err)
+	}
+	defer exec.Close()
+	g, err := discoverGameConfig(exec)
+	if err != nil {
+		t.Fatalf("discoverGameConfig: %v", err)
+	}
+	if g.DBUser == "" || g.DBPass == "" {
+		t.Errorf("expected DB user+pass from live args, got user=%q passLen=%d", g.DBUser, len(g.DBPass))
+	}
+	t.Logf("discovered DBUser=%s DBName=%s RMQGameHost=%s", g.DBUser, g.DBName, g.RMQGameHost)
+}

--- a/cmd/dune-admin/executor.go
+++ b/cmd/dune-admin/executor.go
@@ -54,12 +54,15 @@ type Executor interface {
 	Type() string
 }
 
-// newExecutor returns an sshExecutor when sshHost is non-empty, otherwise
-// a localExecutor. The SSH connection is established immediately; the error
-// must be checked before using the executor.
-func newExecutor(sshHost, sshUser, sshKeyPath string) (Executor, error) {
+// newExecutor returns a localExecutor when sshHost is empty. Otherwise it
+// returns the OS-ssh-command executor when sshMode == "command", or the
+// default golang.org/x/crypto/ssh executor for "" / "library".
+func newExecutor(sshHost, sshUser, sshKeyPath, sshMode, sshExtraOpts string) (Executor, error) {
 	if sshHost == "" {
 		return &localExecutor{}, nil
+	}
+	if sshMode == "command" {
+		return newSSHCommandExecutor(sshHost, sshUser, sshKeyPath, sshExtraOpts)
 	}
 	client, err := dialSSH(sshHost, sshUser, sshKeyPath)
 	if err != nil {
@@ -215,6 +218,13 @@ func (e *localExecutor) WriteFile(path string, data io.Reader) error {
 
 func (e *localExecutor) Dial(network, addr string) (net.Conn, error) {
 	return net.Dial(network, addr)
+}
+
+// sshConnected reports whether the active executor tunnels over SSH (either
+// SSH implementation). Used for status without depending on the concrete
+// *ssh.Client global.
+func sshConnected(e Executor) bool {
+	return e != nil && e.Type() == "ssh"
 }
 
 // ── SSH dialer (used by newExecutor and setup wizard) ─────────────────────────

--- a/cmd/dune-admin/executor.go
+++ b/cmd/dune-admin/executor.go
@@ -56,19 +56,24 @@ type Executor interface {
 
 // newExecutor returns a localExecutor when sshHost is empty. Otherwise it
 // returns the OS-ssh-command executor when sshMode == "command", or the
-// default golang.org/x/crypto/ssh executor for "" / "library".
+// default golang.org/x/crypto/ssh executor for "" / "library". An unknown
+// sshMode is a configuration error rather than a silent fall-back to library.
 func newExecutor(sshHost, sshUser, sshKeyPath, sshMode, sshExtraOpts string) (Executor, error) {
 	if sshHost == "" {
 		return &localExecutor{}, nil
 	}
-	if sshMode == "command" {
+	switch sshMode {
+	case "command":
 		return newSSHCommandExecutor(sshHost, sshUser, sshKeyPath, sshExtraOpts)
+	case "", "library":
+		client, err := dialSSH(sshHost, sshUser, sshKeyPath)
+		if err != nil {
+			return nil, err
+		}
+		return &sshExecutor{client: client}, nil
+	default:
+		return nil, fmt.Errorf("unknown ssh_mode %q (want \"library\" or \"command\")", sshMode)
 	}
-	client, err := dialSSH(sshHost, sshUser, sshKeyPath)
-	if err != nil {
-		return nil, err
-	}
-	return &sshExecutor{client: client}, nil
 }
 
 // ── SSH executor ──────────────────────────────────────────────────────────────

--- a/cmd/dune-admin/executor_sshcmd.go
+++ b/cmd/dune-admin/executor_sshcmd.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+// controlOpts returns the OpenSSH connection-sharing options for the given
+// GOOS. ControlMaster multiplexes many channels over one authenticated
+// connection — replicating the single-client behaviour of sshExecutor. The
+// %C token lets ssh hash the connection parameters into the socket name,
+// avoiding the ~104-char ControlPath length limit. Windows has no support for
+// this, so it returns nil and every invocation opens its own connection.
+func controlOpts(goos string) []string {
+	if goos == "windows" {
+		return nil
+	}
+	path := filepath.Join(os.TempDir(), "dune-admin-cm-%C")
+	return []string{
+		"-o", "ControlMaster=auto",
+		"-o", "ControlPath=" + path,
+		"-o", "ControlPersist=60s",
+	}
+}
+
+// sshExecArgs builds the args to run a remote command:
+//
+//	<base> <target> -- <remoteCmd>
+//
+// The "--" stops ssh option parsing; remoteCmd is handed to the remote shell
+// as a single word, matching sshExecutor's session.Run(cmd) semantics.
+func sshExecArgs(base []string, target, remoteCmd string) []string {
+	args := append([]string{}, base...)
+	return append(args, target, "--", remoteCmd)
+}
+
+// sshDialArgs builds the args to open a stdio TCP tunnel:
+//
+//	<base> -W <addr> <target>
+//
+// -W makes ssh forward its stdin/stdout to addr (the ProxyCommand mechanism),
+// so ProxyJump chains in ~/.ssh/config are applied automatically.
+func sshDialArgs(base []string, target, addr string) []string {
+	args := append([]string{}, base...)
+	return append(args, "-W", addr, target)
+}
+
+// sshAddr is a minimal net.Addr for stdioConn endpoints.
+type sshAddr struct {
+	network string
+	addr    string
+}
+
+func (a sshAddr) Network() string { return a.network }
+func (a sshAddr) String() string  { return a.addr }
+
+// stdioConn adapts the stdin/stdout of an `ssh -W` process to net.Conn.
+// Read pulls from the process stdout, Write pushes to its stdin. Deadline
+// methods are no-ops: pgx/amqp set deadlines, but the connection is bounded by
+// the consumer's context and the ssh process lifetime instead. Documented
+// limitation, acceptable for this admin tool.
+type stdioConn struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+	local  sshAddr
+	remote sshAddr
+	once   sync.Once
+}
+
+func (c *stdioConn) Read(b []byte) (int, error)  { return c.stdout.Read(b) }
+func (c *stdioConn) Write(b []byte) (int, error) { return c.stdin.Write(b) }
+
+func (c *stdioConn) Close() error {
+	c.once.Do(func() {
+		_ = c.stdin.Close()
+		_ = c.stdout.Close()
+		if c.cmd != nil && c.cmd.Process != nil {
+			_ = c.cmd.Process.Kill()
+			_ = c.cmd.Wait()
+		}
+	})
+	return nil
+}
+
+func (c *stdioConn) LocalAddr() net.Addr              { return c.local }
+func (c *stdioConn) RemoteAddr() net.Addr             { return c.remote }
+func (c *stdioConn) SetDeadline(time.Time) error      { return nil }
+func (c *stdioConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *stdioConn) SetWriteDeadline(time.Time) error { return nil }
+
+// sshCommandExecutor implements Executor by shelling out to the OS ssh client.
+type sshCommandExecutor struct {
+	target  string   // ssh target: "user@host" or a ~/.ssh/config alias
+	base    []string // connection-level args shared by every invocation
+	control []string // ControlMaster opts (retained for Close's -O exit)
+}
+
+// buildSSHCommandExecutor assembles the executor from config without doing any
+// I/O beyond stat-ing the key file. base = BatchMode + optional -p +
+// ControlMaster opts + optional -i + extra opts. -i is added only when the key
+// path is set AND the file exists, so command mode falls back to
+// ssh-agent/~/.ssh/config when no key is configured (the whole point: no
+// private key handed to the program).
+func buildSSHCommandExecutor(sshHost, sshUser, sshKeyPath, extraOpts string) *sshCommandExecutor {
+	host := sshHost
+	base := []string{"-o", "BatchMode=yes"}
+	if h, p, err := net.SplitHostPort(sshHost); err == nil {
+		host = h
+		base = append(base, "-p", p)
+	}
+	control := controlOpts(runtime.GOOS)
+	base = append(base, control...)
+	if sshKeyPath != "" {
+		if _, err := os.Stat(sshKeyPath); err == nil {
+			base = append(base, "-i", sshKeyPath)
+		}
+	}
+	base = append(base, strings.Fields(extraOpts)...)
+
+	target := host
+	if sshUser != "" && !strings.Contains(host, "@") {
+		target = sshUser + "@" + host
+	}
+	return &sshCommandExecutor{target: target, base: base, control: control}
+}
+
+func (e *sshCommandExecutor) Type() string { return "ssh" }
+
+// newSSHCommandExecutor builds the executor and probes reachability, eagerly
+// establishing the ControlMaster so a bad config fails fast (mirrors dialSSH).
+func newSSHCommandExecutor(sshHost, sshUser, sshKeyPath, extraOpts string) (Executor, error) {
+	e := buildSSHCommandExecutor(sshHost, sshUser, sshKeyPath, extraOpts)
+	if _, err := e.Exec("true"); err != nil {
+		return nil, fmt.Errorf("ssh command probe %s: %w", e.target, err)
+	}
+	return e, nil
+}
+
+func (e *sshCommandExecutor) Exec(cmd string) (string, error) {
+	c := exec.Command("ssh", sshExecArgs(e.base, e.target, cmd)...) // #nosec G204,G702 -- args from admin config, not user input
+	var buf bytes.Buffer
+	c.Stdout = &buf
+	c.Stderr = &buf
+	err := c.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func (e *sshCommandExecutor) Stream(cmd string) (<-chan string, func(), error) {
+	c := exec.Command("ssh", sshExecArgs(e.base, e.target, cmd)...) // #nosec G204,G702 -- args from admin config, not user input
+	pipe, err := c.StdoutPipe()
+	if err != nil {
+		return nil, func() {}, err
+	}
+	c.Stderr = os.Stderr
+	if err := c.Start(); err != nil {
+		return nil, func() {}, err
+	}
+	ch := make(chan string, 256)
+	go func() {
+		defer close(ch)
+		sc := bufio.NewScanner(pipe)
+		for sc.Scan() {
+			ch <- sc.Text()
+		}
+		_ = c.Wait()
+	}()
+	cancel := func() {
+		if c.Process != nil {
+			_ = c.Process.Kill()
+		}
+	}
+	return ch, cancel, nil
+}
+
+func (e *sshCommandExecutor) PipeToWriter(cmd string, w io.Writer) error {
+	c := exec.Command("ssh", sshExecArgs(e.base, e.target, cmd)...) // #nosec G204,G702 -- args from admin config, not user input
+	c.Stdout = w
+	var errBuf bytes.Buffer
+	c.Stderr = &errBuf
+	return c.Run()
+}
+
+func (e *sshCommandExecutor) WriteFile(path string, data io.Reader) error {
+	remote := fmt.Sprintf("sudo tee %s > /dev/null", shellQuote(path))
+	c := exec.Command("ssh", sshExecArgs(e.base, e.target, remote)...) // #nosec G204,G702 -- args from admin config, not user input
+	stdin, err := c.StdinPipe()
+	if err != nil {
+		return err
+	}
+	if err := c.Start(); err != nil {
+		return err
+	}
+	if _, err := io.Copy(stdin, data); err != nil {
+		_ = stdin.Close()
+		_ = c.Wait()
+		return err
+	}
+	_ = stdin.Close()
+	return c.Wait()
+}
+
+func (e *sshCommandExecutor) Dial(network, addr string) (net.Conn, error) {
+	c := exec.Command("ssh", sshDialArgs(e.base, e.target, addr)...) // #nosec G204,G702 -- args from admin config, not user input
+	stdin, err := c.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := c.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, err
+	}
+	c.Stderr = os.Stderr
+	if err := c.Start(); err != nil {
+		return nil, err
+	}
+	return &stdioConn{
+		cmd:    c,
+		stdin:  stdin,
+		stdout: stdout,
+		local:  sshAddr{network: network, addr: "ssh-stdio"},
+		remote: sshAddr{network: network, addr: addr},
+	}, nil
+}
+
+// Close tears down the ControlMaster (Unix). No-op when control is nil
+// (Windows or no master), since each invocation owned its own connection.
+func (e *sshCommandExecutor) Close() {
+	if len(e.control) == 0 {
+		return
+	}
+	args := append([]string{}, e.base...)
+	args = append(args, "-O", "exit", e.target)
+	_ = exec.Command("ssh", args...).Run() // #nosec G204,G702 -- args from admin config, not user input
+}

--- a/cmd/dune-admin/executor_sshcmd.go
+++ b/cmd/dune-admin/executor_sshcmd.go
@@ -188,7 +188,13 @@ func (e *sshCommandExecutor) PipeToWriter(cmd string, w io.Writer) error {
 	c.Stdout = w
 	var errBuf bytes.Buffer
 	c.Stderr = &errBuf
-	return c.Run()
+	if err := c.Run(); err != nil {
+		if stderr := strings.TrimSpace(errBuf.String()); stderr != "" {
+			return fmt.Errorf("%w: %s", err, stderr)
+		}
+		return err
+	}
+	return nil
 }
 
 func (e *sshCommandExecutor) WriteFile(path string, data io.Reader) error {

--- a/cmd/dune-admin/executor_sshcmd_test.go
+++ b/cmd/dune-admin/executor_sshcmd_test.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestAppConfigSSHModeRoundTrip(t *testing.T) {
+	in := []byte("ssh_mode: command\nssh_extra_opts: \"-o StrictHostKeyChecking=accept-new\"\n")
+	var cfg appConfig
+	if err := yaml.Unmarshal(in, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.SSHMode != "command" {
+		t.Errorf("SSHMode = %q, want %q", cfg.SSHMode, "command")
+	}
+	if cfg.SSHExtraOpts != "-o StrictHostKeyChecking=accept-new" {
+		t.Errorf("SSHExtraOpts = %q", cfg.SSHExtraOpts)
+	}
+}
+
+func TestControlOpts(t *testing.T) {
+	if got := controlOpts("windows"); got != nil {
+		t.Errorf("windows controlOpts = %v, want nil", got)
+	}
+	got := controlOpts("linux")
+	joined := strings.Join(got, " ")
+	for _, want := range []string{"ControlMaster=auto", "ControlPersist=60s", "ControlPath="} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("linux controlOpts %q missing %q", joined, want)
+		}
+	}
+}
+
+func TestSSHExecArgs(t *testing.T) {
+	base := []string{"-o", "BatchMode=yes"}
+	got := sshExecArgs(base, "dune@vm-dune-01", "echo hi")
+	want := []string{"-o", "BatchMode=yes", "dune@vm-dune-01", "--", "echo hi"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sshExecArgs = %v, want %v", got, want)
+	}
+}
+
+func TestSSHDialArgs(t *testing.T) {
+	base := []string{"-o", "BatchMode=yes"}
+	got := sshDialArgs(base, "vm-dune-01", "10.0.0.5:5432")
+	want := []string{"-o", "BatchMode=yes", "-W", "10.0.0.5:5432", "vm-dune-01"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sshDialArgs = %v, want %v", got, want)
+	}
+}
+
+func TestSSHExecArgsDoesNotAliasBase(t *testing.T) {
+	base := []string{"-o", "BatchMode=yes"}
+	_ = sshExecArgs(base, "t", "c")
+	if len(base) != 2 {
+		t.Errorf("base was mutated: %v", base)
+	}
+}
+
+func TestStdioConnReadWrite(t *testing.T) {
+	rIn, wIn := io.Pipe()   // stands in for the process stdin
+	rOut, wOut := io.Pipe() // stands in for the process stdout
+	c := &stdioConn{
+		stdin:  wIn,
+		stdout: rOut,
+		local:  sshAddr{network: "tcp", addr: "ssh-stdio"},
+		remote: sshAddr{network: "tcp", addr: "10.0.0.5:5432"},
+	}
+
+	// Write goes to stdin pipe.
+	go func() {
+		buf := make([]byte, 5)
+		_, _ = io.ReadFull(rIn, buf)
+		_, _ = wOut.Write(buf) // echo back onto stdout pipe
+	}()
+	if _, err := c.Write([]byte("hello")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, 5)
+	if _, err := io.ReadFull(c, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("read = %q, want hello", got)
+	}
+
+	// net.Conn surface.
+	var _ net.Conn = c
+	if c.RemoteAddr().String() != "10.0.0.5:5432" {
+		t.Errorf("RemoteAddr = %q", c.RemoteAddr())
+	}
+	if err := c.SetDeadline(time.Now()); err != nil {
+		t.Errorf("SetDeadline = %v, want nil", err)
+	}
+}
+
+func TestStdioConnCloseIdempotent(t *testing.T) {
+	_, wIn := io.Pipe()
+	rOut, _ := io.Pipe()
+	c := &stdioConn{stdin: wIn, stdout: rOut}
+	if err := c.Close(); err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+}
+
+func TestBuildSSHCommandExecutorTarget(t *testing.T) {
+	e := buildSSHCommandExecutor("vm-dune-01", "dune", "", "")
+	if e.target != "dune@vm-dune-01" {
+		t.Errorf("target = %q, want dune@vm-dune-01", e.target)
+	}
+	// alias already contains user → not double-prefixed
+	e2 := buildSSHCommandExecutor("dune@vm-dune-01", "dune", "", "")
+	if e2.target != "dune@vm-dune-01" {
+		t.Errorf("target = %q", e2.target)
+	}
+}
+
+func TestBuildSSHCommandExecutorPort(t *testing.T) {
+	e := buildSSHCommandExecutor("192.168.33.65:2222", "dune", "", "")
+	joined := strings.Join(e.base, " ")
+	if !strings.Contains(joined, "-p 2222") {
+		t.Errorf("base %q missing -p 2222", joined)
+	}
+	if e.target != "dune@192.168.33.65" {
+		t.Errorf("target = %q, want dune@192.168.33.65", e.target)
+	}
+}
+
+func TestBuildSSHCommandExecutorIdentityOnlyIfExists(t *testing.T) {
+	// Non-existent key path must NOT add -i (ssh would otherwise fail).
+	e := buildSSHCommandExecutor("vm-dune-01", "dune", "/no/such/key", "")
+	if strings.Contains(strings.Join(e.base, " "), "-i") {
+		t.Errorf("non-existent key added -i: %v", e.base)
+	}
+	// Existing key path adds -i.
+	f := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(f, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	e2 := buildSSHCommandExecutor("vm-dune-01", "dune", f, "")
+	if !strings.Contains(strings.Join(e2.base, " "), "-i "+f) {
+		t.Errorf("existing key missing -i: %v", e2.base)
+	}
+}
+
+func TestBuildSSHCommandExecutorExtraOpts(t *testing.T) {
+	e := buildSSHCommandExecutor("vm-dune-01", "dune", "", "-o StrictHostKeyChecking=accept-new")
+	joined := strings.Join(e.base, " ")
+	if !strings.Contains(joined, "StrictHostKeyChecking=accept-new") {
+		t.Errorf("base %q missing extra opt", joined)
+	}
+	if !strings.Contains(joined, "BatchMode=yes") {
+		t.Errorf("base %q missing BatchMode", joined)
+	}
+}
+
+func TestNewExecutorEmptyHostIsLocal(t *testing.T) {
+	for _, mode := range []string{"", "library", "command"} {
+		e, err := newExecutor("", "", "", mode, "")
+		if err != nil {
+			t.Fatalf("mode %q: %v", mode, err)
+		}
+		if _, ok := e.(*localExecutor); !ok {
+			t.Errorf("mode %q: got %T, want *localExecutor", mode, e)
+		}
+	}
+}
+
+func TestSSHConnected(t *testing.T) {
+	if sshConnected(nil) {
+		t.Error("nil executor must report not connected")
+	}
+	if sshConnected(&localExecutor{}) {
+		t.Error("local executor must report ssh not connected")
+	}
+	if !sshConnected(&sshCommandExecutor{}) {
+		t.Error("ssh command executor must report connected")
+	}
+}
+
+// Integration: requires a reachable ssh target. Run with:
+//
+//	SSH_CMD_TARGET=vm-dune-01 go test -run TestSSHCommandExecutorIntegration ./...
+func TestSSHCommandExecutorIntegration(t *testing.T) {
+	target := os.Getenv("SSH_CMD_TARGET")
+	if target == "" {
+		t.Skip("set SSH_CMD_TARGET to run the ssh command-executor integration test")
+	}
+	e, err := newSSHCommandExecutor(target, "", "", "")
+	if err != nil {
+		t.Fatalf("newSSHCommandExecutor: %v", err)
+	}
+	defer e.Close()
+	out, err := e.Exec("echo dune-ok")
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if out != "dune-ok" {
+		t.Errorf("Exec output = %q, want dune-ok", out)
+	}
+}

--- a/cmd/dune-admin/handlers_config.go
+++ b/cmd/dune-admin/handlers_config.go
@@ -303,9 +303,10 @@ func handleDiscover(w http.ResponseWriter, r *http.Request) {
 	}
 	var gameIP, adminIP, directorIP string
 	if globalControl != nil && globalControl.Name() == "kubectl" {
-		gameIP = resolveServicePodIP(globalExecutor, "mq-game")
-		adminIP = resolveServicePodIP(globalExecutor, "mq-admin")
-		directorIP = resolveServicePodIP(globalExecutor, "bgd")
+		pods := fetchClusterPodIPs(globalExecutor)
+		gameIP = podIPByPattern(pods, "mq-game")
+		adminIP = podIPByPattern(pods, "mq-admin")
+		directorIP = podIPByPattern(pods, "bgd")
 	}
 	cfg := persistDiscoveredConfig(loadedConfig, g, gameIP, adminIP, directorIP)
 	if r.URL.Query().Get("persist") == "true" {
@@ -349,5 +350,8 @@ func applyConfig(cfg appConfig) {
 	brokerUser = cfg.BrokerUser
 	brokerPass = cfg.BrokerPass
 	backupDir = cfg.BackupDir
+	sshMode = cfg.SSHMode
+	sshExtraOpts = cfg.SSHExtraOpts
+	autoDiscover = cfg.AutoDiscover
 	loadedConfig = cfg
 }

--- a/cmd/dune-admin/handlers_config.go
+++ b/cmd/dune-admin/handlers_config.go
@@ -288,6 +288,43 @@ func applyMarketBotConfig(cfg appConfig) {
 	}
 }
 
+// handleDiscover runs auto-discovery on demand and, when persist=true, writes
+// the gap-filled values into config.yaml (then applies them). Requires an
+// active executor (command-mode/kubectl).
+func handleDiscover(w http.ResponseWriter, r *http.Request) {
+	if globalExecutor == nil {
+		jsonErr(w, fmt.Errorf("no executor connected"), http.StatusServiceUnavailable)
+		return
+	}
+	g, err := discoverGameConfig(globalExecutor)
+	if err != nil {
+		jsonErr(w, err, http.StatusBadGateway)
+		return
+	}
+	var gameIP, adminIP, directorIP string
+	if globalControl != nil && globalControl.Name() == "kubectl" {
+		gameIP = resolveServicePodIP(globalExecutor, "mq-game")
+		adminIP = resolveServicePodIP(globalExecutor, "mq-admin")
+		directorIP = resolveServicePodIP(globalExecutor, "bgd")
+	}
+	cfg := persistDiscoveredConfig(loadedConfig, g, gameIP, adminIP, directorIP)
+	if r.URL.Query().Get("persist") == "true" {
+		if err := writeConfigFile(cfg); err != nil {
+			jsonErr(w, fmt.Errorf("write config: %w", err), http.StatusInternalServerError)
+			return
+		}
+		loadedConfig = cfg
+		applyConfig(cfg)
+	}
+	jsonOK(w, map[string]any{
+		"db_user": cfg.DBUser, "db_name": cfg.DBName,
+		"db_pass":     maskSecret(cfg.DBPass),
+		"broker_game": cfg.BrokerGameAddr, "broker_admin": cfg.BrokerAdminAddr,
+		"director_url": cfg.DirectorURL,
+		"persisted":    r.URL.Query().Get("persist") == "true",
+	})
+}
+
 // applyConfig pushes a saved appConfig back into the runtime globals so that
 // connectAll() picks up the new values without requiring a process restart.
 func applyConfig(cfg appConfig) {

--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -634,10 +634,16 @@ func loadItemData() error {
 // ── main ──────────────────────────────────────────────────────────────────────
 
 // needsSetupConfigured reports whether a configured install still needs setup.
-// When auto_discover is on, an empty db_pass is fine — discovery supplies it —
-// so the (library-wired) wizard must not trigger.
+// auto_discover suppresses the (library-wired) wizard only when discovery is
+// actually applicable — the kubectl control plane, where it fills the DB
+// password from the running game server. Outside kubectl, an empty db_pass
+// still requires setup, so an unreachable/failed discovery doesn't strand the
+// operator without a wizard path.
 func needsSetupConfigured() bool {
-	return dbPass == "" && !autoDiscover
+	if dbPass != "" {
+		return false
+	}
+	return !autoDiscover || resolveControl() != "kubectl"
 }
 
 func needsSetup() bool {
@@ -763,9 +769,11 @@ func closeGlobalConnections() {
 	}
 	// Close the active executor so command-mode tears down its ControlMaster
 	// (ssh -O exit) on shutdown. For the library executor this also closes its
-	// *ssh.Client; the globalSSH.Close below is then a harmless idempotent no-op.
+	// underlying *ssh.Client (globalSSH), so drop that reference to avoid a
+	// double Close on it below.
 	if globalExecutor != nil {
 		globalExecutor.Close()
+		globalSSH = nil
 	}
 	if globalSSH != nil {
 		_ = globalSSH.Close()

--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -78,6 +78,10 @@ var (
 	sshHost         string
 	sshUser         string
 	sshKeyPath      string
+	sshMode         string
+	sshExtraOpts    string
+	autoDiscover    bool
+	discoverWrite   bool
 	itemDataPath    string
 	scripCurrencyID int
 	dbHost          string
@@ -107,6 +111,15 @@ type appConfig struct {
 	SSHHost string `yaml:"ssh_host" json:"ssh_host"`
 	SSHUser string `yaml:"ssh_user" json:"ssh_user"`
 	SSHKey  string `yaml:"ssh_key"  json:"ssh_key"`
+	// SSHMode selects the SSH transport: "" / "library" uses golang.org/x/crypto/ssh
+	// (default); "command" shells out to the OS ssh client (honours ~/.ssh/config,
+	// ProxyJump, ssh-agent; never reads a private key).
+	SSHMode      string `yaml:"ssh_mode"       json:"ssh_mode"`
+	SSHExtraOpts string `yaml:"ssh_extra_opts" json:"ssh_extra_opts"`
+
+	// AutoDiscover: when true, fill empty DB/RMQ/Director fields from the
+	// running game-server process args at connect time (command-mode + kubectl).
+	AutoDiscover bool `yaml:"auto_discover" json:"auto_discover"`
 
 	// Database — always required.
 	DBHost   string `yaml:"db_host"   json:"db_host"`
@@ -376,6 +389,8 @@ func loadConfig() {
 			setEnvIfMissing("SSH_HOST", cfg.SSHHost)
 			setEnvIfMissing("SSH_USER", cfg.SSHUser)
 			setEnvIfMissing("SSH_KEY", cfg.SSHKey)
+			setEnvIfMissing("SSH_MODE", cfg.SSHMode)
+			setEnvIfMissing("SSH_EXTRA_OPTS", cfg.SSHExtraOpts)
 			setEnvIfMissing("DB_HOST", cfg.DBHost)
 			if cfg.DBPort != 0 {
 				setEnvIfMissing("DB_PORT", strconv.Itoa(cfg.DBPort))
@@ -474,6 +489,10 @@ func init() {
 	flag.StringVar(&sshHost, "host", envOr("SSH_HOST", ""), "SSH host:port (if set, all connections tunnel through SSH)")
 	flag.StringVar(&sshUser, "user", envOr("SSH_USER", "dune"), "SSH user")
 	flag.StringVar(&sshKeyPath, "key", envOr("SSH_KEY", ""), "SSH private key path (auto-detected if empty)")
+	flag.StringVar(&sshMode, "ssh-mode", envOr("SSH_MODE", ""), "SSH transport: library (default, x/crypto/ssh) | command (OS ssh client)")
+	flag.StringVar(&sshExtraOpts, "ssh-extra-opts", envOr("SSH_EXTRA_OPTS", ""), "Extra ssh -o options for command mode, space-separated")
+	flag.BoolVar(&autoDiscover, "auto-discover", loadedConfig.AutoDiscover, "Discover DB/RMQ/Director from running game-server args (command-mode + kubectl)")
+	flag.BoolVar(&discoverWrite, "discover-write", false, "Persist discovered values into config.yaml, then continue")
 	flag.StringVar(&itemDataPath, "itemdata", envOr("ITEM_DATA", ""), "Item data JSON path")
 	flag.IntVar(&scripCurrencyID, "scripcurrency", envIntOr("SCRIP_CURRENCY", 1), "Scrip currency id")
 	flag.StringVar(&dbHost, "dbhost", envOr("DB_HOST", "127.0.0.1"), "PostgreSQL host or DNS name")
@@ -614,13 +633,20 @@ func loadItemData() error {
 
 // ── main ──────────────────────────────────────────────────────────────────────
 
+// needsSetupConfigured reports whether a configured install still needs setup.
+// When auto_discover is on, an empty db_pass is fine — discovery supplies it —
+// so the (library-wired) wizard must not trigger.
+func needsSetupConfigured() bool {
+	return dbPass == "" && !autoDiscover
+}
+
 func needsSetup() bool {
 	// config.yaml takes priority over legacy .env.
 	if _, err := os.Stat(configPath()); err == nil {
-		return dbPass == ""
+		return needsSetupConfigured()
 	}
 	if _, err := os.Stat(".env"); err == nil {
-		return dbPass == ""
+		return needsSetupConfigured()
 	}
 	return true
 }
@@ -734,6 +760,12 @@ func setupIfNeeded() bool {
 func closeGlobalConnections() {
 	if globalDB != nil {
 		globalDB.Close()
+	}
+	// Close the active executor so command-mode tears down its ControlMaster
+	// (ssh -O exit) on shutdown. For the library executor this also closes its
+	// *ssh.Client; the globalSSH.Close below is then a harmless idempotent no-op.
+	if globalExecutor != nil {
+		globalExecutor.Close()
 	}
 	if globalSSH != nil {
 		_ = globalSSH.Close()

--- a/cmd/dune-admin/server.go
+++ b/cmd/dune-admin/server.go
@@ -112,6 +112,7 @@ func buildMux() *http.ServeMux {
 	handleAPI(mux, "POST /api/v1/reconnect", capServerControl, handleReconnect)
 	handleAPI(mux, "GET /api/v1/config", capConfigRead, handleGetConfig)
 	handleAPI(mux, "POST /api/v1/config", capConfigWrite, handleSaveConfig)
+	handleAPI(mux, "POST /api/v1/discover", capServerControl, handleDiscover)
 	handleAPI(mux, "GET /api/v1/update/check", capServerRead, handleUpdateCheck)
 	handleAPI(mux, "POST /api/v1/update/apply", capServerControl, handleUpdateApply)
 
@@ -488,7 +489,7 @@ func handleStatus(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]any{
 		"executor":         executorType,
 		"control":          controlName,
-		"ssh_connected":    globalSSH != nil,
+		"ssh_connected":    sshConnected(globalExecutor),
 		"db_connected":     globalDB != nil,
 		"pod_ns":           globalPodNS,
 		"pod_ip":           globalPodIP,


### PR DESCRIPTION
Closes #216.

Two opt-in, backwards-compatible features. The existing `golang.org/x/crypto/ssh`
path stays the untouched default — with `ssh_mode` unset and `auto_discover` off,
behaviour is identical to today.

## 1. OS-`ssh` command-mode executor (`ssh_mode: command`)

A third `Executor` implementation that shells out to the OS `ssh` client:

- `Exec`/`Stream`/`PipeToWriter`/`WriteFile` → `ssh [opts] <target> -- <cmd>`.
- `Dial(addr)` → `ssh -W <addr> <target>`, wrapping the process stdio in a `net.Conn`,
  so the pgx pool, RabbitMQ, the Director proxy and kubectl DB-pod dialing tunnel
  through it unchanged — cascading `ProxyJump` from `~/.ssh/config` applies
  automatically.
- OpenSSH ControlMaster multiplexing (one auth, many channels; skipped on Windows).
- Host-key checking via the OS client's `known_hosts` (no `InsecureIgnoreHostKey`).
- **Never reads a private key**: `-i` is passed through only if the path exists;
  otherwise ssh-agent / `~/.ssh/config` are used.

To work end-to-end with kubectl, the DB-pool dial and the `ssh_connected` status flag
were decoupled from the concrete `*ssh.Client` onto the `Executor` interface.

## 2. Game-server auto-discovery (`auto_discover: true`)

Reads the running `DuneSandboxServer` process args through the executor (same path
`CaptureJWT` uses) and **gap-fills empty** DB/RMQ/Director config — explicit config
always wins:

- DB user/password/name from the args; DB host via the existing `discoverDBPod`.
- RMQ + Director: cluster-internal service-DNS hostnames resolved to pod IPs (like
  `discoverDBPod`), combined with ports/TLS from the args.
- Discovered passwords are masked in logs, runtime-only by default; opt-in persistence
  via `--discover-write` or `POST /api/v1/discover?persist=true`.
- Out of scope: broker credentials (not in the args, stay manual) and the
  `ServiceAuthToken` (already fetched at runtime by `CaptureJWT`).
- `needsSetup()` is now auto-discover-aware, so an empty `db_pass` under
  `auto_discover` no longer triggers the key-requiring setup wizard.

## Config / flags

| Config | Flag | Default | |
|---|---|---|---|
| `ssh_mode` | `--ssh-mode` | `library` | `library` \| `command` |
| `ssh_extra_opts` | `--ssh-extra-opts` | – | extra `ssh -o` options |
| `auto_discover` | `--auto-discover` | `false` | gap-fill from game-server args |
| – | `--discover-write` | `false` | persist discovered values to config.yaml |

## Tests

Unit: arg builders, ControlMaster platform split, `stdioConn`, executor construction,
mode switch, `sshConnected`, discovery parser, gap-fill precedence, `needsSetup`.
Integration tests gated behind `SSH_CMD_TARGET` (skipped in CI). `make verify` and
`make gosec` pass; new `exec.Command("ssh", …)` calls carry justified `// #nosec
G204,G702` (args from admin config, not user input). Verified live against a mesh-only
deployment: command-mode reaches the host through a bastion and `auto_discover` yields
`db_connected: true` with no hand-entered password.

## Compatibility

Fully backwards-compatible: both features are opt-in and default off. The library SSH
path is byte-for-byte unchanged; it remains the default. Rebased onto current `main`
(v0.37.4); the only overlap with recent changes was the `/api/v1/status` map, resolved
in favour of upstream's fields plus the interface-based `ssh_connected`.
