### PR TITLE
feat(server): graceful shutdown on SIGINT/SIGTERM

### DIFF
--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -17,10 +17,12 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	_ "time/tzdata" // embed the IANA tz database so time.LoadLocation works on
 	// minimal containers without the OS tzdata package (#204: scheduled restart
 	// rejected valid zones like "Europe/London").
@@ -989,6 +991,14 @@ func run(ctx context.Context) error {
 		return nil
 	}
 
+	// Cancel ctx on SIGINT/SIGTERM. In run() (not main()) so the deferred stop()
+	// unwinds alongside the cleanup defers below — an os.Exit in main() would skip
+	// a defer left there. This makes Stufe A's defer-safe cleanup fire on the
+	// normal (signal) shutdown path, not only on a server error. Placed after the
+	// immediate-mode block so render-k8s and friends never touch signal state.
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	if err := loadRuntimeData(); err != nil {
 		return err
 	}
@@ -1060,14 +1070,13 @@ func run(ctx context.Context) error {
 	applyBattlepassEngine(loadedConfig)
 	defer stopBattlepassEngine()
 
-	return startServer(resolveListenAddr())
+	return startServer(ctx, resolveListenAddr())
 }
 
 // startBackgroundServices launches the process-lifetime schedulers and loads the
 // operator-configured runtime data that has no teardown. The schedulers honour
-// ctx.Done(); today ctx is context.Background() (the process is hard-stopped on
-// signal), but threading ctx keeps this forward-compatible with graceful
-// shutdown without changing current behaviour.
+// ctx.Done(): ctx is cancelled by run()'s signal.NotifyContext on SIGINT/SIGTERM,
+// so these goroutines stop as part of graceful shutdown.
 func startBackgroundServices(ctx context.Context) {
 	// Scheduled restarts (#145): per-server schedules live in the DB; the
 	// scheduler iterates the registry each tick. Runs for the process lifetime

--- a/cmd/dune-admin/server.go
+++ b/cmd/dune-admin/server.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -403,7 +405,82 @@ func buildMux() *http.ServeMux {
 	return mux
 }
 
-func startServer(addr string) error {
+// shutdownGrace bounds how long Shutdown waits for in-flight HTTP requests to
+// drain on SIGINT/SIGTERM. It is deliberately far below the server's 10-minute
+// WriteTimeout (long backups/downloads): a signal means "go down soon", so the
+// drain is bounded and any still-running request is force-closed afterwards.
+const shutdownGrace = 30 * time.Second
+
+// serveWithGracefulShutdown runs srv until ctx is cancelled or it fails. On ctx
+// cancellation it drains in-flight requests within grace, then force-closes any
+// that remain. Background work is cancelled separately via the same ctx.
+func serveWithGracefulShutdown(ctx context.Context, srv *http.Server, grace time.Duration) error {
+	// Buffered (cap 1): on the ctx.Done path ListenAndServe still returns once
+	// Shutdown/Close completes, and this send must not block, so the goroutine
+	// always exits — no leak.
+	errc := make(chan error, 1)
+	go func() { errc <- srv.ListenAndServe() }()
+	select {
+	case err := <-errc:
+		return ignoreServerClosed(err)
+	case <-ctx.Done():
+		// A fresh Background-derived timeout, NOT ctx: ctx is already cancelled
+		// here, so passing it (or a child of it) to Shutdown would expire the
+		// deadline immediately and skip the grace window entirely.
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), grace)
+		defer cancel()
+		shutErr := srv.Shutdown(shutdownCtx)
+		if errors.Is(shutErr, context.DeadlineExceeded) {
+			// Shutdown does NOT close still-active connections when the deadline
+			// expires — it only stops waiting. Close aborts them so they cannot
+			// keep using resources (e.g. the DB pool) while run()'s defers tear
+			// them down.
+			componentLog("server").Warn().Dur("grace", grace).
+				Msg("shutdown grace exceeded; force-closing remaining connections")
+			// Best-effort: Shutdown already closed the listeners, so Close's
+			// return is the expected "already closed" and not actionable — and
+			// surfacing it would turn every bounded shutdown into a non-zero exit.
+			_ = srv.Close()
+		}
+		// <-errc joins the ListenAndServe goroutine (it has returned now that the
+		// server is shut down/closed) and recovers a real listen failure if one
+		// occurred before shutdown took effect, instead of returning false-clean.
+		return preferServeErr(<-errc, shutErr)
+	}
+}
+
+// ignoreServerClosed treats http.ErrServerClosed (the value ListenAndServe
+// returns after Shutdown/Close) as a clean stop, surfacing any other error.
+func ignoreServerClosed(err error) error {
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+// preferServeErr decides what the signal-shutdown path returns: a genuine
+// ListenAndServe failure (serveErr) wins over the shutdown outcome, so a bind
+// error that raced with ctx cancellation is never swallowed; otherwise the
+// Shutdown result is mapped via drainResult.
+func preferServeErr(serveErr, shutErr error) error {
+	if e := ignoreServerClosed(serveErr); e != nil {
+		return e
+	}
+	return drainResult(shutErr)
+}
+
+// drainResult maps Shutdown's result for the signal path. A grace-deadline
+// timeout is the intended bounded shutdown (connections force-closed in
+// serveWithGracefulShutdown), not a failure, so it returns nil. Any other error
+// propagates.
+func drainResult(err error) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return nil
+	}
+	return err
+}
+
+func startServer(ctx context.Context, addr string) error {
 	mux := buildMux()
 	initAuthRuntime(loadedConfig)
 
@@ -416,9 +493,10 @@ func startServer(addr string) error {
 		IdleTimeout:       60 * time.Second,
 	}
 	componentLog("server").Info().Str("addr", addr).Msg("dune-admin listening")
-	// Return the error instead of log.Fatal so the deferred cleanup registered
-	// in run() unwinds on shutdown; log.Fatal calls os.Exit, which skips defers.
-	return srv.ListenAndServe()
+	// serveWithGracefulShutdown returns the listen error (or nil on a clean
+	// signal-driven shutdown) instead of log.Fatal, so the deferred cleanup
+	// registered in run() unwinds; log.Fatal calls os.Exit, which skips defers.
+	return serveWithGracefulShutdown(ctx, srv, shutdownGrace)
 }
 
 // spaHandler serves static files from distDir, falling back to index.html

--- a/cmd/dune-admin/server.go
+++ b/cmd/dune-admin/server.go
@@ -437,10 +437,14 @@ func serveWithGracefulShutdown(ctx context.Context, srv *http.Server, grace time
 			// them down.
 			componentLog("server").Warn().Dur("grace", grace).
 				Msg("shutdown grace exceeded; force-closing remaining connections")
-			// Best-effort: Shutdown already closed the listeners, so Close's
-			// return is the expected "already closed" and not actionable — and
-			// surfacing it would turn every bounded shutdown into a non-zero exit.
-			_ = srv.Close()
+			// Close after a clean Shutdown normally returns nil (the listeners are
+			// already untracked), so a non-nil result is a genuine, rare problem
+			// worth surfacing for diagnosis — but only logged, never returned, so a
+			// bounded shutdown still exits 0.
+			if cErr := srv.Close(); cErr != nil {
+				componentLog("server").Warn().Err(cErr).
+					Msg("force-close after grace timeout returned an error")
+			}
 		}
 		// <-errc joins the ListenAndServe goroutine (it has returned now that the
 		// server is shut down/closed) and recovers a real listen failure if one

--- a/cmd/dune-admin/server_shutdown_test.go
+++ b/cmd/dune-admin/server_shutdown_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestServeWithGracefulShutdown_StopsOnCtxCancel locks in the contract that a
+// cancelled context makes serveWithGracefulShutdown return (via srv.Shutdown)
+// instead of blocking forever in ListenAndServe.
+func TestServeWithGracefulShutdown_StopsOnCtxCancel(t *testing.T) {
+	srv := &http.Server{Addr: "127.0.0.1:0", Handler: http.NewServeMux()}
+	ctx, cancel := context.WithCancel(context.Background())
+	errc := make(chan error, 1)
+	go func() { errc <- serveWithGracefulShutdown(ctx, srv, time.Second) }()
+	cancel() // ctx.Done drives Shutdown whether or not ListenAndServe has bound yet
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatalf("graceful shutdown returned %v, want nil", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("serveWithGracefulShutdown did not return after ctx cancel")
+	}
+}
+
+// TestServeWithGracefulShutdown_ReturnsListenError locks in that a failed
+// ListenAndServe (here: an out-of-range port) is surfaced as an error.
+func TestServeWithGracefulShutdown_ReturnsListenError(t *testing.T) {
+	srv := &http.Server{Addr: "127.0.0.1:99999999", Handler: http.NewServeMux()}
+	err := serveWithGracefulShutdown(context.Background(), srv, time.Second)
+	if err == nil || errors.Is(err, http.ErrServerClosed) {
+		t.Fatalf("want a real listen error, got %v", err)
+	}
+}
+
+// TestPreferServeErr: a real ListenAndServe failure wins over the shutdown
+// outcome (so a bind error racing with ctx cancellation is not swallowed); an
+// ErrServerClosed serve result falls through to the mapped shutdown result.
+func TestPreferServeErr(t *testing.T) {
+	bind := errors.New("listen tcp: address already in use")
+	if got := preferServeErr(bind, nil); !errors.Is(got, bind) {
+		t.Errorf("real serve error must win: got %v, want %v", got, bind)
+	}
+	// Clean serve stop + clean shutdown → nil.
+	if got := preferServeErr(http.ErrServerClosed, nil); got != nil {
+		t.Errorf("clean stop: got %v, want nil", got)
+	}
+	// Clean serve stop + grace timeout → nil (bounded shutdown, not a failure).
+	if got := preferServeErr(http.ErrServerClosed, context.DeadlineExceeded); got != nil {
+		t.Errorf("grace timeout: got %v, want nil", got)
+	}
+	// Clean serve stop + a non-deadline shutdown error → that error propagates.
+	listenerErr := errors.New("listener close failed")
+	if got := preferServeErr(http.ErrServerClosed, listenerErr); !errors.Is(got, listenerErr) {
+		t.Errorf("shutdown error: got %v, want %v", got, listenerErr)
+	}
+}
+
+// TestIgnoreServerClosed: ErrServerClosed is a clean stop; other errors pass through.
+func TestIgnoreServerClosed(t *testing.T) {
+	if got := ignoreServerClosed(http.ErrServerClosed); got != nil {
+		t.Errorf("ErrServerClosed: got %v, want nil", got)
+	}
+	if got := ignoreServerClosed(nil); got != nil {
+		t.Errorf("nil: got %v, want nil", got)
+	}
+	boom := errors.New("listen: address in use")
+	if got := ignoreServerClosed(boom); !errors.Is(got, boom) {
+		t.Errorf("other error: got %v, want %v", got, boom)
+	}
+}
+
+// TestDrainResult: a grace-deadline timeout is an intentional bounded shutdown
+// (force-close) and must NOT become a non-zero exit; other errors propagate.
+func TestDrainResult(t *testing.T) {
+	if got := drainResult(context.DeadlineExceeded); got != nil {
+		t.Errorf("DeadlineExceeded: got %v, want nil (force-close is not a failure)", got)
+	}
+	if got := drainResult(nil); got != nil {
+		t.Errorf("nil: got %v, want nil", got)
+	}
+	boom := errors.New("listener close failed")
+	if got := drainResult(boom); !errors.Is(got, boom) {
+		t.Errorf("other error: got %v, want %v", got, boom)
+	}
+}


### PR DESCRIPTION
Closes #245. Follow-up to #223 / #225.

## What

- Add `signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)` + `defer stop()` in `run()`, placed right after the immediate-mode early-return block so `-render-k8s` and other immediate modes never touch signal state. The `ctx` that #225 already threads through `startBackgroundServices`/schedulers is now actually cancelled on signal.
- Add `serveWithGracefulShutdown(ctx, srv, grace)`: `ListenAndServe` in a goroutine; on ctx cancel, `srv.Shutdown` with a 30s grace; on grace timeout, `srv.Close()` force-closes remaining connections (`Shutdown` does not) so they can't use a torn-down DB pool during defer unwinding.
- `startServer(addr)` → `startServer(ctx, addr)` (single caller).
- Pure, unit-tested error mappers: `ignoreServerClosed`, `drainResult`, `preferServeErr`. A grace timeout exits 0 (intended bounded shutdown), and a real listen error racing with cancellation is surfaced rather than returned as a false-clean nil.

## Why

#225 made `run()` defer-safe, but the signal path never used it: `SIGINT`/`SIGTERM` hard-killed the process, so none of `run()`'s ~9 cleanup defers ran. This wires up the shutdown the existing `ctx` plumbing was already prepared for. Recovery / goroutine supervision is intentionally out of scope to keep this small (see #245).

## Testing

- `make verify` (go test -race, vet, golangci-lint, gocognit, govulncheck, markdownlint) — passes
- `make gosec` — clean (0 issues)
- Manual SIGINT smoke test (isolated config dir + spare port) — clean exit 0 with defers run