### PR TITLE
Defer-safe entrypoint: split main() into main() → run() error

### DIFF
--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -901,19 +901,27 @@ func immediateModeLabel() string {
 
 func main() {
 	flag.Parse()
+	if err := run(context.Background()); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
 
+// run wires up and starts the server, returning an error instead of calling
+// os.Exit/log.Fatal so that every deferred cleanup below unwinds on every return
+// path — including the server's exit. main() translates a returned error into a
+// non-zero exit code only after run() has fully returned and its defers ran.
+func run(ctx context.Context) error {
 	handled, err := runImmediateModes()
 	if handled {
 		if err != nil {
-			fmt.Fprintln(os.Stderr, immediateModeLabel()+err.Error())
-			os.Exit(1)
+			return fmt.Errorf("%s%w", immediateModeLabel(), err)
 		}
-		return
+		return nil
 	}
 
 	if err := loadRuntimeData(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		return err
 	}
 
 	alreadyConnected := setupIfNeeded()
@@ -947,14 +955,31 @@ func main() {
 	globalWelcomeCancel = startWelcomePackageScanner(loadedConfig)
 	defer stopWelcomeScanner()
 
+	startBackgroundServices(ctx)
+
+	applyEventEngine(loadedConfig)
+	defer stopEventEngine()
+
+	applyBattlepassEngine(loadedConfig)
+	defer stopBattlepassEngine()
+
+	return startServer(listenAddr)
+}
+
+// startBackgroundServices launches the process-lifetime schedulers and loads the
+// operator-configured runtime data that has no teardown. The schedulers honour
+// ctx.Done(); today ctx is context.Background() (the process is hard-stopped on
+// signal), but threading ctx keeps this forward-compatible with graceful
+// shutdown without changing current behaviour.
+func startBackgroundServices(ctx context.Context) {
 	// Scheduled restarts (#145): load persisted config + run the scheduler for
 	// the process lifetime (independent of the welcome scanner's lifecycle).
 	loadScheduledRestartConfig()
-	go runRestartScheduler(context.Background())
+	go runRestartScheduler(ctx)
 
 	// Scheduled DB backups (#150): same lifecycle as scheduled restarts.
 	loadScheduledBackupConfig()
-	go runBackupScheduler(context.Background())
+	go runBackupScheduler(ctx)
 
 	// Web interfaces (#155): load the operator-configured Server Health links.
 	loadWebInterfaces()
@@ -963,14 +988,6 @@ func main() {
 	initGivePacksStore()
 	initEventStore()
 	initBattlepassStore()
-
-	applyEventEngine(loadedConfig)
-	defer stopEventEngine()
-
-	applyBattlepassEngine(loadedConfig)
-	defer stopBattlepassEngine()
-
-	startServer(listenAddr)
 }
 
 // initLocationStore opens (or creates) the persistent location store and sets

--- a/cmd/dune-admin/main_run_test.go
+++ b/cmd/dune-admin/main_run_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// run() must translate the immediate-mode outcomes that main() previously
+// handled with os.Exit / a bare return into ordinary error returns, so that any
+// deferred cleanup registered later in run() is guaranteed to unwind. These
+// tests exercise the render-k8s immediate mode because it has no DB or network
+// dependency: it only reads package globals and writes a manifest file.
+
+// TestRun_ImmediateModeHandledReturnsNil locks in the mapping
+// (handled, nil) -> return nil: a successfully handled immediate mode makes
+// run() return nil without proceeding to loadRuntimeData/server startup.
+func TestRun_ImmediateModeHandledReturnsNil(t *testing.T) {
+	prev := renderK8SOut
+	t.Cleanup(func() { renderK8SOut = prev })
+
+	renderK8SOut = filepath.Join(t.TempDir(), "manifest.yaml")
+	if err := run(context.Background()); err != nil {
+		t.Fatalf("run() returned error for a successful immediate mode: %v", err)
+	}
+	if _, err := os.Stat(renderK8SOut); err != nil {
+		t.Fatalf("expected manifest written at %s: %v", renderK8SOut, err)
+	}
+}
+
+// TestRun_ImmediateModeErrorPropagates locks in the mapping
+// (handled, err) -> return err (previously os.Exit(1)): a failing immediate mode
+// is surfaced as an error carrying its label prefix, never terminating the
+// process before deferred cleanup can run.
+func TestRun_ImmediateModeErrorPropagates(t *testing.T) {
+	prev := renderK8SOut
+	t.Cleanup(func() { renderK8SOut = prev })
+
+	// A regular file used as a parent directory component forces MkdirAll
+	// (and thus renderK8SManifest) to fail deterministically — no DB or network.
+	notADir := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(notADir, []byte("x"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	renderK8SOut = filepath.Join(notADir, "sub", "manifest.yaml")
+
+	err := run(context.Background())
+	if err == nil {
+		t.Fatal("run() returned nil for a failing immediate mode; want error")
+	}
+	if !strings.Contains(err.Error(), "render-k8s: ") {
+		t.Errorf("error %q missing immediate-mode label prefix %q", err, "render-k8s: ")
+	}
+}

--- a/cmd/dune-admin/server.go
+++ b/cmd/dune-admin/server.go
@@ -378,7 +378,7 @@ func buildMux() *http.ServeMux {
 	return mux
 }
 
-func startServer(addr string) {
+func startServer(addr string) error {
 	mux := buildMux()
 	initAuthRuntime(loadedConfig)
 
@@ -391,7 +391,9 @@ func startServer(addr string) {
 		IdleTimeout:       60 * time.Second,
 	}
 	log.Printf("dune-admin listening on %s", addr)
-	log.Fatal(srv.ListenAndServe())
+	// Return the error instead of log.Fatal so the deferred cleanup registered
+	// in run() unwinds on shutdown; log.Fatal calls os.Exit, which skips defers.
+	return srv.ListenAndServe()
 }
 
 // spaHandler serves static files from distDir, falling back to index.html


### PR DESCRIPTION
## Summary

Splits the entrypoint into a thin `main()` and a `run(ctx context.Context) error`, so that
all cleanup `defer`s in the startup path unwind on every return — including the server's
exit. Today `startServer()` ends in `log.Fatal(srv.ListenAndServe())` (`server.go:394`);
`log.Fatal` calls `os.Exit`, which skips deferred functions, so the nine `defer`s in
`main()` never run on the server exit path. Motivation and references are in #223.

## What changed

- `main()` is now a thin wrapper: `flag.Parse()`, call `run(context.Background())`, print a
  returned error to stderr and `os.Exit(1)`.
- All previous `main()` logic moved verbatim into `run(ctx) error`:
  - `os.Exit(1)` on immediate-mode error → `return fmt.Errorf("%s%w", immediateModeLabel(), err)`
  - bare `return` on a handled immediate mode → `return nil`
  - `os.Exit(1)` on `loadRuntimeData` failure → `return err`
  - `startServer(listenAddr)` → `return startServer(listenAddr)`
- `startServer(addr string)` → `startServer(addr string) error`; `log.Fatal(srv.ListenAndServe())`
  → `return srv.ListenAndServe()`.
- The process-lifetime schedulers + teardown-less init moved into a small
  `startBackgroundServices(ctx)` helper (keeps `run()` linear; threads `ctx` so a future
  graceful-shutdown change is additive — `ctx` is `context.Background()` here, no behavior
  change).

Two production files (`main.go`, `server.go`) + one test file. No new imports, no new
packages — stays within the flat `package main` convention.

## Behavior preserved

Same exit codes, same flag/env handling, same stdout/stderr **with one deliberate
exception worth calling out:** the server-failure path now prints via
`fmt.Fprintln(os.Stderr, err)` instead of `log.Fatal`, so the error text is identical but
**without** the `log` timestamp prefix. Every other path (immediate modes, `loadRuntimeData`
failure, exit codes) is byte-identical. The intended difference: the nine cleanup `defer`s
now run on the exit path instead of being skipped.

This PR adds **no** graceful shutdown and **no** signal handling — `ListenAndServe` still
blocks until an actual error, and the process is still hard-stopped on signals. That's a
possible separate follow-up, kept out of scope here.

## Testing

- New `main_run_test.go`: drives `run()` through the `render-k8s` immediate mode (no DB /
  network) to lock in both mappings — `(handled, err) → return err` (with label prefix) and
  `(handled, nil) → return nil` — i.e. the `os.Exit`-free control flow.
- `make verify` green (vet, `go test -race`, govulncheck, golangci-lint, markdownlint,
  gocognit — `run()` well under the 15 limit).
- `make gosec` clean (0 issues).
- `make build-prebuilt` produces a working binary; `./dune-admin -render-k8s -` exits 0
  through the new `run()` path.

## Reviewer notes

- `run`'s signature is the minimal `run(ctx context.Context) error` — I did not inject
  `getenv`/stdin/stdout/stderr, since the program reads them directly and the headline here
  is defer-safety, not test injection. Happy to adjust to house style.
- If you'd prefer `run()` to keep the `log.Fatal`-style timestamped output on the server
  path, I can log the error in `main()` via `log.Printf` before exiting instead of
  `fmt.Fprintln` — your call.

## Possible follow-ups (only if you're interested)

- Graceful shutdown: `signal.NotifyContext` + `srv.Shutdown(ctx)` (the schedulers already
  honor `ctx.Done()`; this PR threads `ctx` to make that additive). Note the existing
  `WriteTimeout: 10 * time.Minute` for long backup downloads would inform the shutdown grace.

Refs #223
