### PR TITLE
feat(web-proxy): reverse-proxy discovered web interfaces over the executor tunnel

### DIFF
--- a/cmd/dune-admin/control_kubectl.go
+++ b/cmd/dune-admin/control_kubectl.go
@@ -118,7 +118,7 @@ func vmHostIP() string {
 func webInterfacesFromAddresses(vmHost, directorAddr, fileBrowserAddr string) []webInterface {
 	var out []webInterface
 	if url := webInterfaceURL(vmHost, directorAddr); url != "" {
-		out = append(out, webInterface{Label: "Battlegroup Director", URL: url, Target: strings.TrimSpace(directorAddr)})
+		out = append(out, webInterface{Label: directorInterfaceLabel, URL: url, Target: strings.TrimSpace(directorAddr)})
 	}
 	if url := webInterfaceURL(vmHost, fileBrowserAddr); url != "" {
 		out = append(out, webInterface{Label: "File Browser", URL: url, Target: strings.TrimSpace(fileBrowserAddr)})

--- a/cmd/dune-admin/control_kubectl.go
+++ b/cmd/dune-admin/control_kubectl.go
@@ -118,10 +118,10 @@ func vmHostIP() string {
 func webInterfacesFromAddresses(vmHost, directorAddr, fileBrowserAddr string) []webInterface {
 	var out []webInterface
 	if url := webInterfaceURL(vmHost, directorAddr); url != "" {
-		out = append(out, webInterface{Label: "Battlegroup Director", URL: url})
+		out = append(out, webInterface{Label: "Battlegroup Director", URL: url, Target: strings.TrimSpace(directorAddr)})
 	}
 	if url := webInterfaceURL(vmHost, fileBrowserAddr); url != "" {
-		out = append(out, webInterface{Label: "File Browser", URL: url})
+		out = append(out, webInterface{Label: "File Browser", URL: url, Target: strings.TrimSpace(fileBrowserAddr)})
 	}
 	return out
 }

--- a/cmd/dune-admin/handlers_web_interfaces.go
+++ b/cmd/dune-admin/handlers_web_interfaces.go
@@ -34,10 +34,18 @@ func discoveredWebInterfaces(ctx context.Context, ctrl ControlPlane, exec Execut
 // @Router /api/v1/web-interfaces [get]
 func handleGetWebInterfaces(w http.ResponseWriter, r *http.Request) {
 	// interfaces are operator-defined (editable, persisted); discovered are
-	// control-plane-derived (read-only) and never written back.
+	// control-plane-derived (read-only) and never written back. Each entry is
+	// enriched with its mesh-proxy port (0/omitted when not proxied) so the SPA
+	// can open it via dune-admin's own host instead of an unreachable game-side URL.
+	ifaces := getWebInterfaces()
+	discovered := discoveredWebInterfaces(r.Context(), controlFromCtx(r), executorFromCtx(r))
+	// Ports come from the running proxy set for the active server (single source
+	// of truth). When the request's server is the active one, the discovered dial
+	// addresses match and each entry gets its proxy port; otherwise proxyPort is 0.
+	targets := globalWebProxy.currentTargets()
 	jsonOK(w, map[string]any{
-		"interfaces": getWebInterfaces(),
-		"discovered": discoveredWebInterfaces(r.Context(), controlFromCtx(r), executorFromCtx(r)),
+		"interfaces": withProxyPorts(ifaces, targets),
+		"discovered": withProxyPorts(discovered, targets),
 	})
 }
 

--- a/cmd/dune-admin/handlers_web_interfaces.go
+++ b/cmd/dune-admin/handlers_web_interfaces.go
@@ -27,6 +27,30 @@ func discoveredWebInterfaces(ctx context.Context, ctrl ControlPlane, exec Execut
 	return d.discoverWebInterfaces(ctx, exec)
 }
 
+// directorInterfaceLabel is the label the kubectl control plane assigns the
+// discovered Battlegroup Director (see control_kubectl.go). It doubles as the
+// dedupe key in withoutDiscoveredDirector.
+const directorInterfaceLabel = "Battlegroup Director"
+
+// withoutDiscoveredDirector drops the control-plane-discovered Battlegroup
+// Director when director_url is configured, preserving the invariant that the
+// Director is shown from director_url (the same-origin /director/ proxy) rather
+// than the discovered list — otherwise the card renders it twice. With no
+// director_url the list is returned unchanged (no allocation).
+func withoutDiscoveredDirector(discovered []webInterface, directorURL string) []webInterface {
+	if directorURL == "" {
+		return discovered
+	}
+	out := make([]webInterface, 0, len(discovered))
+	for _, wi := range discovered {
+		if wi.Label == directorInterfaceLabel {
+			continue
+		}
+		out = append(out, wi)
+	}
+	return out
+}
+
 // @Summary List configured web interfaces
 // @Tags web-interfaces
 // @Produce json
@@ -39,6 +63,13 @@ func handleGetWebInterfaces(w http.ResponseWriter, r *http.Request) {
 	// can open it via dune-admin's own host instead of an unreachable game-side URL.
 	ifaces := getWebInterfaces()
 	discovered := discoveredWebInterfaces(r.Context(), controlFromCtx(r), executorFromCtx(r))
+	// When director_url is set the card shows the Director as its own DirectorRow,
+	// so drop the discovered copy to avoid rendering it twice (dedupe by label).
+	// Key off the ACTIVE server's director_url — the same source as /status (which
+	// the DirectorRow reads) and as the proxy ports (currentTargets) — so the
+	// dedupe can't disagree with the rendered DirectorRow during a view-switch
+	// where the request server differs from the active one.
+	discovered = withoutDiscoveredDirector(discovered, activeServerCfg().DirectorURL)
 	// Ports come from the running proxy set for the active server (single source
 	// of truth). When the request's server is the active one, the discovered dial
 	// addresses match and each entry gets its proxy port; otherwise proxyPort is 0.
@@ -73,5 +104,10 @@ func handleUpdateWebInterfaces(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, fmt.Errorf("could not save web interfaces"), http.StatusInternalServerError)
 		return
 	}
+	// A newly saved hand-configured absolute-URL interface needs a proxy port to
+	// be reachable; rebuild the active server's proxy set now instead of leaving
+	// it stale until the next server switch / restart. Mirrors the rebuild call
+	// every other state change makes (boot, switch, delete, reconnect).
+	rebuildWebProxiesForActive()
 	jsonOK(w, map[string]string{"ok": "web interfaces saved"})
 }

--- a/cmd/dune-admin/handlers_web_interfaces_test.go
+++ b/cmd/dune-admin/handlers_web_interfaces_test.go
@@ -22,6 +22,49 @@ func TestDiscoveredWebInterfaces_NilExecutorReturnsNil(t *testing.T) {
 	}
 }
 
+// withoutDiscoveredDirector drops the control-plane-discovered "Battlegroup
+// Director" entry when director_url is configured, so the card doesn't render the
+// Director twice (once as the automatic DirectorRow, once from discovery).
+// (Icehunter review point 4.)
+func TestWithoutDiscoveredDirector(t *testing.T) {
+	t.Parallel()
+	director := webInterface{Label: directorInterfaceLabel, URL: "http://host:31003/"}
+	fb := webInterface{Label: "File Browser", URL: "http://host:18888/"}
+
+	labels := func(ws []webInterface) []string {
+		out := make([]string, len(ws))
+		for i, w := range ws {
+			out[i] = w.Label
+		}
+		return out
+	}
+
+	tests := []struct {
+		name        string
+		in          []webInterface
+		directorURL string
+		want        []string
+	}{
+		{"director_url set → drop discovered director", []webInterface{director, fb}, "http://127.0.0.1:11717", []string{"File Browser"}},
+		{"director_url empty → keep all", []webInterface{director, fb}, "", []string{directorInterfaceLabel, "File Browser"}},
+		{"no director in list → unchanged", []webInterface{fb}, "http://x", []string{"File Browser"}},
+		{"nil input → empty", nil, "http://x", []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := labels(withoutDiscoveredDirector(tt.in, tt.directorURL))
+			if len(got) != len(tt.want) {
+				t.Fatalf("labels = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("labels = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
 func TestHandleGetWebInterfaces_NilControlNoDiscovered(t *testing.T) {
 	orig := globalControl
 	origExec := globalExecutor

--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -1010,6 +1010,7 @@ func run(ctx context.Context) error {
 	defer stopWelcomeScanner()
 
 	startBackgroundServices(ctx)
+	defer globalWebProxy.shutdown()
 
 	applyEventEngine(loadedConfig)
 	defer stopEventEngine()
@@ -1036,6 +1037,14 @@ func startBackgroundServices(ctx context.Context) {
 
 	// Web interfaces (#155): load the operator-configured Server Health links.
 	loadWebInterfaces()
+
+	// Mesh web proxy: serve the active server's discovered/configured web
+	// interfaces from local ports over its executor tunnel, so the operator's
+	// browser reaches them without resolving the game host or routing into the
+	// mesh. Rebuilt on every active-server switch. NOTE: no defer teardown here —
+	// startBackgroundServices returns immediately, so a defer would stop the
+	// proxies at once; run() owns the teardown (defer globalWebProxy.shutdown()).
+	rebuildWebProxiesForActive()
 
 	initLocationStore()
 	initGivePacksStore()

--- a/cmd/dune-admin/server_selector.go
+++ b/cmd/dune-admin/server_selector.go
@@ -149,6 +149,9 @@ func handleSetActiveServer(w http.ResponseWriter, r *http.Request) {
 		globalExecutor = active.Executor
 	}
 	persistActiveServer(scope)
+	// Rebuild the mesh web proxies for the newly active server so they tunnel
+	// through its executor (the previous server's proxies are torn down).
+	rebuildWebProxiesForActive()
 	jsonOK(w, map[string]int{"active": body.ID})
 }
 
@@ -183,6 +186,8 @@ func handleDeleteServer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	reassignActiveAfterDelete()
+	// Rebuild proxies for the new active server (or tear them down if none remain).
+	rebuildWebProxiesForActive()
 	removeServerFromMirror(id)
 	invalidateServerHealth(scope) // drop the removed server's cached health
 
@@ -334,6 +339,10 @@ func handleReconnectServer(w http.ResponseWriter, r *http.Request) {
 		globalDB = newSC.DB
 		globalControl = newSC.Control
 		globalExecutor = newSC.Executor
+		// The active server's executor/control changed — rebuild its mesh web
+		// proxies so they tunnel through the reconnected executor (and appear once
+		// discovery works again after a DB/namespace fix).
+		rebuildWebProxiesForActive()
 	}
 	if newSC.DB != nil {
 		ensureDBSchema(newSC.DB)

--- a/cmd/dune-admin/web_interfaces.go
+++ b/cmd/dune-admin/web_interfaces.go
@@ -19,6 +19,11 @@ import (
 type webInterface struct {
 	Label string `json:"label"`
 	URL   string `json:"url"`
+	// Target is the raw host:port dune-admin can Dial through the executor to
+	// reach the service (the address before any host rewrite). Set for
+	// control-plane-discovered entries; empty for hand-configured links. Not
+	// persisted — recomputed on discovery. Enables the mesh web proxy.
+	Target string `json:"-"`
 }
 
 const (

--- a/cmd/dune-admin/web_interfaces_discover_test.go
+++ b/cmd/dune-admin/web_interfaces_discover_test.go
@@ -21,8 +21,8 @@ func TestWebInterfacesFromAddresses(t *testing.T) {
 			director: "207.216.171.194:31592",
 			files:    "207.216.171.194:18888",
 			want: []webInterface{
-				{Label: "Battlegroup Director", URL: "http://192.168.0.67:31592/"},
-				{Label: "File Browser", URL: "http://192.168.0.67:18888/"},
+				{Label: "Battlegroup Director", URL: "http://192.168.0.67:31592/", Target: "207.216.171.194:31592"},
+				{Label: "File Browser", URL: "http://192.168.0.67:18888/", Target: "207.216.171.194:18888"},
 			},
 		},
 		{
@@ -30,14 +30,14 @@ func TestWebInterfacesFromAddresses(t *testing.T) {
 			vmHost:   "192.168.0.67",
 			director: "",
 			files:    "207.216.171.194:18888",
-			want:     []webInterface{{Label: "File Browser", URL: "http://192.168.0.67:18888/"}},
+			want:     []webInterface{{Label: "File Browser", URL: "http://192.168.0.67:18888/", Target: "207.216.171.194:18888"}},
 		},
 		{
 			name:     "no vmHost (local executor) falls back to the reported host",
 			vmHost:   "",
 			director: "207.216.171.194:31592",
 			files:    "",
-			want:     []webInterface{{Label: "Battlegroup Director", URL: "http://207.216.171.194:31592/"}},
+			want:     []webInterface{{Label: "Battlegroup Director", URL: "http://207.216.171.194:31592/", Target: "207.216.171.194:31592"}},
 		},
 		{
 			name:     "neither (none discovered)",

--- a/cmd/dune-admin/web_proxy.go
+++ b/cmd/dune-admin/web_proxy.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// ── Mesh web proxy ───────────────────────────────────────────────────────────
+// Game-side HTTP UIs (Battlegroup Director, File Browser) live on node ports the
+// operator's browser can't reach over the Nebula mesh. dune-admin already reaches
+// them through the executor/SSH tunnel (same path as the DB pool). This serves
+// each such service from a dedicated local port via a root reverse proxy, so the
+// browser only talks to dune-admin and the services' absolute asset paths
+// (/Script/…, /static/…) resolve correctly.
+
+// proxyTarget is a resolved web interface to reverse-proxy: its label, the
+// upstream scheme (http/https), the host:port to Dial through the executor, and
+// the local listener port.
+type proxyTarget struct {
+	label    string
+	scheme   string // upstream scheme: "http" or "https"
+	dialAddr string
+	port     int
+}
+
+// resolveProxyTargets selects the proxyable web interfaces, sorts them
+// deterministically by dial address, and assigns port = listenPort+10+index.
+// A listenPort <= 0 yields no targets (the port base can't be derived).
+//
+// Proxyable = an entry dune-admin can Dial: a discovered entry (its Target, the
+// raw CRD host:port, always plain HTTP) or a hand-configured absolute http(s)
+// URL (whose scheme is preserved so HTTPS upstreams get a TLS dial). Same-origin
+// "/path" entries are skipped — they are already reachable as-is.
+func resolveProxyTargets(ifaces []webInterface, listenPort int) []proxyTarget {
+	if listenPort <= 0 {
+		return nil
+	}
+	var targets []proxyTarget
+	for _, w := range ifaces {
+		scheme, dial := schemeAndDialFor(w)
+		if dial == "" {
+			continue
+		}
+		targets = append(targets, proxyTarget{label: w.Label, scheme: scheme, dialAddr: dial})
+	}
+	sort.Slice(targets, func(i, j int) bool { return targets[i].dialAddr < targets[j].dialAddr })
+	for i := range targets {
+		targets[i].port = listenPort + 10 + i
+	}
+	return targets
+}
+
+// schemeAndDialFor returns the upstream scheme and host:port dune-admin can Dial
+// for a web interface: a discovered entry uses its Target (raw CRD host:port,
+// always plain HTTP), otherwise the absolute http(s) URL is parsed. Returns
+// ("", "") when the entry is not proxyable (same-origin/relative URL). Single
+// source of truth so resolveProxyTargets and withProxyPorts can't drift.
+func schemeAndDialFor(w webInterface) (scheme, dial string) {
+	if w.Target != "" {
+		return "http", w.Target
+	}
+	return schemeAndDialFromURL(w.URL)
+}
+
+// schemeAndDialFromURL returns (scheme, host:port) for an absolute http(s) URL,
+// filling in the default port from the scheme. Returns ("", "") for relative or
+// non-http(s) URLs.
+func schemeAndDialFromURL(raw string) (string, string) {
+	u, err := url.Parse(raw)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Hostname() == "" {
+		return "", ""
+	}
+	// Only root URLs are proxyable. The root reverse proxy forwards the request
+	// path verbatim and builds the upstream from scheme+host only, so a non-root
+	// base path / query / fragment would be silently dropped (https://host/foo →
+	// https://host/, opening the wrong page). Leave those unproxied (opened as-is).
+	if (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.Fragment != "" {
+		return "", ""
+	}
+	if u.Port() != "" {
+		return u.Scheme, u.Host
+	}
+	if u.Scheme == "https" {
+		return u.Scheme, net.JoinHostPort(u.Hostname(), "443")
+	}
+	return u.Scheme, net.JoinHostPort(u.Hostname(), "80")
+}
+
+// proxyListenScheme is the scheme the browser uses to reach a local proxy port.
+// The proxy listeners are always plain HTTP (dune-admin terminates no TLS itself;
+// any TLS is terminated by an external reverse proxy that does not forward these
+// ports). So the SPA must build the open-URL from this scheme, not from
+// window.location.protocol — otherwise an HTTPS-served dashboard would try
+// https://host:proxyPort and fail.
+const proxyListenScheme = "http"
+
+// webInterfaceOut is a web interface enriched with its assigned proxy port for
+// the API. ProxyPort is 0 (omitted) for entries that are not proxied; ProxyScheme
+// is the scheme the browser must use to reach that port (only set when proxied).
+type webInterfaceOut struct {
+	Label       string `json:"label"`
+	URL         string `json:"url"`
+	ProxyPort   int    `json:"proxyPort,omitempty"`
+	ProxyScheme string `json:"proxyScheme,omitempty"`
+}
+
+// withProxyPorts attaches each entry's proxy port + scheme (matched by dial
+// address) so the frontend can open <proxyScheme>://<window.location.hostname>:<proxyPort>/
+// instead of the unreachable rewritten URL.
+func withProxyPorts(ifaces []webInterface, targets []proxyTarget) []webInterfaceOut {
+	portByAddr := make(map[string]int, len(targets))
+	for _, t := range targets {
+		portByAddr[t.dialAddr] = t.port
+	}
+	out := make([]webInterfaceOut, 0, len(ifaces))
+	for _, w := range ifaces {
+		_, dial := schemeAndDialFor(w)
+		entry := webInterfaceOut{Label: w.Label, URL: w.URL, ProxyPort: portByAddr[dial]}
+		if entry.ProxyPort != 0 {
+			entry.ProxyScheme = proxyListenScheme
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// listenPortNum returns the numeric port from listenAddr (e.g. ":8080" → 8080),
+// or 0 when it can't be parsed.
+func listenPortNum() int {
+	_, p, err := net.SplitHostPort(listenAddr)
+	if err != nil {
+		return 0
+	}
+	n, _ := strconv.Atoi(p)
+	return n
+}
+
+// listenHost returns the host/interface from listenAddr (e.g. "127.0.0.1:8080" →
+// "127.0.0.1", ":8080" → ""). The proxy ports bind to this same interface so
+// their exposure matches the main server's: a localhost-bound UI (behind a
+// reverse proxy) does not accidentally expose the proxy ports on all interfaces.
+func listenHost() string {
+	h, _, err := net.SplitHostPort(listenAddr)
+	if err != nil {
+		return ""
+	}
+	return h
+}
+
+// newRootProxy reverse-proxies the entire root path to target, tunneling upstream
+// connections through dial. Unlike newDirectorProxy it does NOT strip a prefix:
+// the proxied app owns the whole port, so its absolute asset paths resolve.
+func newRootProxy(target *url.URL, transport http.RoundTripper) http.HandlerFunc {
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.Transport = transport
+	return func(w http.ResponseWriter, r *http.Request) {
+		r.Host = target.Host
+		proxy.ServeHTTP(w, r)
+	}
+}
+
+// withProxyAuth enforces the same dashboard session as the main UI when auth is
+// enabled. Session cookies are host-scoped (not port-scoped), so the login on the
+// main port is presented to the proxy ports too.
+func withProxyAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if authEnabled(loadedConfig) {
+			if _, ok := authenticateRequest(w, r); !ok {
+				return // authenticateRequest already wrote 401
+			}
+		}
+		next(w, r)
+	}
+}
+
+// startWebProxies launches one root-proxy http.Server per target and returns a
+// func that shuts them all down. Each listener is bound synchronously (so the
+// port is open before this returns); a bind failure is logged and that single
+// proxy skipped — never fatal. dial is injected for testability.
+func startWebProxies(targets []proxyTarget, dial func(network, addr string) (net.Conn, error)) func() {
+	host := listenHost()
+	var servers []*http.Server
+	for _, t := range targets {
+		scheme := t.scheme
+		if scheme == "" {
+			scheme = "http"
+		}
+		upstream := &url.URL{Scheme: scheme, Host: t.dialAddr}
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", withProxyAuth(newRootProxy(upstream, httpTransportVia(dial))))
+		addr := net.JoinHostPort(host, strconv.Itoa(t.port))
+		srv := &http.Server{
+			Addr:              addr,
+			Handler:           mux,
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		ln, err := net.Listen("tcp", srv.Addr)
+		if err != nil {
+			log.Printf("web-proxy: %s on %s: %v (skipped)", t.label, addr, err)
+			continue
+		}
+		log.Printf("web-proxy: %s → %s (upstream %s://%s)", t.label, addr, scheme, t.dialAddr)
+		servers = append(servers, srv)
+		go func() { _ = srv.Serve(ln) }()
+	}
+	return func() {
+		// Close (not graceful Shutdown): on a server switch the old server is no
+		// longer active, so its proxy connections should drop at once. Shutdown
+		// would block on in-flight responses (e.g. a File Browser download) for up
+		// to its timeout — and apply() calls this under the manager lock, which
+		// would stall currentTargets() for that whole window.
+		for _, s := range servers {
+			_ = s.Close()
+		}
+	}
+}
+
+// dialViaExecutor binds the proxy dial path to a specific server's executor. A
+// nil executor dials directly; a set executor tunnels every connection through
+// it (the same path as that server's DB pool), so the proxy reaches hosts
+// reachable from wherever that server runs rather than from this machine.
+func dialViaExecutor(exec Executor) func(network, addr string) (net.Conn, error) {
+	return func(network, addr string) (net.Conn, error) {
+		if exec != nil {
+			return exec.Dial(network, addr)
+		}
+		return net.Dial(network, addr)
+	}
+}
+
+// webProxyManager owns the proxy set for the currently active server. The set is
+// rebuilt whenever the active server changes (boot, switch, removal) so the
+// proxies always tunnel through the active server's executor. It is the single
+// source of truth for the assigned ports the API reports to the SPA.
+type webProxyManager struct {
+	mu      sync.Mutex
+	stop    func()
+	targets []proxyTarget
+}
+
+// globalWebProxy is the process-wide proxy manager for the active server.
+var globalWebProxy = &webProxyManager{}
+
+// apply tears down the current proxy set and starts a fresh one for targets,
+// tunneling through dial. An empty/nil targets list leaves the manager stopped
+// (e.g. no active server). dial is injected for testability; production binds
+// the active server's executor via dialViaExecutor.
+func (m *webProxyManager) apply(targets []proxyTarget, dial func(network, addr string) (net.Conn, error)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.stop != nil {
+		m.stop()
+		m.stop = nil
+	}
+	if len(targets) == 0 {
+		m.targets = nil
+		return
+	}
+	m.targets = targets
+	m.stop = startWebProxies(targets, dial)
+}
+
+// currentTargets returns a copy of the proxy targets for the active server, or
+// nil when no proxies are running. A copy (not the internal slice) so callers
+// can't mutate or race the manager's state.
+func (m *webProxyManager) currentTargets() []proxyTarget {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.targets == nil {
+		return nil
+	}
+	return append([]proxyTarget(nil), m.targets...)
+}
+
+// shutdown stops all proxies and clears the targets (process teardown / no
+// active server).
+func (m *webProxyManager) shutdown() { m.apply(nil, nil) }
+
+// rebuildWebProxiesForActive rebuilds the proxy set for the registry's active
+// server, tunneling through that server's executor. With no active server it
+// tears the proxies down. Safe to call repeatedly (boot, server switch, removal).
+func rebuildWebProxiesForActive() {
+	active := globalRegistry.Active()
+	if active == nil {
+		globalWebProxy.shutdown()
+		return
+	}
+	port := listenPortNum()
+	if port <= 0 {
+		// Can't derive a port base (listenAddr has no parseable port) — disable
+		// the web proxy rather than binding bogus low/privileged ports.
+		log.Printf("web-proxy: disabled — listen address %q has no usable port", listenAddr)
+		globalWebProxy.shutdown()
+		return
+	}
+	ifaces := append(append([]webInterface{}, getWebInterfaces()...),
+		discoveredWebInterfaces(context.Background(), active.Control, active.Executor)...)
+	targets := resolveProxyTargets(ifaces, port)
+	globalWebProxy.apply(targets, dialViaExecutor(active.Executor))
+}

--- a/cmd/dune-admin/web_proxy.go
+++ b/cmd/dune-admin/web_proxy.go
@@ -168,8 +168,15 @@ func newRootProxy(target *url.URL, transport http.RoundTripper) http.HandlerFunc
 }
 
 // withProxyAuth enforces the same dashboard session as the main UI when auth is
-// enabled. Session cookies are host-scoped (not port-scoped), so the login on the
-// main port is presented to the proxy ports too.
+// enabled. Session cookies are host-scoped (not port-scoped), so on a plain-HTTP
+// deployment the login on the main port is presented to the proxy ports too.
+//
+// Known limitation: behind a TLS-terminating reverse proxy (X-Forwarded-Proto:
+// https) the session cookie is set Secure, and browsers will not send a Secure
+// cookie to the plain-HTTP proxy ports — so authenticateRequest sees no session
+// and every proxied interface returns 401. The proxy ports terminate no TLS
+// themselves; supporting auth behind TLS termination needs a non-cookie scheme
+// (e.g. a per-target token) and is intentionally out of scope for this change.
 func withProxyAuth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if authEnabled(loadedConfig) {
@@ -181,13 +188,16 @@ func withProxyAuth(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-// startWebProxies launches one root-proxy http.Server per target and returns a
-// func that shuts them all down. Each listener is bound synchronously (so the
-// port is open before this returns); a bind failure is logged and that single
-// proxy skipped — never fatal. dial is injected for testability.
-func startWebProxies(targets []proxyTarget, dial func(network, addr string) (net.Conn, error)) func() {
+// startWebProxies launches one root-proxy http.Server per target and returns the
+// subset of targets whose listener actually bound, plus a func that shuts them
+// all down. Each listener is bound synchronously (so the port is open before this
+// returns); a bind failure is logged and that single proxy skipped — never fatal.
+// The returned subset is what the manager stores, so the SPA is never told a
+// proxyPort for a listener that failed to start. dial is injected for testability.
+func startWebProxies(targets []proxyTarget, dial func(network, addr string) (net.Conn, error)) ([]proxyTarget, func()) {
 	host := listenHost()
 	var servers []*http.Server
+	var started []proxyTarget
 	for _, t := range targets {
 		scheme := t.scheme
 		if scheme == "" {
@@ -209,9 +219,10 @@ func startWebProxies(targets []proxyTarget, dial func(network, addr string) (net
 		}
 		log.Printf("web-proxy: %s → %s (upstream %s://%s)", t.label, addr, scheme, t.dialAddr)
 		servers = append(servers, srv)
+		started = append(started, t)
 		go func() { _ = srv.Serve(ln) }()
 	}
-	return func() {
+	return started, func() {
 		// Close (not graceful Shutdown): on a server switch the old server is no
 		// longer active, so its proxy connections should drop at once. Shutdown
 		// would block on in-flight responses (e.g. a File Browser download) for up
@@ -264,8 +275,17 @@ func (m *webProxyManager) apply(targets []proxyTarget, dial func(network, addr s
 		m.targets = nil
 		return
 	}
-	m.targets = targets
-	m.stop = startWebProxies(targets, dial)
+	// Store only the targets whose listener actually bound, so currentTargets /
+	// withProxyPorts never advertise a proxyPort for a dead listener. If none
+	// bound, stay in the stopped state (keeping the invariant targets==nil iff
+	// stop==nil that the empty-targets branch above establishes).
+	started, stop := startWebProxies(targets, dial)
+	if len(started) == 0 {
+		stop()
+		m.targets, m.stop = nil, nil
+		return
+	}
+	m.targets, m.stop = started, stop
 }
 
 // currentTargets returns a copy of the proxy targets for the active server, or

--- a/cmd/dune-admin/web_proxy_test.go
+++ b/cmd/dune-admin/web_proxy_test.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// resolveProxyTargets picks proxyable entries, sorts them deterministically by
+// dial address, and assigns ports = listenPort+10+index. Sorting by dialAddr
+// means File Browser (…:18888) sorts before Director (…:31003).
+func TestResolveProxyTargets(t *testing.T) {
+	ifaces := []webInterface{
+		{Label: "File Browser", URL: "http://vm:18888/", Target: "10.0.0.5:18888"},
+		{Label: "Battlegroup Director", URL: "http://vm:31003/", Target: "10.0.0.5:31003"},
+		{Label: "Wiki", URL: "https://wiki.example/"},         // manual absolute root → proxied, port from scheme
+		{Label: "Docs", URL: "https://docs.example/handbook"}, // non-root path → NOT proxied (would be dropped)
+		{Label: "Search", URL: "https://s.example/?q=x"},      // query → NOT proxied
+		{Label: "Local", URL: "/grafana"},                     // same-origin → NOT proxied
+	}
+	got := resolveProxyTargets(ifaces, 8080)
+	want := []proxyTarget{
+		{label: "File Browser", scheme: "http", dialAddr: "10.0.0.5:18888", port: 8090},
+		{label: "Battlegroup Director", scheme: "http", dialAddr: "10.0.0.5:31003", port: 8091},
+		{label: "Wiki", scheme: "https", dialAddr: "wiki.example:443", port: 8092}, // https preserved
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got  %+v\nwant %+v", got, want)
+	}
+}
+
+// resolveProxyTargets yields no targets when the listen port can't be derived
+// (port <= 0) — proxying with a bogus low/privileged port base is worse than off.
+func TestResolveProxyTargets_NoPortBase(t *testing.T) {
+	ifaces := []webInterface{{Label: "Director", Target: "10.0.0.5:31003"}}
+	if got := resolveProxyTargets(ifaces, 0); got != nil {
+		t.Errorf("listenPort 0: got %+v, want nil", got)
+	}
+	if got := resolveProxyTargets(ifaces, -1); got != nil {
+		t.Errorf("listenPort -1: got %+v, want nil", got)
+	}
+}
+
+// withProxyPorts attaches each entry's assigned proxy port (0 when not proxied)
+// so the frontend can build the open-URL from window.location + the port.
+func TestWithProxyPorts(t *testing.T) {
+	ifaces := []webInterface{
+		{Label: "Battlegroup Director", URL: "http://vm:31003/", Target: "10.0.0.5:31003"},
+		{Label: "Local", URL: "/grafana"}, // same-origin → not proxied
+	}
+	targets := resolveProxyTargets(ifaces, 8080) // Director → 8090
+	got := withProxyPorts(ifaces, targets)
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2", len(got))
+	}
+	if got[0].Label != "Battlegroup Director" || got[0].ProxyPort != 8090 || got[0].ProxyScheme != "http" {
+		t.Errorf("director = %+v, want proxyPort 8090 + proxyScheme http", got[0])
+	}
+	if got[1].ProxyPort != 0 || got[1].ProxyScheme != "" {
+		t.Errorf("local = %+v, want proxyPort 0 + empty scheme (not proxied)", got[1])
+	}
+}
+
+// newRootProxy must forward the whole path unchanged so absolute asset paths
+// (/Script/…, /static/…) resolve at the proxied service's root.
+func TestNewRootProxy_PassesAbsoluteAssetPaths(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, "path=%s", r.URL.Path)
+	}))
+	defer upstream.Close()
+	u, _ := url.Parse(upstream.URL)
+	h := newRootProxy(u, httpTransportVia(net.Dial))
+
+	for _, p := range []string{"/", "/Script/app.js", "/static/css/app.css"} {
+		rec := httptest.NewRecorder()
+		h(rec, httptest.NewRequest("GET", p, nil))
+		if rec.Code != http.StatusOK || rec.Body.String() != "path="+p {
+			t.Errorf("%s → %d %q", p, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+// newRootProxy must speak HTTPS upstream for an https target (not plain HTTP to
+// :443), so hand-configured https interfaces proxy correctly.
+func TestNewRootProxy_HTTPSUpstream(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, "tls-path=%s", r.URL.Path)
+	}))
+	defer upstream.Close()
+
+	// Inject a transport that trusts the test server's cert — no global state
+	// mutation, no InsecureSkipVerify.
+	pool := x509.NewCertPool()
+	pool.AddCert(upstream.Certificate())
+	transport := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}}
+
+	u, _ := url.Parse(upstream.URL) // https://127.0.0.1:<port>
+	h := newRootProxy(u, transport)
+
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest("GET", "/Script/app.js", nil))
+	// Success proves TLS was spoken upstream — a plain-HTTP dial to the TLS port
+	// would fail the handshake and yield 502.
+	if rec.Code != http.StatusOK || rec.Body.String() != "tls-path=/Script/app.js" {
+		t.Errorf("https upstream → %d %q, want 200 tls-path=/Script/app.js", rec.Code, rec.Body.String())
+	}
+}
+
+// listenHost extracts the bind interface from listenAddr so proxy ports inherit
+// the main server's exposure (localhost-bound UI → localhost-bound proxies).
+func TestListenHost(t *testing.T) {
+	prev := listenAddr
+	t.Cleanup(func() { listenAddr = prev })
+	for addr, want := range map[string]string{
+		"127.0.0.1:8080": "127.0.0.1",
+		":8080":          "",
+		"0.0.0.0:8080":   "0.0.0.0",
+		"bogus":          "", // unparseable → empty
+	} {
+		listenAddr = addr
+		if got := listenHost(); got != want {
+			t.Errorf("listenHost(%q) = %q, want %q", addr, got, want)
+		}
+	}
+}
+
+// startWebProxies binds to the listenAddr host: a localhost-bound main server
+// must not expose the proxy ports on other interfaces.
+func TestStartWebProxies_BindsToListenHost(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer upstream.Close()
+	uu, _ := url.Parse(upstream.URL)
+
+	prevCfg := loadedConfig
+	prevAddr := listenAddr
+	t.Cleanup(func() { loadedConfig = prevCfg; listenAddr = prevAddr })
+	loadedConfig = appConfig{} // auth off
+	listenAddr = "127.0.0.1:18080"
+
+	port := freePort(t)
+	stop := startWebProxies([]proxyTarget{{label: "x", scheme: "http", dialAddr: uu.Host, port: port}}, net.Dial)
+	defer stop()
+
+	// reachable on the bound loopback interface
+	if body := httpGet(t, fmt.Sprintf("http://127.0.0.1:%d/", port)); body != "ok" {
+		t.Fatalf("proxy on 127.0.0.1 body = %q, want ok", body)
+	}
+}
+
+// withProxyAuth enforces the dashboard session only when auth is enabled.
+func TestWithProxyAuth(t *testing.T) {
+	prev := loadedConfig
+	t.Cleanup(func() { loadedConfig = prev })
+
+	called := false
+	gated := withProxyAuth(func(http.ResponseWriter, *http.Request) { called = true })
+
+	// auth off → passes through
+	loadedConfig = appConfig{}
+	rec := httptest.NewRecorder()
+	gated(rec, httptest.NewRequest("GET", "/", nil))
+	if !called {
+		t.Errorf("auth off: inner handler should have been called")
+	}
+
+	// auth on, no session cookie → blocked with 401
+	called = false
+	enabled := true
+	loadedConfig = appConfig{AuthEnabled: &enabled}
+	rec = httptest.NewRecorder()
+	gated(rec, httptest.NewRequest("GET", "/", nil))
+	if called {
+		t.Errorf("auth on: inner handler should have been blocked")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("auth on: code = %d, want 401", rec.Code)
+	}
+}
+
+// startWebProxies binds a listener per target synchronously, serves it, and the
+// returned stop func shuts them down.
+func TestStartWebProxies_StartStop(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer upstream.Close()
+	uu, _ := url.Parse(upstream.URL)
+
+	prev := loadedConfig
+	t.Cleanup(func() { loadedConfig = prev })
+	loadedConfig = appConfig{} // auth off
+
+	port := freePort(t)
+	tgt := proxyTarget{label: "x", dialAddr: uu.Host, port: port}
+	stop := startWebProxies([]proxyTarget{tgt}, net.Dial)
+
+	base := fmt.Sprintf("http://127.0.0.1:%d/", port)
+	if body := httpGet(t, base); body != "ok" {
+		t.Fatalf("proxy body = %q, want ok", body)
+	}
+
+	stop()
+	// listener closed → a fresh request must fail
+	client := &http.Client{Timeout: time.Second}
+	if _, err := client.Get(base); err == nil {
+		t.Errorf("expected error after stop, got none")
+	}
+}
+
+// dialViaExecutor binds the dial path to a specific server's executor: a nil
+// executor dials the requested address directly, a set executor tunnels through
+// it (so the proxy reaches hosts reachable from wherever that server runs).
+func TestDialViaExecutor(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer backend.Close()
+	bu, _ := url.Parse(backend.URL)
+
+	// nil executor → direct net.Dial to the requested addr.
+	conn, err := dialViaExecutor(nil)("tcp", bu.Host)
+	if err != nil {
+		t.Fatalf("nil exec dial: %v", err)
+	}
+	_ = conn.Close()
+
+	// set executor → routed through it; the requested addr is recorded but the
+	// executor connects to its own target instead.
+	rec := &dialRecordingExecutor{target: bu.Host}
+	conn, err = dialViaExecutor(rec)("tcp", "unreachable.invalid:9999")
+	if err != nil {
+		t.Fatalf("exec dial: %v", err)
+	}
+	_ = conn.Close()
+	if rec.dialAddr != "unreachable.invalid:9999" {
+		t.Errorf("recorded dialAddr = %q, want unreachable.invalid:9999", rec.dialAddr)
+	}
+}
+
+// webProxyManager owns the active server's proxy set: apply starts it,
+// currentTargets reports it, a re-apply swaps it (old port stops serving), and
+// apply(nil) / shutdown tears it down. This is what a server switch relies on.
+func TestWebProxyManager_ApplyRebuildShutdown(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer upstream.Close()
+	uu, _ := url.Parse(upstream.URL)
+
+	prev := loadedConfig
+	t.Cleanup(func() { loadedConfig = prev })
+	loadedConfig = appConfig{} // auth off
+
+	m := &webProxyManager{}
+	client := &http.Client{Timeout: time.Second}
+
+	// apply → serving on the assigned port, targets reported.
+	p1 := freePort(t)
+	m.apply([]proxyTarget{{label: "a", dialAddr: uu.Host, port: p1}}, net.Dial)
+	if got := m.currentTargets(); len(got) != 1 || got[0].port != p1 {
+		t.Fatalf("currentTargets after apply = %+v", got)
+	}
+	if body := httpGet(t, fmt.Sprintf("http://127.0.0.1:%d/", p1)); body != "ok" {
+		t.Fatalf("proxy body = %q, want ok", body)
+	}
+
+	// re-apply on a new port → old listener must close (server switch).
+	p2 := freePort(t)
+	m.apply([]proxyTarget{{label: "b", dialAddr: uu.Host, port: p2}}, net.Dial)
+	if _, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/", p1)); err == nil {
+		t.Errorf("old port %d still served after rebuild", p1)
+	}
+	if body := httpGet(t, fmt.Sprintf("http://127.0.0.1:%d/", p2)); body != "ok" {
+		t.Fatalf("new proxy body = %q, want ok", body)
+	}
+
+	// shutdown → fully stopped, no targets (no active server).
+	m.shutdown()
+	if got := m.currentTargets(); got != nil {
+		t.Errorf("currentTargets after shutdown = %+v, want nil", got)
+	}
+	if _, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/", p2)); err == nil {
+		t.Errorf("port %d still served after shutdown", p2)
+	}
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+// httpGet relies on startWebProxies having bound the listener before returning:
+// the connection queues in the listen backlog and is served once Serve accepts,
+// so no readiness sleep is needed.
+func httpGet(t *testing.T, url string) string {
+	t.Helper()
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	b, _ := io.ReadAll(resp.Body)
+	return string(b)
+}

--- a/cmd/dune-admin/web_proxy_test.go
+++ b/cmd/dune-admin/web_proxy_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -148,7 +149,7 @@ func TestStartWebProxies_BindsToListenHost(t *testing.T) {
 	listenAddr = "127.0.0.1:18080"
 
 	port := freePort(t)
-	stop := startWebProxies([]proxyTarget{{label: "x", scheme: "http", dialAddr: uu.Host, port: port}}, net.Dial)
+	_, stop := startWebProxies([]proxyTarget{{label: "x", scheme: "http", dialAddr: uu.Host, port: port}}, net.Dial)
 	defer stop()
 
 	// reachable on the bound loopback interface
@@ -202,7 +203,7 @@ func TestStartWebProxies_StartStop(t *testing.T) {
 
 	port := freePort(t)
 	tgt := proxyTarget{label: "x", dialAddr: uu.Host, port: port}
-	stop := startWebProxies([]proxyTarget{tgt}, net.Dial)
+	_, stop := startWebProxies([]proxyTarget{tgt}, net.Dial)
 
 	base := fmt.Sprintf("http://127.0.0.1:%d/", port)
 	if body := httpGet(t, base); body != "ok" {
@@ -214,6 +215,47 @@ func TestStartWebProxies_StartStop(t *testing.T) {
 	client := &http.Client{Timeout: time.Second}
 	if _, err := client.Get(base); err == nil {
 		t.Errorf("expected error after stop, got none")
+	}
+}
+
+// startWebProxies returns only the targets whose listener actually bound. A
+// target whose port is already taken is skipped (logged), so the manager never
+// stores — and the SPA is never told — a proxyPort for a dead listener.
+// (Icehunter review point 2.)
+func TestStartWebProxies_ReturnsOnlyStarted(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer upstream.Close()
+	uu, _ := url.Parse(upstream.URL)
+
+	prevCfg := loadedConfig
+	prevAddr := listenAddr
+	t.Cleanup(func() { loadedConfig = prevCfg; listenAddr = prevAddr })
+	loadedConfig = appConfig{} // auth off
+	listenAddr = "127.0.0.1:18083"
+
+	// Occupy a port on the bind host so the "bad" target's listener fails.
+	occupied := freePort(t)
+	busy, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(occupied)))
+	if err != nil {
+		t.Fatalf("occupy port: %v", err)
+	}
+	defer func() { _ = busy.Close() }()
+
+	good := freePort(t)
+	targets := []proxyTarget{
+		{label: "good", scheme: "http", dialAddr: uu.Host, port: good},
+		{label: "bad", scheme: "http", dialAddr: uu.Host, port: occupied},
+	}
+	started, stop := startWebProxies(targets, net.Dial)
+	defer stop()
+
+	if len(started) != 1 || started[0].label != "good" {
+		t.Fatalf("started = %+v, want only the 'good' target", started)
+	}
+	if body := httpGet(t, fmt.Sprintf("http://127.0.0.1:%d/", good)); body != "ok" {
+		t.Fatalf("good proxy body = %q, want ok", body)
 	}
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -457,6 +457,14 @@ export type ScheduledBackups = {
 export type WebInterface = {
   label: string
   url: string
+  // proxyPort, when set, is the local dune-admin port that reverse-proxies this
+  // service over the mesh tunnel. The SPA opens it via the current host on that
+  // port, so the (possibly unresolvable) game-side url is bypassed.
+  proxyPort?: number
+  // proxyScheme is the scheme to reach the proxy port (always "http" — the
+  // listeners are plain HTTP). Use it instead of window.location.protocol so an
+  // HTTPS-served dashboard still opens the http proxy port correctly.
+  proxyScheme?: string
 }
 export type GuildSummary = {
   guild_id: number

--- a/web/src/tabs/BattlegroupTab/components/WebInterfacesCard.tsx
+++ b/web/src/tabs/BattlegroupTab/components/WebInterfacesCard.tsx
@@ -10,8 +10,20 @@ import { HealthCard } from './HealthCard'
 
 const InterfaceRow: React.FC<{ item: WebInterface }> = ({ item }) => {
   const { t } = useTranslation()
+  // Proxied entries (proxyPort set) are reached through dune-admin's own host on
+  // the assigned port — bypassing the game host the operator can't resolve/route.
+  // The host comes from window.location; the scheme comes from the backend
+  // (proxyScheme), NOT window.location.protocol: the proxy listeners are always
+  // plain HTTP, so an HTTPS-served dashboard must still open them over http.
+  // window.location.hostname brackets an IPv6 literal in Chrome/Safari but not in
+  // Firefox/IE, so bracket it ourselves to keep `host:port` a valid URL.
+  const host = window.location.hostname
+  const hostForURL = host.includes(':') && !host.startsWith('[') ? `[${host}]` : host
+  const openURL = item.proxyPort
+    ? `${item.proxyScheme ?? 'http'}://${hostForURL}:${item.proxyPort}/`
+    : item.url
   const copy = () => {
-    copyText(item.url).then((ok) =>
+    copyText(openURL).then((ok) =>
       (ok ? toast.success(t('serverHealth.copied')) : toast.danger(t('serverHealth.copyFailed'))))
   }
   return (
@@ -19,12 +31,12 @@ const InterfaceRow: React.FC<{ item: WebInterface }> = ({ item }) => {
       <Icon name="external-link" className="size-4 text-accent" />
       <div className="flex flex-col min-w-0 flex-1">
         <span className="text-sm font-semibold">{item.label}</span>
-        <span className="text-xs text-muted font-mono truncate">{item.url}</span>
+        <span className="text-xs text-muted font-mono truncate">{openURL}</span>
       </div>
       <Button size="sm" variant="ghost" isIconOnly aria-label={t('serverHealth.copy')} onPress={copy}>
         <Icon name="copy" />
       </Button>
-      <Button size="sm" variant="outline" onPress={() => window.open(item.url, '_blank', 'noopener')}>
+      <Button size="sm" variant="outline" onPress={() => window.open(openURL, '_blank', 'noopener,noreferrer')}>
         {t('serverHealth.open')}
       </Button>
     </div>


### PR DESCRIPTION
## What

- Reverse-proxy each discovered/configured web interface (Battlegroup Director, File Browser) from a dedicated local port (`listenPort+10+i`) over the executor tunnel — the same `Dial` path as the DB pool.
- **Root-path** proxy (not a sub-path): the proxied app owns the whole port, so its absolute asset paths (`/Script/…` BGD/Kestrel, `/static/…` filebrowser) resolve. The SPA builds the open-URL from `window.location` + the assigned port, so no backend needs the browser-facing host.
- **Scoped to the active server**: a `webProxyManager` owns the proxy set, `dialViaExecutor(active.Executor)` binds each proxy to that server's executor, and `rebuildWebProxiesForActive()` re-creates the set on boot and on every active-server switch (`handleSetActiveServer`, `reassignActiveAfterDelete`).
- The web-interfaces handler reports ports from the manager's `currentTargets()` so the SPA's `proxyPort` always matches the running proxies. Each port is gated behind the same dashboard session as the main UI.

## Why

On a kubectl + SSH/Nebula deployment, the discovered Director / File Browser node-port URLs get the host rewritten to the SSH target (`vmHostIP()`), which the operator's browser can't resolve or route into the mesh — they were simply unreachable. dune-admin already reaches them through the executor tunnel, so it can serve them locally and proxy through.

## Testing

- `make verify` passes (vet, `test -race`, govulncheck, golangci-lint, markdownlint, gocognit)
- `make gosec` clean (0 issues)
- ESLint clean
- **Live E2E against two servers** (separate kubectl/SSH boxes): boot proxy serves Director + File Browser over the tunnel (HTTP 200, absolute assets); direct upstream-IP times out (proxy required); **bidirectional live server switch** rebinds the proxies to the new server's executor with consistent handler ports; **switching to an unreachable server degrades gracefully** (proxies stopped, no crash) and recovers on switch back.
- Note: local `make tsc` is blocked by the license-gated `@heroui-pro/react` stub (pre-existing, unrelated — only third-party files error; the two TS files here are clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)