### PR TITLE
fix(amp): resolve director_config.ini in $STATE, not two levels up (#171)

### DIFF
--- a/SETUP_AMP.md
+++ b/SETUP_AMP.md
@@ -141,6 +141,8 @@ INIs directly and do **not** need the `amp_api_*` credentials.
 
 **INI changes fail** — verify `server_ini_dir` and that AMP user owns `UserGame.ini` / `UserEngine.ini`.
 
+**Director page (Operations) says "could not read director config" while the Web Interfaces link works** — the page reads the amp-owned `director_config.ini` on the host, while the link is just an HTTP proxy, so `director_url` being correct doesn't help. The file read needs read access: either run the dune-admin service **as the `amp` user** (it owns the `0700` file, no sudo needed), or add `/usr/bin/cat` to the AMP sudoers grant for the service user. `director.log` shows `read …/director_config.ini: exit status 1` when neither is in place.
+
 **Broker commands fail** — set `broker_exec_prefix` to the exact `podman exec` (or `docker exec`) wrapper used on your AMP host.
 
 **Saving a server setting returns an error (502)** — dune-admin could not reach or authenticate to the AMP Web API. Check `amp_api_user` / `amp_api_pass` (an AMP panel login) and `amp_api_port` (default `8081`), and that the instance ADS is running inside the container.

--- a/cmd/dune-admin/control_amp.go
+++ b/cmd/dune-admin/control_amp.go
@@ -715,9 +715,30 @@ func (c *ampControl) gameOverridePath(dir string) string {
 // page (#173). Symmetric with how AMP writes them and reads director_config.ini.
 // Implements iniFileReader.
 func (c *ampControl) readINIFile(exec Executor, path string) (string, error) {
-	out, err := exec.Exec(fmt.Sprintf("sudo -i -u %s cat %s 2>/dev/null", shellQuote(c.ampUser), shellQuote(path)))
+	out, err := c.readHostFileAsAmp(exec, path)
 	if err != nil {
 		return "", fmt.Errorf("read ini %s as %s: %w", path, c.ampUser, err)
+	}
+	return out, nil
+}
+
+// readHostFileAsAmp reads a host file that may be owned by the amp user (often
+// mode 0700: director_config.ini, UserGame.ini, …). It tries a plain `cat`
+// first — which succeeds with NO sudo when dune-admin runs as the amp user and
+// owns the file (the recommended AMP layout) — because the narrow AMP sudoers
+// (ampinstmgr/podman/tee only) does NOT grant `cat`, so `sudo cat` hits a
+// password prompt and fails non-interactively. It then falls back to
+// `sudo -i -u <ampUser> cat` for split-user deployments where the admin has
+// additionally granted /usr/bin/cat. Regression fix for #171 (and #173): the
+// reads used to go straight to the un-granted `sudo cat` and bounced with an
+// opaque "exit status 1".
+func (c *ampControl) readHostFileAsAmp(exec Executor, path string) (string, error) {
+	if out, err := exec.Exec(fmt.Sprintf("cat %s 2>/dev/null", shellQuote(path))); err == nil && strings.TrimSpace(out) != "" {
+		return out, nil
+	}
+	out, err := exec.Exec(fmt.Sprintf("sudo -i -u %s cat %s 2>/dev/null", shellQuote(c.ampUser), shellQuote(path)))
+	if err != nil {
+		return "", err
 	}
 	return out, nil
 }
@@ -812,13 +833,20 @@ func (c *ampControl) ReadDefaultINI(_ context.Context, exec Executor, filename s
 // so edits persist and apply on the next instance restart.
 
 // directorConfigPath derives $STATE/director_config.ini from the resolved server
-// INI dir, which is $STATE/ue5-saved/UserSettings (so $STATE is two levels up).
+// INI dir. That dir is either $STATE itself (the documented server_ini_dir form)
+// or its $STATE/ue5-saved/UserSettings subdirectory (install.sh layout), so we
+// strip the optional suffix rather than walking two levels up unconditionally —
+// the latter overshot to …/duneawakening/director_config.ini (which doesn't
+// exist) whenever the resolved dir was already $STATE (#171). Mirrors
+// gameOverridePath, which lands UserOverrides.ini in the same $STATE dir.
 func (c *ampControl) directorConfigPath(exec Executor) (string, error) {
 	dir, err := iniDir(c, exec)
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(filepath.Dir(filepath.Dir(dir)), "director_config.ini"), nil
+	d := strings.TrimRight(filepath.ToSlash(dir), "/")
+	d = strings.TrimSuffix(d, "/ue5-saved/UserSettings")
+	return d + "/director_config.ini", nil
 }
 
 func (c *ampControl) readDirectorConfig(exec Executor) (string, string, error) {
@@ -826,9 +854,9 @@ func (c *ampControl) readDirectorConfig(exec Executor) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	out, err := exec.Exec(fmt.Sprintf("sudo -i -u %s cat %s 2>/dev/null", shellQuote(c.ampUser), shellQuote(path)))
+	out, err := c.readHostFileAsAmp(exec, path)
 	if err != nil {
-		return path, "", fmt.Errorf("read %s: %w", path, err)
+		return path, "", fmt.Errorf("read %s: %w — run dune-admin as the %q user (it owns the file), or grant /usr/bin/cat in the AMP sudoers", path, err, c.ampUser)
 	}
 	if strings.TrimSpace(out) == "" {
 		return path, "", fmt.Errorf("director config empty or unreadable at %s", path)

--- a/cmd/dune-admin/control_amp_test.go
+++ b/cmd/dune-admin/control_amp_test.go
@@ -323,6 +323,136 @@ func TestAmpRuntimeCLI_DefaultsToPodman(t *testing.T) {
 	}
 }
 
+// TestDirectorConfigPath_LandsInStateDir is the core regression for #171: the
+// director_config.ini lives in the instance $STATE dir (alongside
+// UserOverrides.ini), regardless of whether the resolved INI dir is the base
+// state dir (server_ini_dir documented form) or its ue5-saved/UserSettings
+// subdirectory. The old derivation did Dir(Dir(iniDir)), which overshot by two
+// levels when iniDir was already $STATE, yielding …/duneawakening/director_config.ini
+// (a path that does not exist) and the opaque "could not read director config".
+func TestDirectorConfigPath_LandsInStateDir(t *testing.T) {
+	t.Parallel()
+	const stateDir = "/home/amp/.ampdata/instances/Dune01/duneawakening/server/state"
+	want := stateDir + "/director_config.ini"
+
+	tests := []struct {
+		name   string
+		iniDir string
+		ue5Has bool // does <base>/ue5-saved/UserSettings/UserGame.ini exist?
+	}{
+		{"base state dir, no ue5 subdir", stateDir, false},
+		{"base state dir, ue5 subdir present", stateDir, true},
+		{"configured as ue5 subdir", stateDir + "/ue5-saved/UserSettings", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec := &fnExecutor{fn: func(cmd string) (string, error) {
+				if strings.Contains(cmd, "UserGame.ini") {
+					if tt.ue5Has {
+						return "yes\n", nil
+					}
+					return "no\n", nil
+				}
+				return "no\n", nil
+			}}
+			ctrl := &ampControl{iniDir: tt.iniDir, ampUser: "amp", instance: "Dune01"}
+			got, err := ctrl.directorConfigPath(exec)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != want {
+				t.Errorf("directorConfigPath = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// TestReadDirectorConfig_FallsBackToPlainCat is the regression for #171: the
+// Director config tab showed "could not read director config / exit status 1"
+// because the read only ever tried `sudo -i -u amp cat`, which the narrow AMP
+// sudoers (ampinstmgr/podman/tee only) refuses. When dune-admin runs AS the amp
+// user it owns the 0700 host file, so a plain `cat` succeeds and no sudo is
+// needed — the read must try that.
+func TestReadDirectorConfig_FallsBackToPlainCat(t *testing.T) {
+	t.Parallel()
+	var sawPlainCat bool
+	exec := &fnExecutor{fn: func(cmd string) (string, error) {
+		trimmed := strings.TrimSpace(cmd)
+		switch {
+		case strings.Contains(cmd, "ue5-saved/UserSettings"):
+			return "no\n", nil // DiscoverIniDir probe → use configured iniDir
+		case strings.HasPrefix(trimmed, "sudo "):
+			return "", errors.New("exit status 1") // sudoers won't grant cat
+		case strings.HasPrefix(trimmed, "cat "):
+			sawPlainCat = true
+			return "[Director]\nfoo=bar\n", nil
+		}
+		return "", nil
+	}}
+	ctrl := &ampControl{iniDir: "/custom/state", ampUser: "amp"}
+
+	_, content, err := ctrl.readDirectorConfig(exec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sawPlainCat {
+		t.Fatalf("expected a plain `cat` read to be attempted")
+	}
+	if !strings.Contains(content, "foo=bar") {
+		t.Errorf("expected director content, got %q", content)
+	}
+}
+
+// TestReadDirectorConfig_FallsBackToSudoCat covers the split-user deployment:
+// the service user does not own the file (plain cat fails), but the admin has
+// granted /usr/bin/cat so `sudo -i -u amp cat` succeeds.
+func TestReadDirectorConfig_FallsBackToSudoCat(t *testing.T) {
+	t.Parallel()
+	exec := &fnExecutor{fn: func(cmd string) (string, error) {
+		trimmed := strings.TrimSpace(cmd)
+		switch {
+		case strings.Contains(cmd, "ue5-saved/UserSettings"):
+			return "no\n", nil
+		case strings.HasPrefix(trimmed, "sudo "):
+			return "[Director]\nfoo=bar\n", nil
+		case strings.HasPrefix(trimmed, "cat "):
+			return "", errors.New("exit status 1") // not the owner
+		}
+		return "", nil
+	}}
+	ctrl := &ampControl{iniDir: "/custom/state", ampUser: "amp"}
+
+	_, content, err := ctrl.readDirectorConfig(exec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(content, "foo=bar") {
+		t.Errorf("expected director content, got %q", content)
+	}
+}
+
+// TestReadDirectorConfig_AllReadsFailIsActionable verifies that when neither a
+// plain nor a sudo cat can read the file (split-user deployment without a cat
+// grant), the wrapped error names the remedy so it shows up in director.log.
+func TestReadDirectorConfig_AllReadsFailIsActionable(t *testing.T) {
+	t.Parallel()
+	exec := &fnExecutor{fn: func(cmd string) (string, error) {
+		if strings.Contains(cmd, "ue5-saved/UserSettings") {
+			return "no\n", nil
+		}
+		return "", errors.New("exit status 1")
+	}}
+	ctrl := &ampControl{iniDir: "/custom/state", ampUser: "amp"}
+
+	_, _, err := ctrl.readDirectorConfig(exec)
+	if err == nil {
+		t.Fatalf("expected an error when every read strategy fails")
+	}
+	if !strings.Contains(err.Error(), "cat") {
+		t.Errorf("error should point the admin at the cat grant / amp user, got %q", err)
+	}
+}
+
 // TestAmpWrapInContainer_RuntimeSelection verifies wrapInContainer emits the
 // configured container runtime as `<rt> exec` in container mode, defaulting to
 // podman when unset.


### PR DESCRIPTION
## Problem

Fixes #171. On the AMP control plane the Director page (Operations) fails with **"could not read director config"**, and `director.log` shows:

```
read …/duneawakening/director_config.ini: exit status 1
```

while the **Web Interfaces** link to the director still works (it's just an HTTP proxy, so a correct `director_url` doesn't help).

## Root cause

`directorConfigPath` derived the file path with `filepath.Dir(filepath.Dir(iniDir))`. That only lands in `$STATE` when the resolved INI dir ends in `/ue5-saved/UserSettings`. When `DiscoverIniDir` returns the **base** `$STATE` instead — which it does for the documented `server_ini_dir` form, i.e. whenever `…/ue5-saved/UserSettings/UserGame.ini` is absent — it walks two levels too high and produces `…/duneawakening/director_config.ini`, a path that doesn't exist. The `2>/dev/null` on the read then masks `No such file or directory` as the opaque `exit status 1` seen in the issue. The real file lives at `$STATE/director_config.ini`, next to `UserOverrides.ini`.

## Fix

- `directorConfigPath` now strips the optional `/ue5-saved/UserSettings` suffix and appends the filename, mirroring `gameOverridePath`. Correct for both layouts (base `$STATE` and the `ue5-saved/UserSettings` subdir).
- **Second, independent failure mode** (split-user deploys): the read went straight to `sudo -i -u amp cat`, but the documented AMP sudoers grant (`ampinstmgr/podman/tee`) doesn't include `cat`, so it fails even on the correct path. New `readHostFileAsAmp` tries a plain `cat` first (works when dune-admin runs **as** the amp user and owns the `0700` file) before the `sudo cat` fallback, and the failure error now names the remedy. Shared by `readDirectorConfig` and `readINIFile`.
- `SETUP_AMP.md` troubleshooting entry.

## Tests

`TestDirectorConfigPath_LandsInStateDir` covers all three layout cases (including the base-state-dir overshoot that reproduces the exact broken path from the issue log). Added `TestReadDirectorConfig_FallsBackToPlainCat` / `…FallsBackToSudoCat` / `…AllReadsFailIsActionable` for the read-strategy chain.

`make verify` + `make gosec` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)