### PR TITLE
fix(server): keep GET /servers reachable with a stale X-Dune-Server header

### DIFF
--- a/cmd/dune-admin/server_selector.go
+++ b/cmd/dune-admin/server_selector.go
@@ -26,8 +26,15 @@ func serverSelectorMiddleware(reg *serverRegistry, next http.Handler) http.Handl
 		if id != "" {
 			sc = reg.Get(id)
 			if sc == nil {
-				jsonErr(w, fmt.Errorf("server %q not found", id), http.StatusNotFound)
-				return
+				// The server list is the discovery/recovery endpoint: never gate it
+				// on a (possibly stale) selection, or deleting the currently-selected
+				// server leaves the client unable to re-list and recover. Treat the
+				// stale header as no selection and fall through to the active server.
+				if !isServerListRequest(r) {
+					jsonErr(w, fmt.Errorf("server %q not found", id), http.StatusNotFound)
+					return
+				}
+				sc = reg.Active() // may be nil for empty registry
 			}
 		} else {
 			sc = reg.Active() // may be nil for empty registry
@@ -37,6 +44,13 @@ func serverSelectorMiddleware(reg *serverRegistry, next http.Handler) http.Handl
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// isServerListRequest reports whether r targets the server-list endpoint
+// (GET /api/v1/servers), the discovery/recovery path that must stay reachable
+// even when the X-Dune-Server header names a server that no longer exists.
+func isServerListRequest(r *http.Request) bool {
+	return r.Method == http.MethodGet && r.URL.Path == "/api/v1/servers"
 }
 
 // serverFromCtx retrieves the ServerContext stashed by serverSelectorMiddleware.

--- a/cmd/dune-admin/server_selector.go
+++ b/cmd/dune-admin/server_selector.go
@@ -18,7 +18,9 @@ const serverContextKey contextKey = 1
 // serverSelectorMiddleware reads the optional X-Dune-Server request header and
 // stashes the matching ServerContext in the request context. When the header is
 // absent the active server from reg is used. When the header names an unknown
-// server the request is rejected with 404.
+// server the request is rejected with 404 — except for the server-list endpoint
+// (GET /api/v1/servers, see isServerListRequest), the discovery/recovery path,
+// where an unknown header is treated as no selection and falls back to active.
 func serverSelectorMiddleware(reg *serverRegistry, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := r.Header.Get("X-Dune-Server")

--- a/cmd/dune-admin/server_selector_test.go
+++ b/cmd/dune-admin/server_selector_test.go
@@ -69,6 +69,60 @@ func TestServerSelectorMiddleware_UnknownHeader_Returns404(t *testing.T) {
 	}
 }
 
+// GET /api/v1/servers is the discovery/recovery endpoint. A stale X-Dune-Server
+// header (e.g. after deleting the currently-selected server) must NOT 404 it, or
+// the client can never re-list servers to recover. The header is ignored there
+// and the request falls through to the active server, exactly like no header.
+func TestServerSelectorMiddleware_UnknownHeader_ServerListExempt(t *testing.T) {
+	t.Parallel()
+	reg := newServerRegistry(nil)
+	reg.Register(&ServerContext{ID: "srv-a", StoreScope: 1}) // first → active
+
+	probe := &probeHandler{}
+	h := serverSelectorMiddleware(reg, probe)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/servers", nil)
+	req.Header.Set("X-Dune-Server", "does-not-exist")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (list must stay reachable with a stale header)", rr.Code)
+	}
+	if !probe.called {
+		t.Fatal("inner handler not called — list endpoint must pass through")
+	}
+	if probe.gotCtx == nil || probe.gotCtx.ID != "srv-a" {
+		t.Errorf("serverFromCtx = %v, want active srv-a (stale header treated as no selection)", probe.gotCtx)
+	}
+}
+
+// The exemption is scoped to the list endpoint only: a stale header on any other
+// route must still 404 so a scoped data request never silently serves the wrong
+// server's data. (A non-list path with the same stale header stays strict.)
+func TestServerSelectorMiddleware_UnknownHeader_NonListStillStrict(t *testing.T) {
+	t.Parallel()
+	reg := newServerRegistry(nil)
+	reg.Register(&ServerContext{ID: "srv-a", StoreScope: 1})
+
+	probe := &probeHandler{}
+	h := serverSelectorMiddleware(reg, probe)
+
+	// POST /api/v1/servers (add) and GET /api/v1/servers/health are NOT the list
+	// endpoint, so a stale header must still be rejected.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/servers/health", nil)
+	req.Header.Set("X-Dune-Server", "does-not-exist")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (only the list endpoint is exempt)", rr.Code)
+	}
+	if probe.called {
+		t.Error("inner handler must not be called for a stale header on a scoped route")
+	}
+}
+
 func TestServerSelectorMiddleware_NoHeader_FallsBackToActive(t *testing.T) {
 	t.Parallel()
 	reg := newServerRegistry(nil)


### PR DESCRIPTION
Fixes #252.

## Problem

`serverSelectorMiddleware` wraps the whole mux and returns **404** for any request
whose `X-Dune-Server` header names a no-longer-registered server. That also gated
`GET /api/v1/servers` — the discovery/recovery endpoint a client uses to learn which
servers exist.

So deleting the **currently-selected** server made the SPA's post-delete
`refresh()` → `GET /servers` go out with the now-stale header → 404 →
`.catch(() => [])` swallowed it to an empty list → the SPA dropped to the Setup
Wizard, as if every server was gone. A page reload recovered (the frontend self-heal
had cleared the stale id by then). Backend/DB were always correct; only the immediate
client view broke.

Reproduced against a running instance:
```
GET /api/v1/servers  -H 'X-Dune-Server: <deleted-id>'  ->  404
GET /api/v1/servers  (no header)                       ->  200 [...]
```

## Fix

Exempt the server-list endpoint from the strict rejection: a stale selection header is
treated as "no selection" there and falls through to the active server, exactly like no
header. The 404 stays for every scoped data route (`/servers/{id}`, `/servers/{id}/config`,
and all other paths) so a stale header never silently serves the wrong server's data.

Backend-only — no frontend change required; this restores the recovery loop for all
clients (dev `:5173` and the embedded SPA `:8080`). An optional frontend belt (clearing
the stale id before the refetch) is described in #252 but not needed for the fix.

## Tests

- `TestServerSelectorMiddleware_UnknownHeader_ServerListExempt` — stale header on
  `GET /api/v1/servers` returns 200 and falls back to the active server.
- `TestServerSelectorMiddleware_UnknownHeader_NonListStillStrict` — stale header on a
  scoped route still 404s.
- Existing `..._UnknownHeader_Returns404` and the known/no-header/empty-registry cases
  unchanged.

`make verify` (vet, golangci-lint, govulncheck, markdownlint, gocognit, test-race) and
`make gosec` both green.