### PR TITLE
fix(server-config): expose ssh_mode (SSH transport) in the WebUI

### DIFF
--- a/cmd/dune-admin/server_config_endpoints_test.go
+++ b/cmd/dune-admin/server_config_endpoints_test.go
@@ -164,3 +164,46 @@ func TestHandleUpdateServerConfig_PreservesMaskedSecretAndPersists(t *testing.T)
 		t.Errorf("mirror entry = %+v, want DBPass=oldsecret DBName=newdb", *entry)
 	}
 }
+
+// A client that omits ssh_mode on update (e.g. an older UI without the field)
+// must not silently reset a "command" server to the library default. End-to-end
+// guard over preserveServerConnectionFields wired into the handler, so a future
+// applyServerConfigDefaults/persist change that drops ssh_mode is caught here.
+func TestHandleUpdateServerConfig_PreservesBlankSSHMode(t *testing.T) {
+	db := openSharedScopeDB(t)
+	useTestServerStores(t, db)
+	// Control "local" (no ssh_host) so connectServer doesn't shell out to ssh;
+	// the persisted ssh_mode is what this test asserts, not the transport.
+	base := ServerConfig{Name: "One", Control: "local", SSHMode: "command", DBName: "dune"}
+	id1, _ := globalServersStore.insertServer(base, 0)
+	s1 := serverScope(id1)
+	base.ID = id1
+
+	reg := newServerRegistry(nil)
+	reg.Register(&ServerContext{ID: s1, Name: "One", Cfg: base})
+	orig := globalRegistry
+	globalRegistry = reg
+	defer func() { globalRegistry = orig }()
+
+	origCfg := loadedConfig
+	loadedConfig = appConfig{Servers: []ServerConfig{base}}
+	defer func() { loadedConfig = origCfg }()
+
+	// Body omits ssh_mode entirely.
+	body, _ := json.Marshal(ServerConfig{Name: "One", Control: "local", DBName: "dune"})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/servers/"+s1+"/config", bytes.NewReader(body))
+	req.SetPathValue("id", s1)
+	rr := httptest.NewRecorder()
+	handleUpdateServerConfig(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	stored, ok, err := globalServersStore.getServer(id1)
+	if err != nil || !ok {
+		t.Fatalf("getServer: ok=%v err=%v", ok, err)
+	}
+	if stored.SSHMode != "command" {
+		t.Errorf("SSHMode = %q, want command (blank in body must not wipe it)", stored.SSHMode)
+	}
+}

--- a/cmd/dune-admin/server_connection_preserve_test.go
+++ b/cmd/dune-admin/server_connection_preserve_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+// preserveServerConnectionFields keeps connection fields the client left blank on
+// an update from wiping the persisted value. ssh_mode is the motivating case: a
+// client (or an older UI build) that omits it must not silently reset a "command"
+// server back to the library default. An explicit value always wins.
+func TestPreserveServerConnectionFields(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		nextMode string
+		oldMode  string
+		want     string
+	}{
+		{"blank next keeps old command", "", "command", "command"},
+		{"blank next keeps old library", "", "library", "library"},
+		{"blank next, blank old stays blank", "", "", ""},
+		{"explicit library overrides command", "library", "command", "library"},
+		{"explicit command kept when old blank", "command", "", "command"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			next := &ServerConfig{SSHMode: tt.nextMode}
+			preserveServerConnectionFields(next, ServerConfig{SSHMode: tt.oldMode})
+			if next.SSHMode != tt.want {
+				t.Errorf("SSHMode = %q, want %q", next.SSHMode, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/dune-admin/server_selector.go
+++ b/cmd/dune-admin/server_selector.go
@@ -380,6 +380,18 @@ func preserveServerMaskedSecrets(next *ServerConfig, old ServerConfig) {
 	}
 }
 
+// preserveServerConnectionFields keeps connection fields the client left blank on
+// an update from wiping the persisted value. Currently the only such field is
+// ssh_mode: a client that omits it (e.g. a UI build without the ssh_mode field)
+// must not silently reset a "command" server back to the library default. An
+// explicit value always wins, so a deliberate change to "library"/"command" is
+// honored. New blank-preserving connection fields go here (hence the plural name).
+func preserveServerConnectionFields(next *ServerConfig, old ServerConfig) {
+	if next.SSHMode == "" {
+		next.SSHMode = old.SSHMode
+	}
+}
+
 // handleGetServerConfig returns one server's ServerConfig with secrets masked.
 func handleGetServerConfig(w http.ResponseWriter, r *http.Request) {
 	id, scope, err := parseServerID(r)
@@ -421,6 +433,7 @@ func handleUpdateServerConfig(w http.ResponseWriter, r *http.Request) {
 		next.Name = sc.Name
 	}
 	preserveServerMaskedSecrets(&next, sc.Cfg)
+	preserveServerConnectionFields(&next, sc.Cfg)
 	applyServerConfigDefaults(&next)
 
 	if err := persistServerConfig(id, next); err != nil {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -165,6 +165,7 @@ export type AppConfig = {
   ssh_host: string
   ssh_user: string
   ssh_key: string
+  ssh_mode: string // '' | 'library' (in-process) | 'command' (OS ssh wrapper)
   // Database
   db_host: string
   db_port: number

--- a/web/src/components/settings/config.ts
+++ b/web/src/components/settings/config.ts
@@ -4,7 +4,7 @@ import type { AppConfig } from '../../api/client'
 
 export const EMPTY: AppConfig = {
   control: '',
-  ssh_host: '', ssh_user: '', ssh_key: '',
+  ssh_host: '', ssh_user: '', ssh_key: '', ssh_mode: '',
   db_host: '', db_port: 0, db_user: '',
   db_pass: '', db_name: '', db_schema: '',
   control_namespace: '',
@@ -76,7 +76,7 @@ export const mergeConfig = (fetched: Record<string, unknown>): AppConfig => {
 // api.servers.saveConfig (per-server).
 export const PER_SERVER_KEYS: (keyof AppConfig)[] = [
   'control', 'control_namespace',
-  'ssh_host', 'ssh_user', 'ssh_key',
+  'ssh_host', 'ssh_user', 'ssh_key', 'ssh_mode',
   'db_host', 'db_port', 'db_user', 'db_pass', 'db_name', 'db_schema',
   'docker_gameserver', 'docker_broker_game', 'docker_broker_admin', 'docker_db',
   'cmd_start', 'cmd_stop', 'cmd_restart', 'cmd_status',

--- a/web/src/components/settings/server/SshPanel.tsx
+++ b/web/src/components/settings/server/SshPanel.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import type { AppConfig } from '../../../api/client'
-import { Panel, SectionLabel } from '../../../dune-ui'
+import { Panel, SectionLabel, FieldSelect } from '../../../dune-ui'
 import { FieldRow } from '../fields/FieldRow'
 import { TextInput } from '../fields/TextInput'
 import { TwoColumnGrid } from '../fields/TwoColumnGrid'
@@ -27,6 +27,9 @@ export const SshPanel: React.FC<SshPanelProps> = ({ cfg, set }) => {
           </FieldRow>
           <FieldRow label={t('settings.ssh.privateKey')} hint={t('settings.ssh.privateKeyHint')}>
             <TextInput value={cfg.ssh_key} onChange={set('ssh_key')} placeholder="~/.ssh/id_ed25519" />
+          </FieldRow>
+          <FieldRow label={t('settings.ssh.mode')} hint={t('settings.ssh.modeHint')}>
+            <FieldSelect value={cfg.ssh_mode || 'library'} onChange={set('ssh_mode')} options={['library', 'command']} />
           </FieldRow>
         </TwoColumnGrid>
       </Panel>

--- a/web/src/locales/de/translation.json
+++ b/web/src/locales/de/translation.json
@@ -1330,7 +1330,9 @@
       "hostPortHint": "aktiviert SSH-Tunnel für alle DB + exec",
       "privateKey": "Privater Schlüsselpfad",
       "privateKeyHint": "absoluter Pfad, leer = automatisch erkennen",
-      "user": "Benutzer"
+      "user": "Benutzer",
+      "mode": "SSH-Transport",
+      "modeHint": "library = In-Process-Client; command = OS-ssh-Wrapper (nutzt ~/.ssh/config, Agent, ProxyJump)"
     },
     "tabs": {
       "advanced": "Erweitert",

--- a/web/src/locales/en-US/translation.json
+++ b/web/src/locales/en-US/translation.json
@@ -1330,7 +1330,9 @@
       "hostPortHint": "enables SSH tunnel for all DB + exec",
       "privateKey": "Private key path",
       "privateKeyHint": "absolute path, blank = auto-detect",
-      "user": "User"
+      "user": "User",
+      "mode": "SSH transport",
+      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
     },
     "tabs": {
       "advanced": "Advanced",

--- a/web/src/locales/es/translation.json
+++ b/web/src/locales/es/translation.json
@@ -1352,8 +1352,8 @@
       "privateKey": "Ruta de clave privada",
       "privateKeyHint": "ruta absoluta, en blanco = detección automática",
       "user": "Usuario",
-      "mode": "SSH transport",
-      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
+      "mode": "Transporte SSH",
+      "modeHint": "library = cliente en proceso; command = envoltorio ssh del SO (usa ~/.ssh/config, agent, ProxyJump)"
     },
     "tabs": {
       "advanced": "Avanzado",

--- a/web/src/locales/es/translation.json
+++ b/web/src/locales/es/translation.json
@@ -1351,7 +1351,9 @@
       "hostPortHint": "activa el túnel SSH para todo BD + exec",
       "privateKey": "Ruta de clave privada",
       "privateKeyHint": "ruta absoluta, en blanco = detección automática",
-      "user": "Usuario"
+      "user": "Usuario",
+      "mode": "SSH transport",
+      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
     },
     "tabs": {
       "advanced": "Avanzado",

--- a/web/src/locales/fr/translation.json
+++ b/web/src/locales/fr/translation.json
@@ -1351,7 +1351,9 @@
       "hostPortHint": "active le tunnel SSH pour toutes les BD + exec",
       "privateKey": "Chemin de la clé privée",
       "privateKeyHint": "chemin absolu, vide = détection automatique",
-      "user": "Utilisateur"
+      "user": "Utilisateur",
+      "mode": "SSH transport",
+      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
     },
     "tabs": {
       "advanced": "Avancé",

--- a/web/src/locales/fr/translation.json
+++ b/web/src/locales/fr/translation.json
@@ -1352,8 +1352,8 @@
       "privateKey": "Chemin de la clé privée",
       "privateKeyHint": "chemin absolu, vide = détection automatique",
       "user": "Utilisateur",
-      "mode": "SSH transport",
-      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
+      "mode": "Transport SSH",
+      "modeHint": "library = client intégré au processus ; command = wrapper ssh de l'OS (utilise ~/.ssh/config, agent, ProxyJump)"
     },
     "tabs": {
       "advanced": "Avancé",

--- a/web/src/locales/ja/translation.json
+++ b/web/src/locales/ja/translation.json
@@ -1330,7 +1330,9 @@
       "hostPortHint": "すべてのDB + execのSSHトンネルを有効化",
       "privateKey": "秘密鍵のパス",
       "privateKeyHint": "絶対パス、空白 = 自動検出",
-      "user": "ユーザー"
+      "user": "ユーザー",
+      "mode": "SSH transport",
+      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
     },
     "tabs": {
       "advanced": "詳細設定",

--- a/web/src/locales/ja/translation.json
+++ b/web/src/locales/ja/translation.json
@@ -1331,8 +1331,8 @@
       "privateKey": "秘密鍵のパス",
       "privateKeyHint": "絶対パス、空白 = 自動検出",
       "user": "ユーザー",
-      "mode": "SSH transport",
-      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
+      "mode": "SSH トランスポート",
+      "modeHint": "library = インプロセスクライアント; command = OS の ssh ラッパー (~/.ssh/config、agent、ProxyJump を使用)"
     },
     "tabs": {
       "advanced": "詳細設定",

--- a/web/src/locales/pl/translation.json
+++ b/web/src/locales/pl/translation.json
@@ -1373,8 +1373,8 @@
       "privateKey": "Ścieżka do klucza prywatnego",
       "privateKeyHint": "ścieżka bezwzględna, puste = autowykrywanie",
       "user": "Użytkownik",
-      "mode": "SSH transport",
-      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
+      "mode": "Transport SSH",
+      "modeHint": "library = klient w procesie; command = systemowy wrapper ssh (używa ~/.ssh/config, agent, ProxyJump)"
     },
     "tabs": {
       "advanced": "Zaawansowane",

--- a/web/src/locales/pl/translation.json
+++ b/web/src/locales/pl/translation.json
@@ -1372,7 +1372,9 @@
       "hostPortHint": "włącza tunel SSH dla całej BD + exec",
       "privateKey": "Ścieżka do klucza prywatnego",
       "privateKeyHint": "ścieżka bezwzględna, puste = autowykrywanie",
-      "user": "Użytkownik"
+      "user": "Użytkownik",
+      "mode": "SSH transport",
+      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
     },
     "tabs": {
       "advanced": "Zaawansowane",

--- a/web/src/locales/pt-BR/translation.json
+++ b/web/src/locales/pt-BR/translation.json
@@ -1352,8 +1352,8 @@
       "privateKey": "Caminho da chave privada",
       "privateKeyHint": "caminho absoluto, em branco = detecção automática",
       "user": "Usuário",
-      "mode": "SSH transport",
-      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
+      "mode": "Transporte SSH",
+      "modeHint": "library = cliente em processo; command = wrapper ssh do SO (usa ~/.ssh/config, agent, ProxyJump)"
     },
     "tabs": {
       "advanced": "Avançado",

--- a/web/src/locales/pt-BR/translation.json
+++ b/web/src/locales/pt-BR/translation.json
@@ -1351,7 +1351,9 @@
       "hostPortHint": "ativa o túnel SSH para todo BD + exec",
       "privateKey": "Caminho da chave privada",
       "privateKeyHint": "caminho absoluto, em branco = detecção automática",
-      "user": "Usuário"
+      "user": "Usuário",
+      "mode": "SSH transport",
+      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
     },
     "tabs": {
       "advanced": "Avançado",

--- a/web/src/locales/ru/translation.json
+++ b/web/src/locales/ru/translation.json
@@ -1372,7 +1372,9 @@
       "hostPortHint": "включает SSH-туннель для всего БД + exec",
       "privateKey": "Путь к приватному ключу",
       "privateKeyHint": "абсолютный путь, пусто = автоопределение",
-      "user": "Пользователь"
+      "user": "Пользователь",
+      "mode": "SSH transport",
+      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
     },
     "tabs": {
       "advanced": "Расширенные",

--- a/web/src/locales/ru/translation.json
+++ b/web/src/locales/ru/translation.json
@@ -1373,8 +1373,8 @@
       "privateKey": "Путь к приватному ключу",
       "privateKeyHint": "абсолютный путь, пусто = автоопределение",
       "user": "Пользователь",
-      "mode": "SSH transport",
-      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
+      "mode": "Транспорт SSH",
+      "modeHint": "library = встроенный клиент; command = обёртка системного ssh (использует ~/.ssh/config, agent, ProxyJump)"
     },
     "tabs": {
       "advanced": "Расширенные",

--- a/web/src/locales/tr/translation.json
+++ b/web/src/locales/tr/translation.json
@@ -1330,7 +1330,9 @@
       "hostPortHint": "tüm DB + exec için SSH tünelini etkinleştirir",
       "privateKey": "Özel anahtar yolu",
       "privateKeyHint": "mutlak yol, boş = otomatik algıla",
-      "user": "Kullanıcı"
+      "user": "Kullanıcı",
+      "mode": "SSH transport",
+      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
     },
     "tabs": {
       "advanced": "Gelişmiş",

--- a/web/src/locales/tr/translation.json
+++ b/web/src/locales/tr/translation.json
@@ -1331,8 +1331,8 @@
       "privateKey": "Özel anahtar yolu",
       "privateKeyHint": "mutlak yol, boş = otomatik algıla",
       "user": "Kullanıcı",
-      "mode": "SSH transport",
-      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
+      "mode": "SSH aktarımı",
+      "modeHint": "library = süreç içi istemci; command = OS ssh sarmalayıcısı (~/.ssh/config, agent, ProxyJump kullanır)"
     },
     "tabs": {
       "advanced": "Gelişmiş",

--- a/web/src/locales/zh-CN/translation.json
+++ b/web/src/locales/zh-CN/translation.json
@@ -1330,7 +1330,9 @@
       "hostPortHint": "为所有数据库和执行启用 SSH 隧道",
       "privateKey": "私钥路径",
       "privateKeyHint": "绝对路径，留空 = 自动检测",
-      "user": "用户"
+      "user": "用户",
+      "mode": "SSH transport",
+      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
     },
     "tabs": {
       "advanced": "高级",

--- a/web/src/locales/zh-CN/translation.json
+++ b/web/src/locales/zh-CN/translation.json
@@ -1331,8 +1331,8 @@
       "privateKey": "私钥路径",
       "privateKeyHint": "绝对路径，留空 = 自动检测",
       "user": "用户",
-      "mode": "SSH transport",
-      "modeHint": "library = in-process client; command = OS ssh wrapper (uses ~/.ssh/config, agent, ProxyJump)"
+      "mode": "SSH 传输",
+      "modeHint": "library = 进程内客户端；command = 操作系统 ssh 包装器（使用 ~/.ssh/config、agent、ProxyJump）"
     },
     "tabs": {
       "advanced": "高级",


### PR DESCRIPTION
## What
Adds an `ssh_mode` (SSH transport) selector to the per-server connection form, plus a backend guard so a blank value on update doesn't wipe a configured transport.

## Why
A server added or edited through the WebUI carried no `ssh_mode`, so `newExecutor` fell back to the `library` transport (in-process `golang.org/x/crypto/ssh`) instead of the `command` OS-ssh wrapper an operator may have configured — the field simply wasn't in the form. Worse, `handleUpdateServerConfig` persisted the blank, so every save reset it. Operators on a setup that relies on the OS ssh client (`~/.ssh/config`, agent, ProxyJump, no in-repo key) had no way to select or keep `command` mode from the UI.

## Changes
- **Frontend**: `SshPanel` gains an `ssh_mode` `FieldSelect` (`library` | `command`, default `library`); `ssh_mode` added to the `AppConfig` type, `EMPTY`, and `PER_SERVER_KEYS` so it round-trips on `GET`/`PUT /api/v1/servers/{id}/config`.
- **Backend**: `preserveServerConnectionFields` keeps a blank `ssh_mode` in the update body from wiping the persisted value (defense for non-UI clients / older builds). Pure-function test + end-to-end handler test.
- **i18n**: `settings.ssh.mode` / `.modeHint` in all 10 locales (en-US/de translated; the others carry the English string pending translation).

## Testing
- `make verify` (incl. `go test -race`) + `make gosec` (0 issues) green
- `pnpm lint` green; `tsc` needs the commercial HeroUI Pro package (pre-existing local blocker, unrelated)
- Live-verified: with `ssh_mode=command` the executor reaches the game hosts through the OS ssh wrapper; a server saved without the field keeps its `command` mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)