### PR TITLE
feat(cli): add -version flag

### DIFF
--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -67,6 +67,7 @@ func resolveAppVersion(ldflagsVersion, workDir string) string {
 // ── config ────────────────────────────────────────────────────────────────────
 
 var (
+	versionMode     bool
 	setupMode       bool
 	setPasswordMode bool
 	cleanMarketMode bool
@@ -542,6 +543,7 @@ func init() {
 	flag.StringVar(&brokerPass, "broker-pass", envOr("BROKER_PASS", ""), "AMQP broker password (required for broker features)")
 	flag.StringVar(&backupDir, "backup-dir", envOr("BACKUP_DIR", ""), "Backup directory path")
 	flag.StringVar(&serverIniDir, "ini-dir", envOr("SERVER_INI_DIR", ""), "Directory containing UserGame.ini / UserOverrides.ini")
+	flag.BoolVar(&versionMode, "version", false, "Print version and exit")
 	flag.BoolVar(&setupMode, "setup", false, "Interactive setup wizard — writes ~/.dune-admin/config.yaml")
 	flag.BoolVar(&setPasswordMode, "set-password", false, "Set the local dashboard login username/password, then exit (auth lockout recovery)")
 	flag.BoolVar(&cleanMarketMode, "clean-market", false, "Delete all bot listings (Revy), then exit")
@@ -793,6 +795,10 @@ func runCleanMarketMode() error {
 }
 
 func runImmediateModes() (handled bool, err error) {
+	if versionMode {
+		fmt.Printf("dune-admin %s (commit %s, built %s)\n", AppVersion, GitCommit, BuildTime)
+		return true, nil
+	}
 	// Explicit -setup flag: reconfigure and exit (don't start server).
 	if setupMode {
 		runSetup()

--- a/cmd/dune-admin/main_run_test.go
+++ b/cmd/dune-admin/main_run_test.go
@@ -40,12 +40,16 @@ func TestRun_VersionModeHandled(t *testing.T) {
 	versionMode = true
 
 	old := os.Stdout
-	r, w, _ := os.Pipe()
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatalf("os.Pipe: %v", pipeErr)
+	}
 	os.Stdout = w
 	handled, err := runImmediateModes()
 	_ = w.Close()
-	os.Stdout = old
+	os.Stdout = old // restore before reading, so later stdout writes are unaffected
 	out, _ := io.ReadAll(r)
+	_ = r.Close()
 
 	if !handled || err != nil {
 		t.Fatalf("version mode: handled=%v err=%v, want true, nil", handled, err)

--- a/cmd/dune-admin/main_run_test.go
+++ b/cmd/dune-admin/main_run_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,6 +28,30 @@ func TestRun_ImmediateModeHandledReturnsNil(t *testing.T) {
 	}
 	if _, err := os.Stat(renderK8SOut); err != nil {
 		t.Fatalf("expected manifest written at %s: %v", renderK8SOut, err)
+	}
+}
+
+// TestRun_VersionModeHandled locks in that -version is an immediate mode: it
+// prints the version to stdout and returns (handled, nil) so run() exits without
+// starting the server / touching the DB.
+func TestRun_VersionModeHandled(t *testing.T) {
+	prev := versionMode
+	t.Cleanup(func() { versionMode = prev })
+	versionMode = true
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	handled, err := runImmediateModes()
+	_ = w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+
+	if !handled || err != nil {
+		t.Fatalf("version mode: handled=%v err=%v, want true, nil", handled, err)
+	}
+	if !strings.Contains(string(out), AppVersion) {
+		t.Fatalf("version output %q does not contain AppVersion %q", out, AppVersion)
 	}
 }
 


### PR DESCRIPTION
## What
- Add a `-version` flag that prints `dune-admin <version> (commit <sha>, built <time>)` and exits.
- Implemented as an immediate mode (checked first in `runImmediateModes`), so it prints and returns without starting the server or touching the DB.

## Why
`AppVersion` / `GitCommit` / `BuildTime` are already stamped at build time but were not printable from the CLI — there was no way to confirm which build is running short of starting the server. This is the standard `--version` operators expect.

## Testing
- New test captures stdout, asserts the printed output contains the version, and that `-version` is handled as an immediate mode.
- `make verify` (race, vet, lint, gocognit, vulncheck, markdownlint) + `make gosec` pass; pre-push hook green.

Example:
```
$ dune-admin -version
dune-admin 0.41.7 (commit 6027049, built 2026-06-18T...Z)
```