### PR TITLE
Fix AMP server status: live player counts + map labels

### DIFF
--- a/cmd/dune-admin/control.go
+++ b/cmd/dune-admin/control.go
@@ -60,8 +60,13 @@ type BattlegroupStatus struct {
 }
 
 type ServerRow struct {
-	Map           string `json:"map"`
-	Sietch        string `json:"sietch"`
+	Map    string `json:"map"`
+	Sietch string `json:"sietch"`
+	// DisplayName is the operator-configured server name from the director
+	// (lastServerState.displayName, e.g. "Sietch Umbu"). It is the same across
+	// every partition of a server, so it's used as a label only for the home
+	// (Survival / Hagga Basin) instance.
+	DisplayName   string `json:"displayName,omitempty"`
 	Dimension     int    `json:"dimension"`
 	Partition     int    `json:"partition"`
 	Phase         string `json:"phase"`

--- a/cmd/dune-admin/control_amp.go
+++ b/cmd/dune-admin/control_amp.go
@@ -116,6 +116,7 @@ func (c *ampControl) GetStatus(ctx context.Context, exec Executor) (*Battlegroup
 			row.Players = meta.players
 			row.PlayerHardCap = meta.playerHardCap
 			row.Queue = meta.queue
+			row.DisplayName = meta.displayName
 			if meta.label != "" {
 				row.Sietch = meta.label
 			}
@@ -139,6 +140,7 @@ func (c *ampControl) GetStatus(ctx context.Context, exec Executor) (*Battlegroup
 type partitionMeta struct {
 	dimension     int
 	label         string
+	displayName   string
 	players       int
 	playerHardCap int
 	queue         int
@@ -192,6 +194,7 @@ func collectPartitions(v any, out map[int]partitionMeta) {
 				out[id] = partitionMeta{
 					dimension:     jsonInt(p["dimensionIndex"]),
 					label:         jsonString(p["label"]),
+					displayName:   directorDisplayName(t),
 					players:       directorPlayerCount(t),
 					playerHardCap: effectivePlayerHardCap(t),
 					queue:         jsonInt(t["numPlayersInQueue"]),
@@ -244,6 +247,16 @@ func directorPlayerCount(node map[string]any) int {
 		}
 	}
 	return jsonInt(node["numPlayersInGame"])
+}
+
+// directorDisplayName returns the operator-configured server name from a
+// partition's lastServerState.displayName (e.g. "Sietch Umbu"), or "" when
+// absent.
+func directorDisplayName(node map[string]any) string {
+	if state, ok := node["lastServerState"].(map[string]any); ok {
+		return jsonString(state["displayName"])
+	}
+	return ""
 }
 
 // effectivePlayerHardCap resolves a server node's player cap: the per-server

--- a/cmd/dune-admin/control_amp.go
+++ b/cmd/dune-admin/control_amp.go
@@ -192,7 +192,7 @@ func collectPartitions(v any, out map[int]partitionMeta) {
 				out[id] = partitionMeta{
 					dimension:     jsonInt(p["dimensionIndex"]),
 					label:         jsonString(p["label"]),
-					players:       jsonInt(t["numPlayersInGame"]),
+					players:       directorPlayerCount(t),
 					playerHardCap: effectivePlayerHardCap(t),
 					queue:         jsonInt(t["numPlayersInQueue"]),
 				}
@@ -229,6 +229,21 @@ func jsonInt(v any) int {
 func jsonString(v any) string {
 	s, _ := v.(string)
 	return s
+}
+
+// directorPlayerCount returns the live player count for a partition's server
+// node. The director's numPlayersInGame counter is not maintained for these
+// Dune servers (shouldUpdatePlayerCountOnFls=false), so it reads back 0 even
+// when players are connected; the authoritative live roster is
+// lastServerState.players. Falls back to numPlayersInGame when that roster is
+// absent (e.g. a director build that does maintain the counter).
+func directorPlayerCount(node map[string]any) int {
+	if state, ok := node["lastServerState"].(map[string]any); ok {
+		if players, ok := state["players"].([]any); ok {
+			return len(players)
+		}
+	}
+	return jsonInt(node["numPlayersInGame"])
 }
 
 // effectivePlayerHardCap resolves a server node's player cap: the per-server

--- a/cmd/dune-admin/control_amp_test.go
+++ b/cmd/dune-admin/control_amp_test.go
@@ -572,3 +572,37 @@ func TestCollectPartitions_WalksNestedAndIgnoresNull(t *testing.T) {
 		t.Errorf("collected %d partitions, want 4: %+v", len(out), out)
 	}
 }
+
+// TestDirectorPlayerCount covers reading the live roster instead of the stale
+// numPlayersInGame counter (which Dune servers leave at 0).
+func TestDirectorPlayerCount(t *testing.T) {
+	t.Parallel()
+
+	// Live roster wins over a stale-zero counter.
+	roster := map[string]any{
+		"numPlayersInGame": float64(0),
+		"lastServerState": map[string]any{
+			"players": []any{
+				map[string]any{"playerId": "1480"},
+				map[string]any{"playerId": "247"},
+			},
+		},
+	}
+	if got := directorPlayerCount(roster); got != 2 {
+		t.Errorf("roster of 2 with counter 0: got %d, want 2", got)
+	}
+
+	// Empty roster is authoritative — 0 even if the counter is non-zero.
+	empty := map[string]any{
+		"numPlayersInGame": float64(9),
+		"lastServerState":  map[string]any{"players": []any{}},
+	}
+	if got := directorPlayerCount(empty); got != 0 {
+		t.Errorf("empty roster: got %d, want 0", got)
+	}
+
+	// No lastServerState — fall back to numPlayersInGame.
+	if got := directorPlayerCount(map[string]any{"numPlayersInGame": float64(5)}); got != 5 {
+		t.Errorf("fallback to counter: got %d, want 5", got)
+	}
+}

--- a/cmd/dune-admin/discord_status.go
+++ b/cmd/dune-admin/discord_status.go
@@ -154,17 +154,35 @@ func deriveServerState(status *BattlegroupStatus, err error) serverState {
 	return serverStateBooting
 }
 
-// partitionLabel returns the display label for a single ServerRow. The
-// director-supplied Sietch name is preferred; falls back to the pretty map
-// name; falls back to "Unknown".
+// partitionLabel returns the display label for a single ServerRow.
+//
+// The Survival / Hagga Basin map is the operator's home instance, so it is
+// labeled with the configured server name from the director (DisplayName, e.g.
+// "Sietch Umbu"). Every other map uses its pretty region name (Overland, Deep
+// Desert, …): the director's per-partition label is an internal codename for
+// some maps (e.g. "Abbir") and inconsistent across maps, so it is used only as
+// a fallback for unrecognised maps. Falls back to "Unknown".
 func partitionLabel(s ServerRow) string {
-	if s.Sietch != "" {
-		return s.Sietch
+	if s.DisplayName != "" && isSurvivalMap(s.Map) {
+		return s.DisplayName
 	}
 	if label := prettyRegionName(s.Map); label != "" {
 		return label
 	}
+	if s.Sietch != "" {
+		return s.Sietch
+	}
 	return "Unknown"
+}
+
+// isSurvivalMap reports whether a director map name is the Survival / Hagga
+// Basin map (e.g. "Survival_1") — the operator's home instance.
+func isSurvivalMap(mapName string) bool {
+	m := strings.TrimSpace(mapName)
+	m = strings.TrimPrefix(m, "Map_")
+	m = strings.TrimPrefix(m, "SH_")
+	m = stripTrailingNumericSuffix(m)
+	return strings.EqualFold(m, "Survival")
 }
 
 type partitionRow struct {
@@ -192,12 +210,12 @@ func groupByLabel(rows []partitionRow) ([]string, map[string][]partitionRow) {
 	return order, groups
 }
 
-// aggregateMapCounts returns one entry per partition, labeled by the
-// director-supplied Sietch name when available, otherwise by the pretty map
-// name. When multiple partitions share the same base label (e.g. several
-// "Hagga Basin" shards with no director label), a " #N" suffix is appended
-// using 1-based position ordered by Partition index. Single-partition groups
-// keep the bare label. Output is sorted players-desc, label-asc.
+// aggregateMapCounts returns one entry per partition, labeled by partitionLabel
+// (server name for the Survival home instance, pretty region name otherwise). When
+// multiple partitions share the same base label (e.g. several "Hagga Basin"
+// shards), a " #N" suffix is appended using 1-based position ordered by
+// Partition index. Single-partition groups keep the bare label. Output is
+// sorted players-desc, label-asc.
 func aggregateMapCounts(servers []ServerRow) []mapPlayerCount {
 	rows := make([]partitionRow, 0, len(servers))
 	for _, s := range servers {

--- a/cmd/dune-admin/discord_status_test.go
+++ b/cmd/dune-admin/discord_status_test.go
@@ -680,17 +680,35 @@ func TestAggregateMapCounts(t *testing.T) {
 		})
 	})
 
-	t.Run("director labels present, used verbatim", func(t *testing.T) {
+	t.Run("region name preferred over director label", func(t *testing.T) {
 		t.Parallel()
 		servers := []ServerRow{
-			{Map: "Survival_1", Sietch: "Survival_1", Partition: 1, Players: 12},
-			{Map: "Survival_2", Sietch: "Survival_2", Partition: 2, Players: 8},
-			{Map: "DeepDesert", Players: 3},
+			// The director codename ("Abbir") is ignored in favour of the region.
+			{Map: "Survival_1", Sietch: "Abbir", Partition: 1, Players: 12},
+			{Map: "DeepDesert", Sietch: "Deep Desert", Partition: 2, Players: 3},
+			// Unknown map → fall back to the director Sietch label.
+			{Map: "", Sietch: "Custom Arena", Partition: 5, Players: 2},
 		}
 		check(t, aggregateMapCounts(servers), map[string]int{
-			"Survival_1":  12,
-			"Survival_2":  8,
-			"Deep Desert": 3,
+			"Hagga Basin":  12,
+			"Deep Desert":  3,
+			"Custom Arena": 2,
+		})
+	})
+
+	t.Run("survival home instance uses server display name", func(t *testing.T) {
+		t.Parallel()
+		// DisplayName is server-wide; only the Survival/Hagga Basin home instance
+		// uses it. Other maps keep their region names.
+		servers := []ServerRow{
+			{Map: "Survival_1", Sietch: "Abbir", DisplayName: "Sietch Umbu", Partition: 1, Players: 2},
+			{Map: "Overmap", Sietch: "Overland", DisplayName: "Sietch Umbu", Partition: 2, Players: 1},
+			{Map: "DeepDesert_1", DisplayName: "Sietch Umbu", Partition: 8, Players: 0},
+		}
+		check(t, aggregateMapCounts(servers), map[string]int{
+			"Sietch Umbu": 2,
+			"Overland":    1,
+			"Deep Desert": 0,
 		})
 	})
 


### PR DESCRIPTION
## Summary

Fixes two issues with the AMP server-status display (Discord status embed + the Server Overview), both confirmed against upstream `main` and a live AMP + Battlegroup Director deployment.

### 1. Player counts always read 0
The AMP control plane reads each partition's player count from the director's `numPlayersInGame` field. On Dune servers that counter is not maintained (`shouldUpdatePlayerCountOnFls=false`) and reads back `0` even when players are connected — so every partition reports 0 players while the DB-derived online total is non-zero, producing an inconsistent embed ("N Online" but every map shows 0).

`directorPlayerCount` now counts the authoritative live roster (`lastServerState.players`), falling back to `numPlayersInGame` when that roster is absent.

### 2. Map labels
`partitionLabel` preferred the director's per-partition `label`, which is an internal codename for some maps (e.g. `"Abbir"` for the Survival / Hagga Basin map) and inconsistent across maps. Now:
- Maps are labeled by their pretty region name (Hagga Basin, Overland, Deep Desert, …).
- The Survival / Hagga Basin **home instance** is labeled with the operator-configured server name (`lastServerState.displayName`, e.g. `"Sietch Umbu"`), threaded through as `ServerRow.DisplayName`.
- The director label is kept only as a fallback for unrecognised maps.

## Testing
- `make verify` (go test -race, vet, gofmt) passes; new unit tests for `directorPlayerCount` and the labeling behaviour.
- `make gosec` clean (0 issues), `make vulncheck` no vulnerabilities, golangci-lint clean, gocognit under the gate.
- Verified end-to-end against a live AMP + director deployment: partitions with connected players report correct counts, and labels render as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
