### PR TITLE
Fix journey/tag/progression writes failing with "account_id does not exist" (42703) on current-build servers

### DIFF
--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -1897,13 +1897,19 @@ func cmdDeleteCharacter(pool *pgxpool.Pool, accountID int64, reason string) Cmd 
 	}
 }
 
-func cmdGetPlayerTags(pool *pgxpool.Pool, accountID int64) Cmd {
+func cmdGetPlayerTags(pool *pgxpool.Pool, actorID int64) Cmd {
 	return func() Msg {
 		if pool == nil {
 			return msgTags{err: fmt.Errorf("not connected")}
 		}
-		rows, err := pool.Query(context.Background(),
-			`SELECT tag FROM dune.player_tags WHERE account_id=$1 ORDER BY tag`, accountID)
+		ctx := context.Background()
+		keyCol, keyVal, err := playerKeyFor(ctx, pool, "player_tags", actorID)
+		if err != nil {
+			return msgTags{err: err}
+		}
+		// #nosec G201 -- keyCol is a fixed internal allowlist (character_id|account_id)
+		rows, err := pool.Query(ctx,
+			fmt.Sprintf(`SELECT tag FROM dune.player_tags WHERE %s = $1 ORDER BY tag`, keyCol), keyVal)
 		if err != nil {
 			return msgTags{err: err}
 		}
@@ -1923,25 +1929,17 @@ func cmdGetPlayerTags(pool *pgxpool.Pool, accountID int64) Cmd {
 	}
 }
 
-func cmdUpdatePlayerTags(pool *pgxpool.Pool, accountID int64, add []string, remove []string) Cmd {
+func cmdUpdatePlayerTags(pool *pgxpool.Pool, actorID int64, add []string, remove []string) Cmd {
 	return func() Msg {
 		if pool == nil {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
-		var addArg, removeArg interface{}
-		if len(add) > 0 {
-			addArg = add
-		} else {
-			addArg = []string{}
-		}
-		if len(remove) > 0 {
-			removeArg = remove
-		} else {
-			removeArg = []string{}
-		}
-		_, err := pool.Exec(context.Background(),
-			`SELECT dune.update_player_tags($1, $2::text[], $3::text[])`, accountID, addArg, removeArg)
+		ctx := context.Background()
+		keyCol, keyVal, err := playerKeyFor(ctx, pool, "player_tags", actorID)
 		if err != nil {
+			return msgMutate{err: err}
+		}
+		if err := upsertPlayerTags(ctx, pool, keyCol, keyVal, add, remove); err != nil {
 			return msgMutate{err: fmt.Errorf("update player tags: %w", err)}
 		}
 		return msgMutate{ok: "Tags updated"}
@@ -2823,14 +2821,153 @@ func cmdSearchColumns(pool *pgxpool.Pool, term string) Cmd {
 	}
 }
 
+// ── per-character table key (issue #267) ─────────────────────────────────────
+//
+// Current Dune servers migrated several per-player tables (journey_story_node,
+// player_tags) from an account_id key to a character_id key, where
+// character_id == dune.actors.id. dune-admin addresses these tables by the
+// operator-selected character (actor), so we thread the actor id and pick the
+// live key column at runtime. Legacy servers that still key by account_id keep
+// working by resolving the character's owner account id on demand.
+
+const (
+	playerKeyCharacterID = "character_id" // current schema
+	playerKeyAccountID   = "account_id"   // legacy schema
+)
+
+// pgExecutor is the subset of pgxpool.Pool / pgx.Tx used by the schema-aware
+// player-table writers, so they work inside a transaction or directly.
+type pgExecutor interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+var (
+	playerKeyColMu    sync.RWMutex
+	playerKeyColCache = map[string]string{} // dune table name -> key column
+)
+
+// playerKeyColumnFromProbe maps "does this table have a character_id column?"
+// to the key column to use. Pure, for testability.
+func playerKeyColumnFromProbe(hasCharacterID bool) string {
+	if hasCharacterID {
+		return playerKeyCharacterID
+	}
+	return playerKeyAccountID
+}
+
+// selectPlayerKey picks the (column, value) pair to address a per-character
+// table for a given character, given the live key column. Pure, so the
+// account_id -> character_id branching is unit-testable without a database.
+func selectPlayerKey(liveColumn string, actorID, accountID int64) (string, int64) {
+	if liveColumn == playerKeyCharacterID {
+		return playerKeyCharacterID, actorID
+	}
+	return playerKeyAccountID, accountID
+}
+
+// playerRef identifies one character for game-DB writes that span both the
+// migrated per-character tables (keyed by actor id on current servers) and
+// account-level tables such as player_state (always keyed by account id).
+// Resolve once via newPlayerRef so a single operation re-uses both ids.
+type playerRef struct {
+	actorID   int64 // dune.actors.id — the operator-selected character
+	accountID int64 // dune.actors.owner_account_id
+}
+
+func newPlayerRef(ctx context.Context, pool *pgxpool.Pool, actorID int64) (playerRef, error) {
+	accountID, err := resolveProgressionAccountID(ctx, pool, actorID)
+	if err != nil {
+		return playerRef{}, err
+	}
+	return playerRef{actorID: actorID, accountID: accountID}, nil
+}
+
+// keyFor returns the (column, value) addressing dune.<table> for this character
+// on the live schema, without re-resolving the owner account id.
+func (p playerRef) keyFor(ctx context.Context, pool *pgxpool.Pool, table string) (string, int64) {
+	col := playerKeyColumn(ctx, pool, table)
+	return selectPlayerKey(col, p.actorID, p.accountID)
+}
+
+// playerKeyColumn reports which key column dune.<table> uses on the connected
+// server: "character_id" on current servers, "account_id" on legacy ones.
+// Probed once per table via information_schema and cached. On probe error it
+// assumes the current schema and does not cache, so a later call can re-probe.
+func playerKeyColumn(ctx context.Context, pool *pgxpool.Pool, table string) string {
+	playerKeyColMu.RLock()
+	col, ok := playerKeyColCache[table]
+	playerKeyColMu.RUnlock()
+	if ok {
+		return col
+	}
+
+	var hasCharacterID bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_schema = $1::text
+			  AND table_name   = $2::text
+			  AND column_name  = 'character_id'
+		)`, dbSchema, table).Scan(&hasCharacterID); err != nil {
+		// Probe failed — assume the current schema rather than risk silently
+		// reintroducing the account_id bug; don't cache the guess.
+		return playerKeyCharacterID
+	}
+
+	col = playerKeyColumnFromProbe(hasCharacterID)
+	playerKeyColMu.Lock()
+	playerKeyColCache[table] = col
+	playerKeyColMu.Unlock()
+	return col
+}
+
+// playerKeyFor returns the key column and bound value to address dune.<table>
+// for the operator-selected character `actorID` on the live schema. The owner
+// account id is resolved only when the server still uses the legacy key.
+func playerKeyFor(ctx context.Context, pool *pgxpool.Pool, table string, actorID int64) (string, int64, error) {
+	col := playerKeyColumn(ctx, pool, table)
+	accountID := int64(0)
+	if col != playerKeyCharacterID {
+		var err error
+		if accountID, err = resolveProgressionAccountID(ctx, pool, actorID); err != nil {
+			return "", 0, err
+		}
+	}
+	keyCol, keyVal := selectPlayerKey(col, actorID, accountID)
+	return keyCol, keyVal, nil
+}
+
+// upsertPlayerTags adds and/or removes player_tags for a character, replacing
+// the legacy dune.update_player_tags proc — which is account_id-keyed and so is
+// absent/renamed on migrated servers (issue #267). The caller passes the
+// resolved key from playerKeyFor.
+func upsertPlayerTags(ctx context.Context, db pgExecutor, keyCol string, keyVal int64, add, remove []string) error {
+	if len(add) > 0 {
+		// #nosec G201 -- keyCol is a fixed internal allowlist (character_id|account_id), never user input
+		q := fmt.Sprintf(`INSERT INTO dune.player_tags (%s, tag)
+			SELECT $1, unnest($2::text[]) ON CONFLICT DO NOTHING`, keyCol)
+		if _, err := db.Exec(ctx, q, keyVal, add); err != nil {
+			return fmt.Errorf("add tags: %w", err)
+		}
+	}
+	if len(remove) > 0 {
+		// #nosec G201 -- keyCol is a fixed internal allowlist (character_id|account_id), never user input
+		q := fmt.Sprintf(`DELETE FROM dune.player_tags WHERE %s = $1 AND tag = ANY($2::text[])`, keyCol)
+		if _, err := db.Exec(ctx, q, keyVal, remove); err != nil {
+			return fmt.Errorf("remove tags: %w", err)
+		}
+	}
+	return nil
+}
+
 // ── journey / progression commands ───────────────────────────────────────────
 
-func cmdFetchJourneyNodes(pool *pgxpool.Pool, scope string, accountID int64) Cmd {
+func cmdFetchJourneyNodes(pool *pgxpool.Pool, scope string, actorID int64) Cmd {
 	return func() Msg {
 		if pool == nil {
 			return msgJourney{err: fmt.Errorf("not connected")}
 		}
-		key := journeyCacheKey(scope, accountID)
+		key := journeyCacheKey(scope, actorID)
 
 		// Cache hit?
 		journeyCacheMu.RLock()
@@ -2840,14 +2977,20 @@ func cmdFetchJourneyNodes(pool *pgxpool.Pool, scope string, accountID int64) Cmd
 			return msgJourney{rows: entry.nodes}
 		}
 
-		rows, err := pool.Query(context.Background(), `
+		ctx := context.Background()
+		keyCol, keyVal, err := playerKeyFor(ctx, pool, "journey_story_node", actorID)
+		if err != nil {
+			return msgJourney{err: err}
+		}
+		// #nosec G201 -- keyCol is a fixed internal allowlist (character_id|account_id)
+		rows, err := pool.Query(ctx, fmt.Sprintf(`
 			SELECT story_node_id,
 			       (complete_condition_state = 'true'::jsonb) AS is_complete,
 			       (reveal_condition_state   = 'true'::jsonb) AS is_revealed,
 			       has_pending_reward
 			FROM dune.journey_story_node
-			WHERE account_id = $1
-			ORDER BY story_node_id`, accountID)
+			WHERE %s = $1
+			ORDER BY story_node_id`, keyCol), keyVal)
 		if err != nil {
 			return msgJourney{err: err}
 		}
@@ -2954,37 +3097,44 @@ func factionIDByName(name string) int16 {
 	return 0
 }
 
-func cmdCompleteJourneyNode(pool *pgxpool.Pool, accountID int64, nodeID string) Cmd {
+func cmdCompleteJourneyNode(pool *pgxpool.Pool, actorID int64, nodeID string) Cmd {
 	return func() Msg {
 		if pool == nil {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
 		ctx := context.Background()
+		ref, err := newPlayerRef(ctx, pool, actorID)
+		if err != nil {
+			return msgMutate{err: err}
+		}
+		keyCol, keyVal := ref.keyFor(ctx, pool, "journey_story_node")
 		// Complete the node itself plus all child nodes (nodeID + ".anything").
 		// The game checks sub-nodes to determine quest completion state.
-		res, err := pool.Exec(ctx, `
+		// #nosec G201 -- keyCol is a fixed internal allowlist (character_id|account_id)
+		res, err := pool.Exec(ctx, fmt.Sprintf(`
 			UPDATE dune.journey_story_node
 			SET complete_condition_state = 'true'::jsonb,
 			    reveal_condition_state   = 'true'::jsonb
-			WHERE account_id = $1
-			  AND (story_node_id = $2 OR story_node_id LIKE $2 || '.%')`,
-			accountID, nodeID)
+			WHERE %s = $1
+			  AND (story_node_id = $2 OR story_node_id LIKE $2 || '.%%')`, keyCol),
+			keyVal, nodeID)
 		if err != nil {
 			return msgMutate{err: fmt.Errorf("complete node: %w", err)}
 		}
 		updated := res.RowsAffected()
 		if updated == 0 {
 			// Node doesn't exist yet — insert it.
-			_, err = pool.Exec(ctx, `
+			// #nosec G201 -- keyCol is a fixed internal allowlist (character_id|account_id)
+			_, err = pool.Exec(ctx, fmt.Sprintf(`
 				INSERT INTO dune.journey_story_node
-					(account_id, story_node_id, has_pending_reward,
+					(%s, story_node_id, has_pending_reward,
 					 complete_condition_state, reveal_condition_state,
 					 fail_condition_state, metadata_state, reset_group)
 				VALUES ($1, $2, false,
 					'true'::jsonb, 'true'::jsonb,
 					'{}'::jsonb, '{}'::jsonb,
-					'Default'::dune.JourneyStoryResetGroup)`,
-				accountID, nodeID)
+					'Default'::dune.JourneyStoryResetGroup)`, keyCol),
+				keyVal, nodeID)
 			if err != nil {
 				return msgMutate{err: fmt.Errorf("insert node: %w", err)}
 			}
@@ -2997,12 +3147,12 @@ func cmdCompleteJourneyNode(pool *pgxpool.Pool, accountID int64, nodeID string) 
 		// written — which is why journey-only completion historically did not
 		// "stick" without login/logout cycles.
 		appliedTags := tagsForJourneyNodeSubtree(nodeID)
-		extra, err := applyTagsWithTierBump(ctx, pool, accountID, appliedTags)
+		extra, err := applyTagsWithTierBump(ctx, pool, ref, appliedTags)
 		if err != nil {
 			return msgMutate{err: err}
 		}
 
-		svExtra, svErr := maybeGrantSpiceVision(ctx, pool, accountID, nodeID)
+		svExtra, svErr := maybeGrantSpiceVision(ctx, pool, ref.accountID, nodeID)
 		if svErr != nil {
 			return msgMutate{err: svErr}
 		}
@@ -3012,19 +3162,18 @@ func cmdCompleteJourneyNode(pool *pgxpool.Pool, accountID int64, nodeID string) 
 	}
 }
 
-// applyTagsWithTierBump writes `tags` via dune.update_player_tags and, for any
+// applyTagsWithTierBump writes `tags` into dune.player_tags and, for any
 // Faction.<X>.Tier<N> (N ∈ 0–5) it sees, also raises that faction's rep + the
 // FactionPlayerComponent ReputationAmount on the controller actor so the
 // in-game rank UI reflects the promotion. Never lowers existing rep.
 // Returns a short " , +K tag(s), bumped rep for N faction(s)" fragment for
 // inclusion in the caller's success message (empty when no tags applied).
-func applyTagsWithTierBump(ctx context.Context, pool *pgxpool.Pool, accountID int64, tags []string) (string, error) {
+func applyTagsWithTierBump(ctx context.Context, pool *pgxpool.Pool, ref playerRef, tags []string) (string, error) {
 	if len(tags) == 0 {
 		return "", nil
 	}
-	if _, err := pool.Exec(ctx,
-		`SELECT dune.update_player_tags($1, $2::text[], '{}'::text[])`,
-		accountID, tags); err != nil {
+	keyCol, keyVal := ref.keyFor(ctx, pool, "player_tags")
+	if err := upsertPlayerTags(ctx, pool, keyCol, keyVal, tags, nil); err != nil {
 		return "", fmt.Errorf("apply tags: %w", err)
 	}
 
@@ -3038,7 +3187,7 @@ func applyTagsWithTierBump(ctx context.Context, pool *pgxpool.Pool, accountID in
 	var controllerID int64
 	_ = pool.QueryRow(ctx, `
 		SELECT player_controller_id FROM dune.player_state
-		WHERE account_id = $1 LIMIT 1`, accountID).Scan(&controllerID)
+		WHERE account_id = $1 LIMIT 1`, ref.accountID).Scan(&controllerID)
 	if controllerID == 0 {
 		// Fresh character without a player_state row — can't bump rep yet.
 		// Tags landed, the rep side effect will have to wait until the
@@ -3095,8 +3244,8 @@ func resolveContractTags(contractID string) (string, []string, error) {
 }
 
 // cmdCompleteContract applies the AddedFlagsOnCompletion tags for one contract.
-func cmdCompleteContract(pool *pgxpool.Pool, accountID int64, contractID string) Cmd {
-	return cmdCompleteContracts(pool, accountID, []string{contractID})
+func cmdCompleteContract(pool *pgxpool.Pool, actorID int64, contractID string) Cmd {
+	return cmdCompleteContracts(pool, actorID, []string{contractID})
 }
 
 // cmdCompleteContracts applies the union of AddedFlagsOnCompletion across
@@ -3104,12 +3253,12 @@ func cmdCompleteContract(pool *pgxpool.Pool, accountID int64, contractID string)
 // pass, plus any SkillsKeyRewards skill-block unlocks. Unknown contracts
 // cause the whole batch to fail before any write so the operation is
 // all-or-nothing.
-func cmdCompleteContracts(pool *pgxpool.Pool, accountID int64, contractIDs []string) Cmd {
+func cmdCompleteContracts(pool *pgxpool.Pool, actorID int64, contractIDs []string) Cmd {
 	return func() Msg {
 		if pool == nil {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
-		if err := validateContractMutationInput(accountID, contractIDs); err != nil {
+		if err := validateContractMutationInput(actorID, contractIDs); err != nil {
 			return msgMutate{err: err}
 		}
 
@@ -3119,12 +3268,18 @@ func cmdCompleteContracts(pool *pgxpool.Pool, accountID int64, contractIDs []str
 		}
 
 		ctx := context.Background()
-		extra, err := applyTagsWithTierBump(ctx, pool, accountID, set.removeTags)
+		ref, err := newPlayerRef(ctx, pool, actorID)
+		if err != nil {
+			return msgMutate{err: err}
+		}
+		extra, err := applyTagsWithTierBump(ctx, pool, ref, set.removeTags)
 		if err != nil {
 			return msgMutate{err: err}
 		}
 
-		grantedExtra, err := applyContractSkillGrants(ctx, pool, accountID, set.removeSkills)
+		// Skill grants and contract-item dismissal target account-level tables,
+		// which were not part of the account_id -> character_id migration.
+		grantedExtra, err := applyContractSkillGrants(ctx, pool, ref.accountID, set.removeSkills)
 		if err != nil {
 			return msgMutate{err: err}
 		}
@@ -3135,7 +3290,7 @@ func cmdCompleteContracts(pool *pgxpool.Pool, accountID int64, contractIDs []str
 		// force-completed. ContractName.Name uses the short alias form
 		// (no DA_CT_ prefix).
 		shortNames := contractShortNames(set.resolvedNames)
-		dismissedExtra, err := dismissActiveContracts(ctx, pool, accountID, shortNames)
+		dismissedExtra, err := dismissActiveContracts(ctx, pool, ref.accountID, shortNames)
 		if err != nil {
 			return msgMutate{err: err}
 		}
@@ -3146,9 +3301,9 @@ func cmdCompleteContracts(pool *pgxpool.Pool, accountID int64, contractIDs []str
 	}
 }
 
-func validateContractMutationInput(accountID int64, contractIDs []string) error {
-	if accountID == 0 {
-		return fmt.Errorf("account ID required")
+func validateContractMutationInput(actorID int64, contractIDs []string) error {
+	if actorID == 0 {
+		return fmt.Errorf("player ID required")
 	}
 	if len(contractIDs) == 0 {
 		return fmt.Errorf("at least one contract required")
@@ -3211,13 +3366,12 @@ func contractShortNames(resolvedNames []string) []string {
 	return shortNames
 }
 
-func removeContractTags(ctx context.Context, pool *pgxpool.Pool, accountID int64, removeTags []string) error {
+func removeContractTags(ctx context.Context, pool *pgxpool.Pool, ref playerRef, removeTags []string) error {
 	if len(removeTags) == 0 {
 		return nil
 	}
-	if _, err := pool.Exec(ctx,
-		`SELECT dune.update_player_tags($1, '{}'::text[], $2::text[])`,
-		accountID, removeTags); err != nil {
+	keyCol, keyVal := ref.keyFor(ctx, pool, "player_tags")
+	if err := upsertPlayerTags(ctx, pool, keyCol, keyVal, nil, removeTags); err != nil {
 		return fmt.Errorf("remove tags: %w", err)
 	}
 	return nil
@@ -3277,12 +3431,12 @@ func contractBatchSummary(resolvedNames []string) string {
 // Skills.Key.* ModuleData entries that cmdCompleteContracts wrote. Skill blocks
 // are only removed when SkillPointsSpent <= 1 — branches the player genuinely
 // levelled beyond the admin grant are left intact.
-func cmdReverseContracts(pool *pgxpool.Pool, accountID int64, contractIDs []string) Cmd {
+func cmdReverseContracts(pool *pgxpool.Pool, actorID int64, contractIDs []string) Cmd {
 	return func() Msg {
 		if pool == nil {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
-		if err := validateContractMutationInput(accountID, contractIDs); err != nil {
+		if err := validateContractMutationInput(actorID, contractIDs); err != nil {
 			return msgMutate{err: err}
 		}
 
@@ -3292,11 +3446,15 @@ func cmdReverseContracts(pool *pgxpool.Pool, accountID int64, contractIDs []stri
 		}
 
 		ctx := context.Background()
-		if err := removeContractTags(ctx, pool, accountID, set.removeTags); err != nil {
+		ref, err := newPlayerRef(ctx, pool, actorID)
+		if err != nil {
+			return msgMutate{err: err}
+		}
+		if err := removeContractTags(ctx, pool, ref, set.removeTags); err != nil {
 			return msgMutate{err: err}
 		}
 
-		pawnID := loadContractPawnID(ctx, pool, accountID)
+		pawnID := loadContractPawnID(ctx, pool, ref.accountID)
 		stripped, err := stripContractSkillBlocks(ctx, pool, pawnID, set.removeSkills)
 		if err != nil {
 			return msgMutate{err: err}
@@ -3723,31 +3881,36 @@ func allJourneyTags() []string {
 	return out
 }
 
-func cmdResetJourneyNode(pool *pgxpool.Pool, accountID int64, nodeID string) Cmd {
+func cmdResetJourneyNode(pool *pgxpool.Pool, actorID int64, nodeID string) Cmd {
 	return func() Msg {
 		if pool == nil {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
 		ctx := context.Background()
-		_, err := pool.Exec(ctx, `
+		ref, err := newPlayerRef(ctx, pool, actorID)
+		if err != nil {
+			return msgMutate{err: err}
+		}
+		jCol, jVal := ref.keyFor(ctx, pool, "journey_story_node")
+		// #nosec G201 -- jCol is a fixed internal allowlist (character_id|account_id)
+		_, err = pool.Exec(ctx, fmt.Sprintf(`
 			UPDATE dune.journey_story_node
 			SET complete_condition_state = 'false'::jsonb,
 			    has_pending_reward       = false
-			WHERE account_id = $1
-			  AND (story_node_id = $2 OR story_node_id LIKE $2 || '.%')`,
-			accountID, nodeID)
+			WHERE %s = $1
+			  AND (story_node_id = $2 OR story_node_id LIKE $2 || '.%%')`, jCol),
+			jVal, nodeID)
 		if err != nil {
 			return msgMutate{err: fmt.Errorf("reset node: %w", err)}
 		}
 
 		// Also strip any tags this node + its descendants would have emitted
-		// on completion. The proc accepts (add, remove) text[] pairs.
+		// on completion.
 		removeTags := tagsForJourneyNodeSubtree(nodeID)
 		extra := ""
 		if len(removeTags) > 0 {
-			if _, err = pool.Exec(ctx,
-				`SELECT dune.update_player_tags($1, '{}'::text[], $2::text[])`,
-				accountID, removeTags); err != nil {
+			tCol, tVal := ref.keyFor(ctx, pool, "player_tags")
+			if err = upsertPlayerTags(ctx, pool, tCol, tVal, nil, removeTags); err != nil {
 				return msgMutate{err: fmt.Errorf("remove node tags: %w", err)}
 			}
 			extra = fmt.Sprintf(", removed %d tag(s)", len(removeTags))
@@ -3756,15 +3919,22 @@ func cmdResetJourneyNode(pool *pgxpool.Pool, accountID int64, nodeID string) Cmd
 	}
 }
 
-func cmdWipeJourneyNodes(pool *pgxpool.Pool, accountID int64) Cmd {
+func cmdWipeJourneyNodes(pool *pgxpool.Pool, actorID int64) Cmd {
 	return func() Msg {
 		if pool == nil {
 			return msgMutate{err: fmt.Errorf("not connected")}
 		}
 		ctx := context.Background()
-		_, err := pool.Exec(ctx,
-			`SELECT dune.delete_all_journey_story_nodes($1)`, accountID)
+		ref, err := newPlayerRef(ctx, pool, actorID)
 		if err != nil {
+			return msgMutate{err: err}
+		}
+		jCol, jVal := ref.keyFor(ctx, pool, "journey_story_node")
+		// Replaces the legacy dune.delete_all_journey_story_nodes proc, which is
+		// account_id-keyed and absent/renamed on migrated servers (issue #267).
+		// #nosec G201 -- jCol is a fixed internal allowlist (character_id|account_id)
+		if _, err = pool.Exec(ctx,
+			fmt.Sprintf(`DELETE FROM dune.journey_story_node WHERE %s = $1`, jCol), jVal); err != nil {
 			return msgMutate{err: fmt.Errorf("wipe journey: %w", err)}
 		}
 
@@ -3773,14 +3943,13 @@ func cmdWipeJourneyNodes(pool *pgxpool.Pool, accountID int64) Cmd {
 		removeTags := allJourneyTags()
 		extra := ""
 		if len(removeTags) > 0 {
-			if _, err = pool.Exec(ctx,
-				`SELECT dune.update_player_tags($1, '{}'::text[], $2::text[])`,
-				accountID, removeTags); err != nil {
+			tCol, tVal := ref.keyFor(ctx, pool, "player_tags")
+			if err = upsertPlayerTags(ctx, pool, tCol, tVal, nil, removeTags); err != nil {
 				return msgMutate{err: fmt.Errorf("remove journey tags: %w", err)}
 			}
 			extra = fmt.Sprintf(", removed %d journey tag(s)", len(removeTags))
 		}
-		return msgMutate{ok: fmt.Sprintf("Wiped all journey nodes for account %d%s", accountID, extra)}
+		return msgMutate{ok: fmt.Sprintf("Wiped all journey nodes for player %d%s", ref.actorID, extra)}
 	}
 }
 
@@ -4037,7 +4206,8 @@ func resolveProgressionUnlockPlayer(ctx context.Context, pool *pgxpool.Pool, act
 func applyProgressionUnlock(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	accountID, controllerID int64,
+	ref playerRef,
+	controllerID int64,
 	flsID string,
 	factionID int16,
 	targetTier int,
@@ -4049,6 +4219,11 @@ func applyProgressionUnlock(
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
+	// NOTE(issue #267): this still routes through the game's own
+	// complete_journey_story_nodes_for_player proc (keyed by FLS/Funcom id).
+	// If a migrated server's copy of that proc fails, this needs an inline
+	// character_id-keyed upsert like the other journey writes — tracked as a
+	// follow-up; the operator journey/tag paths are the reported regressions.
 	if _, err = tx.Exec(ctx,
 		`SELECT dune.complete_journey_story_nodes_for_player($1, $2::text[])`,
 		flsID, journeyNodes); err != nil {
@@ -4065,8 +4240,8 @@ func applyProgressionUnlock(
 		return fmt.Errorf("change_player_faction: %w", err)
 	}
 
-	if _, err = tx.Exec(ctx,
-		`SELECT dune.update_player_tags($1, $2::text[], '{}'::text[])`, accountID, allTags); err != nil {
+	tCol, tVal := ref.keyFor(ctx, pool, "player_tags")
+	if err = upsertPlayerTags(ctx, tx, tCol, tVal, allTags, nil); err != nil {
 		return fmt.Errorf("update player tags: %w", err)
 	}
 
@@ -4128,26 +4303,27 @@ func progressionReverseTags(baseTags, nodes []string) []string {
 	return allTags
 }
 
-func applyProgressionReverse(ctx context.Context, pool *pgxpool.Pool, accountID int64, allTags, nodes []string) (int64, error) {
+func applyProgressionReverse(ctx context.Context, pool *pgxpool.Pool, ref playerRef, allTags, nodes []string) (int64, error) {
 	tx, err := pool.Begin(ctx)
 	if err != nil {
 		return 0, err
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	if _, err = tx.Exec(ctx,
-		`SELECT dune.update_player_tags($1, '{}'::text[], $2::text[])`,
-		accountID, allTags); err != nil {
+	tCol, tVal := ref.keyFor(ctx, pool, "player_tags")
+	if err = upsertPlayerTags(ctx, tx, tCol, tVal, nil, allTags); err != nil {
 		return 0, fmt.Errorf("remove tags: %w", err)
 	}
 
-	result, err := tx.Exec(ctx, `
+	jCol, jVal := ref.keyFor(ctx, pool, "journey_story_node")
+	// #nosec G201 -- jCol is a fixed internal allowlist (character_id|account_id)
+	result, err := tx.Exec(ctx, fmt.Sprintf(`
 		UPDATE dune.journey_story_node
 		SET complete_condition_state = 'false'::jsonb,
 		    has_pending_reward       = false
-		WHERE account_id = $1
-		  AND story_node_id = ANY($2::text[])`,
-		accountID, nodes)
+		WHERE %s = $1
+		  AND story_node_id = ANY($2::text[])`, jCol),
+		jVal, nodes)
 	if err != nil {
 		return 0, fmt.Errorf("reset journey nodes: %w", err)
 	}
@@ -4194,11 +4370,12 @@ func cmdProgressionUnlock(pool *pgxpool.Pool, actorID int64, faction, preset str
 		if err != nil {
 			return msgMutate{err: err}
 		}
+		ref := playerRef{actorID: actorID, accountID: accountID}
 
 		if err := applyProgressionUnlock(
 			ctx,
 			pool,
-			accountID,
+			ref,
 			controllerID,
 			flsID,
 			cfg.factionID,
@@ -4240,7 +4417,7 @@ func cmdReverseProgressionUnlock(pool *pgxpool.Pool, actorID int64, faction, pre
 		}
 
 		ctx := context.Background()
-		accountID, err := resolveProgressionAccountID(ctx, pool, actorID)
+		ref, err := newPlayerRef(ctx, pool, actorID)
 		if err != nil {
 			return msgMutate{err: err}
 		}
@@ -4249,7 +4426,7 @@ func cmdReverseProgressionUnlock(pool *pgxpool.Pool, actorID int64, faction, pre
 		baseTags := progressionUnlockTags(cfg, targetTier)
 		allTags := progressionReverseTags(baseTags, nodes)
 
-		resetNodes, err := applyProgressionReverse(ctx, pool, accountID, allTags, nodes)
+		resetNodes, err := applyProgressionReverse(ctx, pool, ref, allTags, nodes)
 		if err != nil {
 			return msgMutate{err: err}
 		}
@@ -6564,6 +6741,11 @@ func cmdFetchCharacterLevel(ctx context.Context, pool *pgxpool.Pool, accountID i
 
 // cmdFetchPlayerTagsForAccount is the injectable (ctx+pool) form of
 // cmdGetPlayerTags, used by the events engine dependency injection.
+//
+// NOTE(issue #267): this still reads dune.player_tags by account_id and so will
+// fail on servers migrated to character_id. The events/battlepass engines poll
+// per account, so migrating them needs per-character semantics — tracked as a
+// follow-up separate from the operator-facing journey/tag write fixes.
 func cmdFetchPlayerTagsForAccount(ctx context.Context, pool *pgxpool.Pool, accountID int64) ([]string, error) {
 	rows, err := pool.Query(ctx,
 		`SELECT tag FROM dune.player_tags WHERE account_id = $1 ORDER BY tag`, accountID)
@@ -6620,6 +6802,9 @@ func cmdFetchBattlepassPlayers(ctx context.Context, pool *pgxpool.Pool) ([]battl
 // cmdFetchCompletedJourneyNodeIDs returns the IDs of every completed journey
 // story node for the account. Used by the battlepass engine, which polls
 // slower than the journey cache TTL and reads completion state only.
+//
+// NOTE(issue #267): still keyed by account_id; see cmdFetchPlayerTagsForAccount
+// for why the engine read paths are migrated separately from the operator writes.
 func cmdFetchCompletedJourneyNodeIDs(ctx context.Context, pool *pgxpool.Pool, accountID int64) ([]string, error) {
 	rows, err := pool.Query(ctx, `
 		SELECT story_node_id FROM dune.journey_story_node

--- a/cmd/dune-admin/db_cmd_reverse_contracts_test.go
+++ b/cmd/dune-admin/db_cmd_reverse_contracts_test.go
@@ -16,7 +16,7 @@ func TestValidateContractMutationInput(t *testing.T) {
 		wantError string
 	}{
 		{name: "valid", accountID: 10, contracts: []string{"DA_CT_A"}},
-		{name: "missing-account", accountID: 0, contracts: []string{"DA_CT_A"}, wantError: "account ID required"},
+		{name: "missing-player", accountID: 0, contracts: []string{"DA_CT_A"}, wantError: "player ID required"},
 		{name: "missing-contracts", accountID: 10, contracts: nil, wantError: "at least one contract required"},
 	}
 
@@ -104,7 +104,7 @@ func TestContractBatchSummary(t *testing.T) {
 func TestRemoveContractTags_NoTagsIsNoop(t *testing.T) {
 	t.Parallel()
 
-	if err := removeContractTags(context.Background(), nil, 123, nil); err != nil {
+	if err := removeContractTags(context.Background(), nil, playerRef{actorID: 123, accountID: 123}, nil); err != nil {
 		t.Fatalf("expected no-op nil tags, got %v", err)
 	}
 }

--- a/cmd/dune-admin/db_player_key_test.go
+++ b/cmd/dune-admin/db_player_key_test.go
@@ -1,0 +1,51 @@
+package main
+
+import "testing"
+
+// TestSelectPlayerKey covers the account_id -> character_id key selection for
+// per-character dune tables (issue #267). On current servers these tables are
+// keyed by character_id (= the actor id); on legacy servers by account_id.
+func TestSelectPlayerKey(t *testing.T) {
+	t.Parallel()
+
+	const actorID, accountID = int64(54), int64(2)
+
+	t.Run("current schema keys by character_id with the actor id", func(t *testing.T) {
+		t.Parallel()
+		col, val := selectPlayerKey(playerKeyCharacterID, actorID, accountID)
+		if col != playerKeyCharacterID || val != actorID {
+			t.Fatalf("got (%q, %d), want (%q, %d)", col, val, playerKeyCharacterID, actorID)
+		}
+	})
+
+	t.Run("legacy schema keys by account_id with the account id", func(t *testing.T) {
+		t.Parallel()
+		col, val := selectPlayerKey(playerKeyAccountID, actorID, accountID)
+		if col != playerKeyAccountID || val != accountID {
+			t.Fatalf("got (%q, %d), want (%q, %d)", col, val, playerKeyAccountID, accountID)
+		}
+	})
+
+	t.Run("unknown column falls back to legacy account_id key", func(t *testing.T) {
+		t.Parallel()
+		// Defensive: anything that isn't the character_id sentinel is treated as
+		// the legacy account-keyed schema rather than mis-addressing by actor id.
+		col, val := selectPlayerKey("", actorID, accountID)
+		if col != playerKeyAccountID || val != accountID {
+			t.Fatalf("got (%q, %d), want (%q, %d)", col, val, playerKeyAccountID, accountID)
+		}
+	})
+}
+
+// TestPlayerKeyColumnFromProbe verifies the information_schema probe result is
+// mapped to the right key column.
+func TestPlayerKeyColumnFromProbe(t *testing.T) {
+	t.Parallel()
+
+	if got := playerKeyColumnFromProbe(true); got != playerKeyCharacterID {
+		t.Fatalf("character_id present: got %q, want %q", got, playerKeyCharacterID)
+	}
+	if got := playerKeyColumnFromProbe(false); got != playerKeyAccountID {
+		t.Fatalf("character_id absent: got %q, want %q", got, playerKeyAccountID)
+	}
+}

--- a/cmd/dune-admin/handlers_players.go
+++ b/cmd/dune-admin/handlers_players.go
@@ -285,22 +285,22 @@ func handleGetInventory(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, rows)
 }
 
-// @Summary Get journey node state for an account
+// @Summary Get journey node state for a character
 // @Tags players
 // @Produce json
-// @Param id path int true "Account ID"
+// @Param id path int true "Player (character/actor) ID"
 // @Success 200 {array} object
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /api/v1/players/{id}/journey [get]
 func handleGetJourney(w http.ResponseWriter, r *http.Request) {
-	accountIDStr := r.PathValue("id")
-	accountID, err := strconv.ParseInt(accountIDStr, 10, 64)
+	playerIDStr := r.PathValue("id")
+	playerID, err := strconv.ParseInt(playerIDStr, 10, 64)
 	if err != nil {
-		jsonErr(w, fmt.Errorf("invalid accountId"), 400)
+		jsonErr(w, fmt.Errorf("invalid id"), 400)
 		return
 	}
-	msg, ok := cmdFetchJourneyNodes(dbFromCtx(r), scopeFromReq(r), accountID)().(msgJourney)
+	msg, ok := cmdFetchJourneyNodes(dbFromCtx(r), scopeFromReq(r), playerID)().(msgJourney)
 	if !ok {
 		jsonErr(w, fmt.Errorf("internal error"), 500)
 		return
@@ -882,10 +882,10 @@ func handleDeleteCharacter(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"ok": msg.ok})
 }
 
-// @Summary Get tags assigned to a player account
+// @Summary Get tags assigned to a character
 // @Tags players
 // @Produce json
-// @Param id path int true "Account ID"
+// @Param id path int true "Player (character/actor) ID"
 // @Success 200 {array} string
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
@@ -913,26 +913,26 @@ func handleGetPlayerTags(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, tags)
 }
 
-// @Summary Add or remove tags on a player account
+// @Summary Add or remove tags on a character
 // @Tags players
 // @Accept json
 // @Produce json
-// @Param body body object true "account_id, add ([]string), remove ([]string)"
+// @Param body body object true "player_id, add ([]string), remove ([]string)"
 // @Success 200 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /api/v1/players/update-tags [post]
 func handleUpdatePlayerTags(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		AccountID int64    `json:"account_id"`
-		Add       []string `json:"add"`
-		Remove    []string `json:"remove"`
+		PlayerID int64    `json:"player_id"`
+		Add      []string `json:"add"`
+		Remove   []string `json:"remove"`
 	}
 	if err := decode(r, &req); err != nil {
 		jsonErr(w, err, 400)
 		return
 	}
-	msg, ok := cmdUpdatePlayerTags(dbFromCtx(r), req.AccountID, req.Add, req.Remove)().(msgMutate)
+	msg, ok := cmdUpdatePlayerTags(dbFromCtx(r), req.PlayerID, req.Add, req.Remove)().(msgMutate)
 	if !ok {
 		jsonErr(w, fmt.Errorf("internal error"), 500)
 		return
@@ -1218,25 +1218,25 @@ func handleProgressionReverse(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"ok": msg.ok})
 }
 
-// @Summary Mark a journey node as complete for an account
+// @Summary Mark a journey node as complete for a character
 // @Tags players
 // @Accept json
 // @Produce json
-// @Param body body object true "account_id, node_id"
+// @Param body body object true "player_id, node_id"
 // @Success 200 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /api/v1/players/journey/complete [post]
 func handleJourneyComplete(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		AccountID int64  `json:"account_id"`
-		NodeID    string `json:"node_id"`
+		PlayerID int64  `json:"player_id"`
+		NodeID   string `json:"node_id"`
 	}
 	if err := decode(r, &req); err != nil {
 		jsonErr(w, err, 400)
 		return
 	}
-	msg, ok := cmdCompleteJourneyNode(dbFromCtx(r), req.AccountID, req.NodeID)().(msgMutate)
+	msg, ok := cmdCompleteJourneyNode(dbFromCtx(r), req.PlayerID, req.NodeID)().(msgMutate)
 	if !ok {
 		jsonErr(w, fmt.Errorf("internal error"), 500)
 		return
@@ -1249,25 +1249,25 @@ func handleJourneyComplete(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"ok": msg.ok})
 }
 
-// @Summary Complete a single contract for an account
+// @Summary Complete a single contract for a character
 // @Tags contracts
 // @Accept json
 // @Produce json
-// @Param body body object true "account_id, contract_id"
+// @Param body body object true "player_id, contract_id"
 // @Success 200 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /api/v1/players/contract/complete [post]
 func handleCompleteContract(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		AccountID  int64  `json:"account_id"`
+		PlayerID   int64  `json:"player_id"`
 		ContractID string `json:"contract_id"`
 	}
 	if err := decode(r, &req); err != nil {
 		jsonErr(w, err, 400)
 		return
 	}
-	msg, ok := cmdCompleteContract(dbFromCtx(r), req.AccountID, req.ContractID)().(msgMutate)
+	msg, ok := cmdCompleteContract(dbFromCtx(r), req.PlayerID, req.ContractID)().(msgMutate)
 	if !ok {
 		jsonErr(w, fmt.Errorf("internal error"), 500)
 		return
@@ -1370,25 +1370,25 @@ func handleGrantJobSkills(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"ok": msg.ok})
 }
 
-// @Summary Complete multiple contracts for an account
+// @Summary Complete multiple contracts for a character
 // @Tags contracts
 // @Accept json
 // @Produce json
-// @Param body body object true "account_id, contract_ids ([]string)"
+// @Param body body object true "player_id, contract_ids ([]string)"
 // @Success 200 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /api/v1/players/contracts/complete [post]
 func handleCompleteContracts(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		AccountID   int64    `json:"account_id"`
+		PlayerID    int64    `json:"player_id"`
 		ContractIDs []string `json:"contract_ids"`
 	}
 	if err := decode(r, &req); err != nil {
 		jsonErr(w, err, 400)
 		return
 	}
-	msg, ok := cmdCompleteContracts(dbFromCtx(r), req.AccountID, req.ContractIDs)().(msgMutate)
+	msg, ok := cmdCompleteContracts(dbFromCtx(r), req.PlayerID, req.ContractIDs)().(msgMutate)
 	if !ok {
 		jsonErr(w, fmt.Errorf("internal error"), 500)
 		return
@@ -1401,25 +1401,25 @@ func handleCompleteContracts(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"ok": msg.ok})
 }
 
-// @Summary Reverse (undo) multiple completed contracts for an account
+// @Summary Reverse (undo) multiple completed contracts for a character
 // @Tags contracts
 // @Accept json
 // @Produce json
-// @Param body body object true "account_id, contract_ids ([]string)"
+// @Param body body object true "player_id, contract_ids ([]string)"
 // @Success 200 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /api/v1/players/contracts/reverse [post]
 func handleReverseContracts(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		AccountID   int64    `json:"account_id"`
+		PlayerID    int64    `json:"player_id"`
 		ContractIDs []string `json:"contract_ids"`
 	}
 	if err := decode(r, &req); err != nil {
 		jsonErr(w, err, 400)
 		return
 	}
-	msg, ok := cmdReverseContracts(dbFromCtx(r), req.AccountID, req.ContractIDs)().(msgMutate)
+	msg, ok := cmdReverseContracts(dbFromCtx(r), req.PlayerID, req.ContractIDs)().(msgMutate)
 	if !ok {
 		jsonErr(w, fmt.Errorf("internal error"), 500)
 		return
@@ -1458,25 +1458,25 @@ func handleListContracts(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, out)
 }
 
-// @Summary Reset (incomplete) a journey node for an account
+// @Summary Reset (incomplete) a journey node for a character
 // @Tags players
 // @Accept json
 // @Produce json
-// @Param body body object true "account_id, node_id"
+// @Param body body object true "player_id, node_id"
 // @Success 200 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /api/v1/players/journey/reset [post]
 func handleJourneyReset(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		AccountID int64  `json:"account_id"`
-		NodeID    string `json:"node_id"`
+		PlayerID int64  `json:"player_id"`
+		NodeID   string `json:"node_id"`
 	}
 	if err := decode(r, &req); err != nil {
 		jsonErr(w, err, 400)
 		return
 	}
-	msg, ok := cmdResetJourneyNode(dbFromCtx(r), req.AccountID, req.NodeID)().(msgMutate)
+	msg, ok := cmdResetJourneyNode(dbFromCtx(r), req.PlayerID, req.NodeID)().(msgMutate)
 	if !ok {
 		jsonErr(w, fmt.Errorf("internal error"), 500)
 		return
@@ -1489,24 +1489,24 @@ func handleJourneyReset(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"ok": msg.ok})
 }
 
-// @Summary Wipe all journey nodes for an account
+// @Summary Wipe all journey nodes for a character
 // @Tags players
 // @Accept json
 // @Produce json
-// @Param body body object true "account_id"
+// @Param body body object true "player_id"
 // @Success 200 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /api/v1/players/journey/wipe [post]
 func handleJourneyWipe(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		AccountID int64 `json:"account_id"`
+		PlayerID int64 `json:"player_id"`
 	}
 	if err := decode(r, &req); err != nil {
 		jsonErr(w, err, 400)
 		return
 	}
-	msg, ok := cmdWipeJourneyNodes(dbFromCtx(r), req.AccountID)().(msgMutate)
+	msg, ok := cmdWipeJourneyNodes(dbFromCtx(r), req.PlayerID)().(msgMutate)
 	if !ok {
 		jsonErr(w, fmt.Errorf("internal error"), 500)
 		return

--- a/cmd/dune-admin/progression_presets.go
+++ b/cmd/dune-admin/progression_presets.go
@@ -109,15 +109,15 @@ func completionError(presetID, nodeID string, msg msgMutate, ok bool) error {
 }
 
 func applyProgressionPresetNodes(
-	accountID int64,
+	actorID int64,
 	presetID string,
 	nodeIDs []string,
-	complete func(accountID int64, nodeID string) (msgMutate, bool),
+	complete func(actorID int64, nodeID string) (msgMutate, bool),
 ) (int, int, error) {
 	totalNodes := 0
 	totalTags := 0
 	for _, nodeID := range nodeIDs {
-		msg, ok := complete(accountID, nodeID)
+		msg, ok := complete(actorID, nodeID)
 		if err := completionError(presetID, nodeID, msg, ok); err != nil {
 			return totalNodes, totalTags, err
 		}
@@ -128,7 +128,7 @@ func applyProgressionPresetNodes(
 	return totalNodes, totalTags, nil
 }
 
-func cmdApplyProgressionPreset(accountID int64, presetID string) Cmd {
+func cmdApplyProgressionPreset(actorID int64, presetID string) Cmd {
 	return func() Msg {
 		if globalDB == nil {
 			return msgMutate{err: fmt.Errorf("not connected")}
@@ -138,7 +138,7 @@ func cmdApplyProgressionPreset(accountID int64, presetID string) Cmd {
 			return msgMutate{err: fmt.Errorf("unknown preset: %s", presetID)}
 		}
 
-		totalNodes, totalTags, err := applyProgressionPresetNodes(accountID, presetID, preset.Nodes, func(id int64, nodeID string) (msgMutate, bool) {
+		totalNodes, totalTags, err := applyProgressionPresetNodes(actorID, presetID, preset.Nodes, func(id int64, nodeID string) (msgMutate, bool) {
 			msg, ok := cmdCompleteJourneyNode(globalDB, id, nodeID)().(msgMutate)
 			return msg, ok
 		})
@@ -189,18 +189,18 @@ func handleListProgressionPresets(w http.ResponseWriter, _ *http.Request) {
 
 func handleApplyProgressionPreset(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		AccountID int64  `json:"account_id"`
-		PresetID  string `json:"preset_id"`
+		PlayerID int64  `json:"player_id"`
+		PresetID string `json:"preset_id"`
 	}
 	if err := decode(r, &req); err != nil {
 		jsonErr(w, err, 400)
 		return
 	}
-	if req.AccountID == 0 || req.PresetID == "" {
-		jsonErr(w, fmt.Errorf("account_id and preset_id required"), 400)
+	if req.PlayerID == 0 || req.PresetID == "" {
+		jsonErr(w, fmt.Errorf("player_id and preset_id required"), 400)
 		return
 	}
-	msg, ok := cmdApplyProgressionPreset(req.AccountID, req.PresetID)().(msgMutate)
+	msg, ok := cmdApplyProgressionPreset(req.PlayerID, req.PresetID)().(msgMutate)
 	if !ok {
 		jsonErr(w, fmt.Errorf("internal error"), 500)
 		return

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1097,8 +1097,8 @@ export const api = {
   reconnect: () => req<Status>('POST', '/reconnect'),
   progression: {
     presets: () => req<ProgressionPreset[]>('GET', '/progression/presets'),
-    applyPreset: (account_id: number, preset_id: string) =>
-      req<MutateResult>('POST', '/players/progression/apply-preset', { account_id, preset_id }),
+    applyPreset: (player_id: number, preset_id: string) =>
+      req<MutateResult>('POST', '/players/progression/apply-preset', { player_id, preset_id }),
   },
   config: {
     get: () => req<AppConfig>('GET', '/config'),
@@ -1158,7 +1158,7 @@ export const api = {
     specs: () => req<SpecTrack[]>('GET', '/players/specs'),
     templates: () => req<{ id: string, name: string }[]>('GET', '/players/templates'),
     inventory: (id: number) => req<InventoryItem[]>('GET', `/players/${id}/inventory`),
-    journey: (accountId: number) => req<JourneyNode[]>('GET', `/players/${accountId}/journey`),
+    journey: (playerId: number) => req<JourneyNode[]>('GET', `/players/${playerId}/journey`),
     giveItem: (player_id: number, template: string, qty: number, quality: number) =>
       req<MutateResult>('POST', '/players/give-item', { player_id, template, qty, quality }),
     giveItems: (player_id: number, items: { template: string, qty: number, quality: number }[]) =>
@@ -1180,8 +1180,8 @@ export const api = {
     rename: (account_id: number, name: string) => req<MutateResult>('POST', '/players/rename', { account_id, name }),
     deleteCharacter: (account_id: number, reason: string) =>
       req<MutateResult>('POST', '/players/delete', { account_id, reason }),
-    tags: (account_id: number) => req<string[]>('GET', `/players/${account_id}/tags`),
-    updateTags: (account_id: number, add: string[], remove: string[]) => req<MutateResult>('POST', '/players/update-tags', { account_id, add, remove }),
+    tags: (player_id: number) => req<string[]>('GET', `/players/${player_id}/tags`),
+    updateTags: (player_id: number, add: string[], remove: string[]) => req<MutateResult>('POST', '/players/update-tags', { player_id, add, remove }),
     returningPlayerAward: (account_id: number) => req<MutateResult>('POST', '/players/returning-player-award', { account_id }),
     dismissReturningPlayerAward: (account_id: number) => req<MutateResult>('POST', '/players/dismiss-returning-player-award', { account_id }),
     exportUrl: (account_id: number) => `${apiBase}/players/${account_id}/export`,
@@ -1212,16 +1212,16 @@ export const api = {
       req<MutateResult>('POST', '/players/set-faction-tier', { actor_id, faction_id, tier }),
     progressionUnlock: (player_id: number, faction: string, preset: string) =>
       req<MutateResult>('POST', '/players/progression-unlock', { player_id, faction, preset }),
-    journeyComplete: (account_id: number, node_id: string) =>
-      req<MutateResult>('POST', '/players/journey/complete', { account_id, node_id }),
-    journeyReset: (account_id: number, node_id: string) =>
-      req<MutateResult>('POST', '/players/journey/reset', { account_id, node_id }),
-    journeyWipe: (account_id: number) =>
-      req<MutateResult>('POST', '/players/journey/wipe', { account_id }),
-    completeContract: (account_id: number, contract_id: string) =>
-      req<MutateResult>('POST', '/players/contract/complete', { account_id, contract_id }),
-    completeContracts: (account_id: number, contract_ids: string[]) =>
-      req<MutateResult>('POST', '/players/contracts/complete', { account_id, contract_ids }),
+    journeyComplete: (player_id: number, node_id: string) =>
+      req<MutateResult>('POST', '/players/journey/complete', { player_id, node_id }),
+    journeyReset: (player_id: number, node_id: string) =>
+      req<MutateResult>('POST', '/players/journey/reset', { player_id, node_id }),
+    journeyWipe: (player_id: number) =>
+      req<MutateResult>('POST', '/players/journey/wipe', { player_id }),
+    completeContract: (player_id: number, contract_id: string) =>
+      req<MutateResult>('POST', '/players/contract/complete', { player_id, contract_id }),
+    completeContracts: (player_id: number, contract_ids: string[]) =>
+      req<MutateResult>('POST', '/players/contracts/complete', { player_id, contract_ids }),
     grantJobSkills: (account_id: number, job: string) =>
       req<MutateResult>('POST', '/players/grant-job-skills', { account_id, job }),
     resetJobSkills: (account_id: number, job: string) =>
@@ -1241,8 +1241,8 @@ export const api = {
       req<MutateResult>('POST', '/players/grant-all-keystones', { player_id }),
     resetAllKeystones: (player_id: number) =>
       req<MutateResult>('POST', '/players/reset-all-keystones', { player_id }),
-    reverseContracts: (account_id: number, contract_ids: string[]) =>
-      req<MutateResult>('POST', '/players/contracts/reverse', { account_id, contract_ids }),
+    reverseContracts: (player_id: number, contract_ids: string[]) =>
+      req<MutateResult>('POST', '/players/contracts/reverse', { player_id, contract_ids }),
     progressionReverse: (player_id: number, faction: string, preset: string) =>
       req<MutateResult>('POST', '/players/progression-reverse', { player_id, faction, preset }),
     vehicles: (controller_id: number) => req<VehicleRow[]>('GET', `/players/${controller_id}/vehicles`),

--- a/web/src/tabs/PlayersTab/views/ActionsView/sections/ContractsSection.tsx
+++ b/web/src/tabs/PlayersTab/views/ActionsView/sections/ContractsSection.tsx
@@ -37,7 +37,7 @@ export const ContractsSection: React.FC<ContractsSectionProps> = ({ player }) =>
   }, [contractCatalogLoaded, setContractCatalog, setContractCatalogLoaded, setContractCatalogError])
 
   const handleCompleteContracts = () => {
-    run(() => api.players.completeContracts(player.account_id, selectedContracts),
+    run(() => api.players.completeContracts(player.id, selectedContracts),
       `Completed ${selectedContracts.length} contract(s) for ${player.name}`)
       .then(() => {
         setSelectedContracts([])
@@ -46,7 +46,7 @@ export const ContractsSection: React.FC<ContractsSectionProps> = ({ player }) =>
   }
 
   const handleReverseContracts = () => {
-    run(() => api.players.reverseContracts(player.account_id, selectedContracts),
+    run(() => api.players.reverseContracts(player.id, selectedContracts),
       `Reversed ${selectedContracts.length} contract(s) for ${player.name}`)
       .then(() => {
         setSelectedContracts([])

--- a/web/src/tabs/PlayersTab/views/ActionsView/sections/JourneySection.tsx
+++ b/web/src/tabs/PlayersTab/views/ActionsView/sections/JourneySection.tsx
@@ -31,14 +31,14 @@ export const JourneySection: React.FC<JourneySectionProps> = ({ player }) => {
     if (nodesLoaded) return
     Promise.resolve()
       .then(() => setNodesLoading(true))
-      .then(() => api.players.journey(player.account_id))
+      .then(() => api.players.journey(player.id))
       .then((n) => {
         setNodes(n)
         setNodesLoaded(true)
       })
       .catch(() => {})
       .finally(() => setNodesLoading(false))
-  }, [nodesLoaded, player.account_id, setNodes, setNodesLoaded])
+  }, [nodesLoaded, player.id, setNodes, setNodesLoaded])
 
   React.useEffect(() => {
     Promise.resolve().then(() => setSelectedKeys(new Set()))
@@ -70,7 +70,7 @@ export const JourneySection: React.FC<JourneySectionProps> = ({ player }) => {
       t('players.actions.journey.wipeAllDesc', { player: player.name }),
       t('players.actions.journey.wipeAll'),
       () => run(
-        () => api.players.journeyWipe(player.account_id),
+        () => api.players.journeyWipe(player.id),
         `Wiped all journey nodes for ${player.name}`,
       ).then(() => setNodes([])),
     )
@@ -78,7 +78,7 @@ export const JourneySection: React.FC<JourneySectionProps> = ({ player }) => {
 
   const handleCompleteNode = (n: JourneyNode) => {
     run(
-      () => api.players.journeyComplete(player.account_id, n.node_id),
+      () => api.players.journeyComplete(player.id, n.node_id),
       `Completed ${n.node_id}`,
     ).then(() =>
       setNodes((prev) =>
@@ -93,7 +93,7 @@ export const JourneySection: React.FC<JourneySectionProps> = ({ player }) => {
 
   const handleResetNode = (n: JourneyNode) => {
     run(
-      () => api.players.journeyReset(player.account_id, n.node_id),
+      () => api.players.journeyReset(player.id, n.node_id),
       `Reset ${n.node_id}`,
     ).then(() =>
       setNodes((prev) =>

--- a/web/src/tabs/PlayersTab/views/ActionsView/sections/ProgressionSection.tsx
+++ b/web/src/tabs/PlayersTab/views/ActionsView/sections/ProgressionSection.tsx
@@ -70,7 +70,7 @@ export const ProgressionSection: React.FC<ProgressionSectionProps> = ({ player }
   const selectedMQDef = MAIN_QUESTS.find((m) => m.id === selectedMQ)
 
   const handleApplyPreset = (p: ProgressionPreset) => {
-    run(() => api.progression.applyPreset(player.account_id, p.id),
+    run(() => api.progression.applyPreset(player.id, p.id),
       `Applied preset '${p.name}' to ${player.name}`)
       .then(() => setNodesLoaded(false))
   }
@@ -95,7 +95,7 @@ export const ProgressionSection: React.FC<ProgressionSectionProps> = ({ player }
 
   const handleUnlockTrainer = () => {
     run(async () => {
-      const r = await api.players.completeContracts(player.account_id, trainerMatches)
+      const r = await api.players.completeContracts(player.id, trainerMatches)
       await api.players.grantJobSkills(player.account_id, selectedTrainer)
       return r
     }, `Unlocked ${selectedTrainer} (${trainerMatches.length} contracts + skill tree) for ${player.name}`)
@@ -114,7 +114,7 @@ export const ProgressionSection: React.FC<ProgressionSectionProps> = ({ player }
   }
 
   const handleUnlockMainQuest = () => {
-    run(() => api.players.journeyComplete(player.account_id, selectedMQ),
+    run(() => api.players.journeyComplete(player.id, selectedMQ),
       `Unlocked ${selectedMQDef?.label ?? selectedMQ} for ${player.name}`)
       .then(() => setNodesLoaded(false))
   }

--- a/web/src/tabs/PlayersTab/views/ActionsView/sections/TagsSection.tsx
+++ b/web/src/tabs/PlayersTab/views/ActionsView/sections/TagsSection.tsx
@@ -35,14 +35,14 @@ export const TagsSection: React.FC<TagsSectionProps> = ({ player }) => {
     if (tagsLoaded) return
     Promise.resolve()
       .then(() => setTagsLoading(true))
-      .then(() => api.players.tags(player.account_id))
+      .then(() => api.players.tags(player.id))
       .then((t) => {
         setTags(t)
         setTagsLoaded(true)
       })
       .catch(() => {})
       .finally(() => setTagsLoading(false))
-  }, [tagsLoaded, player.account_id])
+  }, [tagsLoaded, player.id])
 
   const filteredActiveTags = filterQuery
     ? tags.filter((t) => t.toLowerCase().includes(filterQuery.toLowerCase()))
@@ -51,7 +51,7 @@ export const TagsSection: React.FC<TagsSectionProps> = ({ player }) => {
   const handleAddTags = () => {
     const toAdd = pendingTags
     run(
-      () => api.players.updateTags(player.account_id, toAdd, []),
+      () => api.players.updateTags(player.id, toAdd, []),
       `Added ${toAdd.length} tag${toAdd.length > 1 ? 's' : ''}`,
     ).then(() => {
       setTags((prev) => [...new Set([...prev, ...toAdd])].sort())
@@ -62,7 +62,7 @@ export const TagsSection: React.FC<TagsSectionProps> = ({ player }) => {
   const handleRemoveTag = (tag: string) => {
     setTags((prev) => prev.filter((s) => s !== tag))
     run(
-      () => api.players.updateTags(player.account_id, [], [tag]),
+      () => api.players.updateTags(player.id, [], [tag]),
       t('players.actions.tags.removedTag'),
     )
   }


### PR DESCRIPTION
## Summary

Fixes #267.

Current Dune: Awakening servers have migrated several per-player tables — `journey_story_node` and `player_tags` — from an `account_id` key to a `character_id` key (where `character_id == dune.actors.id`). dune-admin v0.42.0 still issues `account_id`-keyed SQL, so applying progression presets and journey/tag/contract writes crash with:

```
ERROR: column "account_id" does not exist (SQLSTATE 42703)
```

## Approach

- **Runtime schema guard.** A new probe (`playerKeyColumn`) checks `information_schema` once per table (cached) and selects `character_id` on migrated servers, falling back to `account_id` on legacy servers. This keeps dune-admin working across server versions.
- **Thread the character id.** The operator-selected character/actor id (`player.id`, i.e. `dune.actors.id`) is threaded through the journey, tags, contract and progression endpoints via a small `playerRef` helper. On legacy servers the character's `owner_account_id` is resolved on demand. Genuinely account-level operations (delete/export/job-skills/codex) intentionally keep `account_id`.
- **Replace broken proc calls.** The game procs `update_player_tags` and `delete_all_journey_story_nodes` are `account_id`-keyed and absent/renamed on migrated servers, so their call sites are replaced with schema-correct inline SQL that dune-admin controls.
- **Wire field rename.** The affected endpoints now take `player_id` instead of `account_id`; the SPA sends `player.id`. Swagger annotations updated.

## Validation

Verified locally — `go build`, `go vet`, `go test -race`, `gofmt` all pass (including new unit tests for the key-selection logic in `db_player_key_test.go`).

Verified against a **live current-build server**:
- The schema probe query returns `character_id` for both tables; `journey_story_node`'s primary key is now `(story_node_id, character_id)`.
- The old `WHERE account_id` query reproduces `column "account_id" does not exist`.
- The new read **and** write SQL (UPDATE/INSERT with the `JourneyStoryResetGroup` enum cast, tag add/remove, deletes) all execute cleanly against the live schema.

## Scope / follow-up

This PR covers the operator-driven journey, tag, contract and progression write/read paths in the reported crash. The **events/battlepass engine** read paths (`cmdFetchPlayerTagsForAccount`, `cmdFetchCompletedJourneyNodeIDs`) remain `account_id`-keyed — they poll per account and need per-character semantics, so they're flagged with `NOTE(issue #267)` comments and left for a separate change.

The bundled `db-routines/*.sql` are read-only dumps of the game's own procs, so they are not modified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
