### PR TITLE
amp: fix Server Control Update (unsupported) + Restart (container wedge)

### DIFF
--- a/.claude/rules/amp.md
+++ b/.claude/rules/amp.md
@@ -24,6 +24,8 @@ control: amp
 amp_instance:   DuneAwakening01
 amp_container:  AMP_DuneAwakening01       # default: AMP_<instance>
 amp_container_runtime: podman             # podman (default) | docker
+amp_container_stop_timeout: 60            # restart graceful-stop seconds before SIGKILL (default 60)
+amp_update_auto_restart: true             # auto-restart container after an update finishes (default true)
 amp_user:       amp
 amp_log_path:   /AMP/duneawakening/logs   # in-container log dir
 amp_api_user:   admin                     # AMP panel login — enables gameplay-settings writes
@@ -50,7 +52,7 @@ Use `/usr/bin/docker` instead of `/usr/bin/podman` when `amp_container_runtime: 
 | Method | Implementation |
 | --- | --- |
 | `GetStatus` | Lists `DuneSandboxServer-Linux-Shipping` host processes; reports container DB phase |
-| `ExecCommand` | start/stop: `ampinstmgr -s/-q <amp_instance>`. restart (container): `<runtime> restart <container>` — `ampinstmgr` does NOT reap game procs; container restart is the only way to cycle them |
+| `ExecCommand` | start/stop: `ampinstmgr -s/-q <amp_instance>`. restart (container): `<runtime> restart -t <amp_container_stop_timeout> <container>` — `ampinstmgr` does NOT reap game procs; container restart is the only way to cycle them (generous stop timeout so it doesn't wedge on SIGKILL). update: AMP Web API `Core/UpdateApplication` (SteamCMD), then a background watcher polls `Core/GetStatus` RunningTasks and restarts the container when the update finishes (unless `amp_update_auto_restart: false`) |
 | `writeServerSettings` | AMP Web API `Core/Login` + `Core/SetConfig` (node `Meta.GenericModule.<FieldName>`) via in-container curl; needs `amp_api_*` |
 | `ListProcesses` | Host `ps` for game-server processes, decorated with map/port/partition |
 | `ListLogSources` | `<runtime> exec <container> ls <amp_log_path>` |

--- a/SETUP_AMP.md
+++ b/SETUP_AMP.md
@@ -69,6 +69,13 @@ server_ini_dir: /home/amp/.ampdata/instances/DuneAwakening01/duneawakening/serve
 # Optional:
 amp_use_container: true
 amp_container_runtime: docker   # podman (default) | docker — match your AMP container backend
+amp_container_stop_timeout: 60  # seconds to wait for a graceful stop on restart before SIGKILL
+                                # (default 60). The runtime default of 10s is too short for the
+                                # game shards + in-container Postgres/RabbitMQ and can wedge the
+                                # container in "stopping"; raise it if your stack stops slowly.
+amp_update_auto_restart: true   # default true — after a Server Control "Update", automatically
+                                # restart the container once SteamCMD finishes so it boots on the
+                                # new files. Set false to trigger the update only and restart manually.
 amp_data_root: /AMP/duneawakening
 director_url: http://127.0.0.1:11717
 broker_exec_prefix: "sudo -i -u amp podman exec AMP_DuneAwakening01"

--- a/cmd/dune-admin/amp_api.go
+++ b/cmd/dune-admin/amp_api.go
@@ -173,6 +173,82 @@ func (c *ampAPIClient) setConfig(node, value string) error {
 	return nil
 }
 
+// updateApplication triggers AMP's game-server update via Core/UpdateApplication
+// on the instance — the SteamCMD app_update AMP runs from its dashboard "Update"
+// button. AMP performs the update as a background task and returns a RunningTask
+// object; this returns the raw response once the task is accepted. Like
+// setConfig, a stale cached session triggers one re-login and retry.
+func (c *ampAPIClient) updateApplication() (string, error) {
+	resp, err := c.postUpdate()
+	if err == nil || !isSessionError(err) {
+		return resp, err
+	}
+	// Session expired — force re-login and retry once.
+	c.sessionID = ""
+	if _, lerr := c.login(); lerr != nil {
+		return "", lerr
+	}
+	return c.postUpdate()
+}
+
+// postUpdate performs one Core/UpdateApplication call against the current
+// session and interprets the response. An empty body (void return on some AMP
+// builds), a bare {}, or a RunningTask object is success; a {"Status":false}
+// ActionResult is surfaced as an error.
+func (c *ampAPIClient) postUpdate() (string, error) {
+	sid, err := c.ensureSession()
+	if err != nil {
+		return "", err
+	}
+	resp, err := c.post("Core/UpdateApplication", map[string]any{"SESSIONID": sid})
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(resp) == "" {
+		return resp, nil
+	}
+	if err := parseActionResult("Core/UpdateApplication", resp); err != nil {
+		return "", err
+	}
+	return resp, nil
+}
+
+// runningTaskCount returns how many tasks AMP reports running on the instance
+// (Core/GetStatus → RunningTasks). The post-update watcher polls this to wait out
+// a SteamCMD update before restarting the container. Re-logs in once on session
+// expiry, like the other calls.
+func (c *ampAPIClient) runningTaskCount() (int, error) {
+	n, err := c.getStatusRunningTasks()
+	if err == nil || !isSessionError(err) {
+		return n, err
+	}
+	c.sessionID = ""
+	if _, lerr := c.login(); lerr != nil {
+		return 0, lerr
+	}
+	return c.getStatusRunningTasks()
+}
+
+// getStatusRunningTasks performs one Core/GetStatus call and returns the length
+// of its RunningTasks array.
+func (c *ampAPIClient) getStatusRunningTasks() (int, error) {
+	sid, err := c.ensureSession()
+	if err != nil {
+		return 0, err
+	}
+	resp, err := c.post("Core/GetStatus", map[string]any{"SESSIONID": sid})
+	if err != nil {
+		return 0, err
+	}
+	var result struct {
+		RunningTasks []json.RawMessage `json:"RunningTasks"`
+	}
+	if err := json.Unmarshal([]byte(extractJSONObject(resp)), &result); err != nil {
+		return 0, fmt.Errorf("amp api GetStatus: decode response: %w (output: %s)", err, resp)
+	}
+	return len(result.RunningTasks), nil
+}
+
 // getConfig reads a single AMP config node's current value.
 func (c *ampAPIClient) getConfig(node string) (string, error) {
 	sid, err := c.ensureSession()

--- a/cmd/dune-admin/amp_api.go
+++ b/cmd/dune-admin/amp_api.go
@@ -150,7 +150,7 @@ func (c *ampAPIClient) setConfig(node, value string) error {
 	if err != nil {
 		return err
 	}
-	if err := parseActionResult(node, resp); err != nil {
+	if err := parseActionResult("SetConfig", node, resp); err != nil {
 		if !isSessionError(err) {
 			return err
 		}
@@ -168,7 +168,7 @@ func (c *ampAPIClient) setConfig(node, value string) error {
 		if err != nil {
 			return err
 		}
-		return parseActionResult(node, resp)
+		return parseActionResult("SetConfig", node, resp)
 	}
 	return nil
 }
@@ -207,7 +207,7 @@ func (c *ampAPIClient) postUpdate() (string, error) {
 	if strings.TrimSpace(resp) == "" {
 		return resp, nil
 	}
-	if err := parseActionResult("Core/UpdateApplication", resp); err != nil {
+	if err := parseActionResult("UpdateApplication", "", resp); err != nil {
 		return "", err
 	}
 	return resp, nil
@@ -271,31 +271,42 @@ func (c *ampAPIClient) getConfig(node string) (string, error) {
 	return jsonScalarToString(result.CurrentValue), nil
 }
 
-// parseActionResult interprets an AMP SetConfig response, which is either an
-// ActionResult object ({"Status":bool,"Reason":string}) or — on some AMP
-// versions — a bare JSON bool. A missing Status is treated as success (older
-// builds return {} when the write succeeds).
-func parseActionResult(node, resp string) error {
+// parseActionResult interprets an AMP action response (SetConfig,
+// UpdateApplication, ...), which is either an ActionResult object
+// ({"Status":bool,"Reason":string}) or — on some AMP versions — a bare JSON
+// bool. A missing Status is treated as success (older builds return {} when
+// the write succeeds).
+//
+// action names the caller's operation for the error text (e.g. "SetConfig",
+// "UpdateApplication"); node is an optional secondary identifier (the config
+// node path for SetConfig) appended when non-empty. Every call site must pass
+// its own action — reusing another caller's label produces a misleading error
+// (e.g. an UpdateApplication rejection must not say "SetConfig").
+func parseActionResult(action, node, resp string) error {
+	label := action
+	if node != "" {
+		label = action + " " + node
+	}
 	trimmed := strings.TrimSpace(resp)
 	switch trimmed {
 	case "true":
 		return nil
 	case "false":
-		return fmt.Errorf("amp api SetConfig %s: rejected", node)
+		return fmt.Errorf("amp api %s: rejected", label)
 	}
 	var result struct {
 		Status *bool  `json:"Status"`
 		Reason string `json:"Reason"`
 	}
 	if err := json.Unmarshal([]byte(extractJSONObject(trimmed)), &result); err != nil {
-		return fmt.Errorf("amp api SetConfig %s: decode response: %w (output: %s)", node, err, trimmed)
+		return fmt.Errorf("amp api %s: decode response: %w (output: %s)", label, err, trimmed)
 	}
 	if result.Status != nil && !*result.Status {
 		reason := result.Reason
 		if reason == "" {
 			reason = "rejected"
 		}
-		return fmt.Errorf("amp api SetConfig %s: %s", node, reason)
+		return fmt.Errorf("amp api %s: %s", label, reason)
 	}
 	return nil
 }

--- a/cmd/dune-admin/amp_api_test.go
+++ b/cmd/dune-admin/amp_api_test.go
@@ -210,6 +210,12 @@ func TestAMPAPISetConfig_StatusFalseIsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "No such node") {
 		t.Errorf("error should surface AMP reason, got: %v", err)
 	}
+	// Regression guard: parseActionResult is shared with postUpdate — a
+	// setConfig failure must still name "SetConfig" (only update's messages
+	// changed to name the correct action).
+	if !strings.Contains(err.Error(), "SetConfig") {
+		t.Errorf("setConfig error should still say SetConfig, got: %v", err)
+	}
 }
 
 func TestAMPAPISetConfig_AcceptsBareBoolResult(t *testing.T) {

--- a/cmd/dune-admin/connection.go
+++ b/cmd/dune-admin/connection.go
@@ -380,6 +380,9 @@ func legacyServerFromFlat(ac appConfig) ServerConfig {
 		AmpPgBin:            ac.AmpPgBin,
 		AmpPgLib:            ac.AmpPgLib,
 		AmpBackupDir:        ac.AmpBackupDir,
+
+		AmpContainerStopTimeout: ac.AmpContainerStopTimeout,
+		AmpUpdateAutoRestart:    ac.AmpUpdateAutoRestart,
 		// Director proxy
 		DirectorURL: ac.DirectorURL,
 		// Migrate the legacy global market-bot toggle onto the default server so
@@ -439,6 +442,8 @@ func serverCfgToAppConfig(sc ServerConfig) appConfig {
 	ac.AmpPgBin = sc.AmpPgBin
 	ac.AmpPgLib = sc.AmpPgLib
 	ac.AmpBackupDir = sc.AmpBackupDir
+	ac.AmpContainerStopTimeout = sc.AmpContainerStopTimeout
+	ac.AmpUpdateAutoRestart = sc.AmpUpdateAutoRestart
 	ac.DirectorURL = sc.DirectorURL
 	ac.MarketBotEnabled = sc.MarketBotEnabled
 	ac.WebInterfaceHostOverride = sc.WebInterfaceHostOverride

--- a/cmd/dune-admin/control.go
+++ b/cmd/dune-admin/control.go
@@ -120,21 +120,29 @@ func newControlPlane(name string, cfg appConfig) ControlPlane {
 		if cfg.AmpUseContainer != nil {
 			useContainer = *cfg.AmpUseContainer
 		}
+		// An AMP update auto-restarts the container by default; the operator can
+		// opt out with amp_update_auto_restart: false.
+		updateAutoRestart := true
+		if cfg.AmpUpdateAutoRestart != nil {
+			updateAutoRestart = *cfg.AmpUpdateAutoRestart
+		}
 		return &ampControl{
-			instance:         cfg.AmpInstance,
-			container:        container,
-			ampUser:          user,
-			logPath:          cfg.AmpLogPath,
-			directorURL:      cfg.DirectorURL,
-			iniDir:           cfg.ServerIniDir,
-			useContainer:     useContainer,
-			containerRuntime: cfg.AmpContainerRuntime,
-			dataRoot:         cfg.AmpDataRoot,
-			apiUser:          cfg.AmpAPIUser,
-			apiPass:          cfg.AmpAPIPass,
-			apiPort:          cfg.AmpAPIPort,
-			pgBin:            cfg.AmpPgBin,
-			pgLib:            cfg.AmpPgLib,
+			instance:             cfg.AmpInstance,
+			container:            container,
+			ampUser:              user,
+			logPath:              cfg.AmpLogPath,
+			directorURL:          cfg.DirectorURL,
+			iniDir:               cfg.ServerIniDir,
+			useContainer:         useContainer,
+			containerRuntime:     cfg.AmpContainerRuntime,
+			dataRoot:             cfg.AmpDataRoot,
+			apiUser:              cfg.AmpAPIUser,
+			apiPass:              cfg.AmpAPIPass,
+			apiPort:              cfg.AmpAPIPort,
+			pgBin:                cfg.AmpPgBin,
+			pgLib:                cfg.AmpPgLib,
+			containerStopTimeout: cfg.AmpContainerStopTimeout,
+			updateAutoRestart:    updateAutoRestart,
 		}
 	default:
 		return &localControl{

--- a/cmd/dune-admin/control_amp.go
+++ b/cmd/dune-admin/control_amp.go
@@ -51,6 +51,12 @@ type ampControl struct {
 	// a colon-joined path spanning both. Empty → validated AMP defaults.
 	pgBin string // dir containing pg_dump/pg_restore
 	pgLib string // LD_LIBRARY_PATH for the above
+
+	// afterUpdateRestart, when set, replaces the default post-update recovery
+	// (background: wait for the AMP update task to finish, then restart the
+	// container so it boots clean on the new files). Injected in tests to avoid
+	// spawning the real watcher goroutine.
+	afterUpdateRestart func(client *ampAPIClient, exec Executor)
 }
 
 const (
@@ -255,9 +261,111 @@ func (c *ampControl) ExecCommand(_ context.Context, exec Executor, cmd string) (
 		return exec.Exec(fmt.Sprintf("sudo -i -u %s ampinstmgr -q %s 2>&1", c.ampUser, c.instance))
 	case "restart":
 		return c.restartGame(exec)
+	case "update":
+		return c.updateApplication(exec)
 	default:
 		return "", fmt.Errorf("amp control does not support %q", cmd)
 	}
+}
+
+// ampContainerStopTimeout is the seconds `<runtime> restart` waits for a graceful
+// stop before SIGKILL. See restartGame for why the 10s runtime default is unsafe
+// for this heavy container.
+const ampContainerStopTimeout = 60
+
+// Post-update watcher tunables (vars so tests can reference them). After a
+// SteamCMD update is kicked off, watchUpdateAndRestart polls AMP's running-task
+// count: it waits for the update task to appear (up to ampUpdateAppearGrace) and
+// then clear, restarting the container once it does — or once ampUpdateMaxWait
+// elapses as a safety cap.
+var (
+	ampUpdatePollInterval = 10 * time.Second
+	ampUpdateAppearGrace  = 2 * time.Minute
+	ampUpdateMaxWait      = 30 * time.Minute
+)
+
+// updateApplication triggers AMP's SteamCMD update of the game server through the
+// instance Web API (Core/UpdateApplication) — the same action as the AMP
+// dashboard "Update" button — then kicks off background recovery.
+//
+// Why recovery is needed: SteamCMD rewrites the game files in place while the
+// DuneSandboxServer shards are still running, which crashes them (segfault on the
+// swapped binary/paks). In this containerised setup neither `ampinstmgr` stop nor
+// AMP's own app-stop reap those shards — only a container restart cycles them —
+// and we can't restart before the update because the ADS that runs the update
+// lives inside that same container. So the safe, one-click sequence is: trigger
+// the update, wait for it to finish, then restart the container to boot clean on
+// the new files. The wait+restart runs in the background so the HTTP call returns
+// immediately (a SteamCMD update can take minutes). Requires the AMP API
+// credentials, like server settings.
+func (c *ampControl) updateApplication(exec Executor) (string, error) {
+	if c.apiUser == "" || c.apiPass == "" {
+		return "", fmt.Errorf("amp api credentials not configured — set amp_api_user and amp_api_pass to update the server under AMP")
+	}
+	client := newAMPAPIClient(exec, c.wrapInContainer, c.apiUser, c.apiPass, c.apiPort)
+	if _, err := client.updateApplication(); err != nil {
+		return "", fmt.Errorf("update server: %w", err)
+	}
+	c.kickAfterUpdateRestart(client, exec)
+	return "Server update started via AMP — SteamCMD is updating the game files. " +
+		"The server will go offline during the update and automatically restart on the new files when it finishes.", nil
+}
+
+// kickAfterUpdateRestart launches post-update recovery, using the injected hook
+// when set (tests) or the real background watcher otherwise.
+func (c *ampControl) kickAfterUpdateRestart(client *ampAPIClient, exec Executor) {
+	if c.afterUpdateRestart != nil {
+		c.afterUpdateRestart(client, exec)
+		return
+	}
+	go c.watchUpdateAndRestart(client, exec)
+}
+
+// watchUpdateAndRestart waits for the AMP update to finish, then restarts the
+// container. It logs its own outcome (fire-and-forget goroutine).
+func (c *ampControl) watchUpdateAndRestart(client *ampAPIClient, exec Executor) {
+	log := componentLog("control_amp")
+	log.Info().Msg("update kicked off; waiting for the AMP update task to finish, then restarting the container")
+	err := waitForUpdateThenRestart(
+		client.runningTaskCount,
+		func() error { _, e := c.restartGame(exec); return e },
+		time.Sleep,
+		now,
+	)
+	if err != nil {
+		log.Error().Err(err).Msg("post-update container restart failed — recover manually via Server Control → Restart")
+		return
+	}
+	log.Info().Msg("post-update container restart complete")
+}
+
+// waitForUpdateThenRestart polls statusFn (AMP running-task count) until the
+// update task has appeared and then cleared, then calls restartFn. If no task
+// ever appears within ampUpdateAppearGrace it restarts anyway (fast/no-op
+// update); ampUpdateMaxWait caps the total wait so a task that never clears still
+// recovers. sleepFn/nowFn are injected for testing. Best-effort: transient
+// statusFn errors are ignored (they don't count as "cleared").
+func waitForUpdateThenRestart(statusFn func() (int, error), restartFn func() error, sleepFn func(time.Duration), nowFn func() time.Time) error {
+	start := nowFn()
+	seenTask := false
+	for {
+		if n, err := statusFn(); err == nil {
+			if n > 0 {
+				seenTask = true
+			} else if seenTask {
+				break // task appeared then cleared → update finished
+			}
+		}
+		elapsed := nowFn().Sub(start)
+		if !seenTask && elapsed >= ampUpdateAppearGrace {
+			break // never saw a task within grace → nothing to wait for
+		}
+		if elapsed >= ampUpdateMaxWait {
+			break // safety cap
+		}
+		sleepFn(ampUpdatePollInterval)
+	}
+	return restartFn()
 }
 
 // restartGame cycles the game server so config changes (CVars / UPROPERTYs)
@@ -274,13 +382,21 @@ func (c *ampControl) ExecCommand(_ context.Context, exec Executor, cmd string) (
 //
 // In native mode (no container) the game runs as host processes ampinstmgr
 // manages directly, so the stop/start cycle is retained.
+//
+// The container restart passes an explicit stop timeout (ampContainerStopTimeout)
+// rather than the runtime default of 10s. The Dune shards + in-container Postgres
+// and RabbitMQ take well over 10s to shut down gracefully; at the 10s default,
+// `podman restart` escalates to SIGKILL, which has been observed to leave the
+// container wedged in the "stopping" state ("given PID did not die within
+// timeout") — requiring a manual host-level kill to recover. The generous
+// timeout lets the stack exit cleanly on SIGINT so SIGKILL is never reached.
 func (c *ampControl) restartGame(exec Executor) (string, error) {
 	if c.useContainer {
 		if c.container == "" {
 			return "", fmt.Errorf("amp control in container mode requires amp_container to be set")
 		}
-		return exec.Exec(fmt.Sprintf("sudo -i -u %s %s restart %s 2>&1",
-			c.ampUser, c.runtimeCLI(), c.container))
+		return exec.Exec(fmt.Sprintf("sudo -i -u %s %s restart -t %d %s 2>&1",
+			c.ampUser, c.runtimeCLI(), ampContainerStopTimeout, c.container))
 	}
 	return exec.Exec(fmt.Sprintf("sudo -i -u %s ampinstmgr -q %s 2>&1 && sudo -i -u %s ampinstmgr -s %s 2>&1",
 		c.ampUser, c.instance, c.ampUser, c.instance))

--- a/cmd/dune-admin/control_amp.go
+++ b/cmd/dune-admin/control_amp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -348,20 +349,49 @@ func (c *ampControl) kickAfterUpdateRestart(client *ampAPIClient, exec Executor)
 
 // watchUpdateAndRestart waits for the AMP update to finish, then restarts the
 // container. It logs its own outcome (fire-and-forget goroutine).
+//
+// Deliberately uses its own context.Background()-derived lifetime rather than
+// the ExecCommand request's context: the HTTP handler returns almost
+// immediately after kicking this off (that's the whole point — the update can
+// take minutes), so the request's context would be cancelled within
+// milliseconds and kill the watcher before it ever polled once. This mirrors
+// how every other long-running background loop in this codebase manages its
+// own lifetime independently of any triggering request (see
+// applyBattlepassEngine/stopBattlepassEngine in battlepass_engine.go). Wiring
+// an actual shutdown-triggered cancellation (so dune-admin's own graceful
+// shutdown can interrupt a pending watcher cleanly) is a natural follow-up —
+// out of scope here; today ctx cancellation makes the poll loop correctly
+// interruptible and testable, but nothing yet calls cancel() in production.
 func (c *ampControl) watchUpdateAndRestart(client *ampAPIClient, exec Executor) {
 	log := componentLog("control_amp")
 	log.Info().Msg("update kicked off; waiting for the AMP update task to finish, then restarting the container")
 	err := waitForUpdateThenRestart(
+		context.Background(),
 		client.runningTaskCount,
 		func() error { _, e := c.restartGame(exec); return e },
-		time.Sleep,
+		ctxSleep,
 		now,
 	)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			log.Warn().Err(err).Msg("post-update watcher cancelled before the container restart — recover manually via Server Control → Restart")
+			return
+		}
 		log.Error().Err(err).Msg("post-update container restart failed — recover manually via Server Control → Restart")
 		return
 	}
 	log.Info().Msg("post-update container restart complete")
+}
+
+// ctxSleep is the production sleepFn for waitForUpdateThenRestart: it sleeps
+// for d, or returns early with ctx.Err() if ctx is cancelled first.
+func ctxSleep(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
 }
 
 // waitForUpdateThenRestart polls statusFn (AMP running-task count) until the
@@ -369,8 +399,10 @@ func (c *ampControl) watchUpdateAndRestart(client *ampAPIClient, exec Executor) 
 // ever appears within ampUpdateAppearGrace it restarts anyway (fast/no-op
 // update); ampUpdateMaxWait caps the total wait so a task that never clears still
 // recovers. sleepFn/nowFn are injected for testing. Best-effort: transient
-// statusFn errors are ignored (they don't count as "cleared").
-func waitForUpdateThenRestart(statusFn func() (int, error), restartFn func() error, sleepFn func(time.Duration), nowFn func() time.Time) error {
+// statusFn errors are ignored (they don't count as "cleared"). If ctx is
+// cancelled while waiting, the loop returns ctx's error immediately WITHOUT
+// calling restartFn — a cancelled watcher must not still fire a restart.
+func waitForUpdateThenRestart(ctx context.Context, statusFn func() (int, error), restartFn func() error, sleepFn func(context.Context, time.Duration) error, nowFn func() time.Time) error {
 	start := nowFn()
 	seenTask := false
 	for {
@@ -388,7 +420,9 @@ func waitForUpdateThenRestart(statusFn func() (int, error), restartFn func() err
 		if elapsed >= ampUpdateMaxWait {
 			break // safety cap
 		}
-		sleepFn(ampUpdatePollInterval)
+		if err := sleepFn(ctx, ampUpdatePollInterval); err != nil {
+			return err // cancelled — do not restart
+		}
 	}
 	return restartFn()
 }

--- a/cmd/dune-admin/control_amp.go
+++ b/cmd/dune-admin/control_amp.go
@@ -52,6 +52,13 @@ type ampControl struct {
 	pgBin string // dir containing pg_dump/pg_restore
 	pgLib string // LD_LIBRARY_PATH for the above
 
+	// containerStopTimeout is the seconds `<runtime> restart` waits for a graceful
+	// stop before SIGKILL (container mode). 0 → ampContainerStopTimeout.
+	containerStopTimeout int
+	// updateAutoRestart controls whether "update" restarts the container once the
+	// SteamCMD update finishes. Defaults to true when built from config.
+	updateAutoRestart bool
+
 	// afterUpdateRestart, when set, replaces the default post-update recovery
 	// (background: wait for the AMP update task to finish, then restart the
 	// container so it boots clean on the new files). Injected in tests to avoid
@@ -268,10 +275,19 @@ func (c *ampControl) ExecCommand(_ context.Context, exec Executor, cmd string) (
 	}
 }
 
-// ampContainerStopTimeout is the seconds `<runtime> restart` waits for a graceful
-// stop before SIGKILL. See restartGame for why the 10s runtime default is unsafe
-// for this heavy container.
+// ampContainerStopTimeout is the default seconds `<runtime> restart` waits for a
+// graceful stop before SIGKILL when amp_container_stop_timeout is unset. See
+// restartGame for why the 10s runtime default is unsafe for this heavy container.
 const ampContainerStopTimeout = 60
+
+// stopTimeout resolves the configured container stop timeout, falling back to
+// ampContainerStopTimeout when unset (≤0).
+func (c *ampControl) stopTimeout() int {
+	if c.containerStopTimeout > 0 {
+		return c.containerStopTimeout
+	}
+	return ampContainerStopTimeout
+}
 
 // Post-update watcher tunables (vars so tests can reference them). After a
 // SteamCMD update is kicked off, watchUpdateAndRestart polls AMP's running-task
@@ -307,15 +323,24 @@ func (c *ampControl) updateApplication(exec Executor) (string, error) {
 		return "", fmt.Errorf("update server: %w", err)
 	}
 	c.kickAfterUpdateRestart(client, exec)
+	if !c.updateAutoRestart {
+		return "Server update started via AMP — SteamCMD is updating the game files in the background. " +
+			"Auto-restart is disabled (amp_update_auto_restart=false); restart the server via Server Control → Restart once the update finishes.", nil
+	}
 	return "Server update started via AMP — SteamCMD is updating the game files. " +
 		"The server will go offline during the update and automatically restart on the new files when it finishes.", nil
 }
 
 // kickAfterUpdateRestart launches post-update recovery, using the injected hook
-// when set (tests) or the real background watcher otherwise.
+// when set (tests) or the real background watcher otherwise. When auto-restart is
+// disabled it does nothing — the update still runs; the operator restarts.
 func (c *ampControl) kickAfterUpdateRestart(client *ampAPIClient, exec Executor) {
 	if c.afterUpdateRestart != nil {
 		c.afterUpdateRestart(client, exec)
+		return
+	}
+	if !c.updateAutoRestart {
+		componentLog("control_amp").Info().Msg("update kicked off; auto-restart disabled — restart the container manually when the update finishes")
 		return
 	}
 	go c.watchUpdateAndRestart(client, exec)
@@ -396,7 +421,7 @@ func (c *ampControl) restartGame(exec Executor) (string, error) {
 			return "", fmt.Errorf("amp control in container mode requires amp_container to be set")
 		}
 		return exec.Exec(fmt.Sprintf("sudo -i -u %s %s restart -t %d %s 2>&1",
-			c.ampUser, c.runtimeCLI(), ampContainerStopTimeout, c.container))
+			c.ampUser, c.runtimeCLI(), c.stopTimeout(), c.container))
 	}
 	return exec.Exec(fmt.Sprintf("sudo -i -u %s ampinstmgr -q %s 2>&1 && sudo -i -u %s ampinstmgr -s %s 2>&1",
 		c.ampUser, c.instance, c.ampUser, c.instance))

--- a/cmd/dune-admin/control_amp_restart_test.go
+++ b/cmd/dune-admin/control_amp_restart_test.go
@@ -17,8 +17,8 @@ func TestAmpExecCommand_RestartContainerModeCyclesContainer(t *testing.T) {
 	if _, err := c.ExecCommand(context.Background(), exec, "restart"); err != nil {
 		t.Fatalf("restart: %v", err)
 	}
-	if !strings.Contains(exec.cmd, "docker restart AMP_X") {
-		t.Errorf("restart cmd = %q, want 'docker restart AMP_X'", exec.cmd)
+	if !strings.Contains(exec.cmd, "docker restart -t 60 AMP_X") {
+		t.Errorf("restart cmd = %q, want 'docker restart -t 60 AMP_X' (generous stop timeout so the heavy container shuts down gracefully instead of wedging on SIGKILL)", exec.cmd)
 	}
 	if strings.Contains(exec.cmd, "ampinstmgr") {
 		t.Errorf("container restart must not use ampinstmgr (does not reap game procs): %q", exec.cmd)
@@ -34,8 +34,8 @@ func TestAmpExecCommand_RestartContainerModeDefaultsPodman(t *testing.T) {
 	if _, err := c.ExecCommand(context.Background(), exec, "restart"); err != nil {
 		t.Fatalf("restart: %v", err)
 	}
-	if !strings.Contains(exec.cmd, "podman restart AMP_X") {
-		t.Errorf("restart cmd = %q, want 'podman restart AMP_X'", exec.cmd)
+	if !strings.Contains(exec.cmd, "podman restart -t 60 AMP_X") {
+		t.Errorf("restart cmd = %q, want 'podman restart -t 60 AMP_X'", exec.cmd)
 	}
 }
 

--- a/cmd/dune-admin/control_amp_update_test.go
+++ b/cmd/dune-admin/control_amp_update_test.go
@@ -21,6 +21,7 @@ func ampUpdateControl() *ampControl {
 		instance:           "Dune01",
 		apiUser:            "admin",
 		apiPass:            "pw",
+		updateAutoRestart:  true,
 		afterUpdateRestart: func(*ampAPIClient, Executor) {},
 	}
 }
@@ -111,6 +112,51 @@ func TestAmpExecCommand_UpdateFailureSkipsRecovery(t *testing.T) {
 	}
 	if kicked {
 		t.Error("a failed update must not kick the recovery restart")
+	}
+}
+
+// TestAmpExecCommand_UpdateAutoRestartDisabled verifies that with
+// amp_update_auto_restart=false the update still runs but no recovery restart is
+// kicked, and the message tells the operator to restart manually.
+func TestAmpExecCommand_UpdateAutoRestartDisabled(t *testing.T) {
+	t.Parallel()
+	exec := &fnExecutor{fn: func(cmd string) (string, error) {
+		switch {
+		case strings.Contains(cmd, "Core/Login"):
+			return `{"success":true,"sessionID":"sess"}`, nil
+		case strings.Contains(cmd, "Core/UpdateApplication"):
+			return `{"Id":"task-1"}`, nil
+		default:
+			// GetStatus (watcher) or a restart command here means recovery ran.
+			t.Fatalf("auto-restart disabled must not poll or restart; got: %q", cmd)
+			return "", nil
+		}
+	}}
+	c := &ampControl{
+		useContainer: true, container: "AMP_X", ampUser: "amp", containerRuntime: "docker",
+		instance: "Dune01", apiUser: "admin", apiPass: "pw",
+		updateAutoRestart: false, // afterUpdateRestart intentionally nil → real gate path
+	}
+	out, err := c.ExecCommand(context.Background(), exec, "update")
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !strings.Contains(out, "auto_restart") && !strings.Contains(strings.ToLower(out), "restart the server") {
+		t.Errorf("message should tell the operator to restart manually, got: %q", out)
+	}
+}
+
+// TestAmpRestart_UsesConfiguredStopTimeout verifies a configured
+// amp_container_stop_timeout overrides the default in the restart command.
+func TestAmpRestart_UsesConfiguredStopTimeout(t *testing.T) {
+	t.Parallel()
+	exec := &fakeAMPExecutor{}
+	c := &ampControl{instance: "Dune01", useContainer: true, container: "AMP_X", ampUser: "amp", containerRuntime: "docker", containerStopTimeout: 90}
+	if _, err := c.ExecCommand(context.Background(), exec, "restart"); err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+	if !strings.Contains(exec.cmd, "docker restart -t 90 AMP_X") {
+		t.Errorf("restart cmd = %q, want configured 'restart -t 90'", exec.cmd)
 	}
 }
 

--- a/cmd/dune-admin/control_amp_update_test.go
+++ b/cmd/dune-admin/control_amp_update_test.go
@@ -1,0 +1,361 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ampUpdateControl is a containerised AMP control plane with API credentials,
+// the configuration required to reach the instance ADS API for an update. The
+// post-update recovery hook is stubbed to a no-op so ExecCommand("update") tests
+// don't spawn the real background watcher (which would poll Core/GetStatus).
+func ampUpdateControl() *ampControl {
+	return &ampControl{
+		useContainer:       true,
+		container:          "AMP_X",
+		ampUser:            "amp",
+		containerRuntime:   "docker",
+		instance:           "Dune01",
+		apiUser:            "admin",
+		apiPass:            "pw",
+		afterUpdateRestart: func(*ampAPIClient, Executor) {},
+	}
+}
+
+// TestAmpExecCommand_UpdateCallsUpdateApplication verifies that "update" under
+// AMP logs in once and POSTs Core/UpdateApplication to the instance's loopback
+// ADS API, wrapped for in-container exec — the same SteamCMD update the AMP
+// dashboard "Update" button triggers.
+func TestAmpExecCommand_UpdateCallsUpdateApplication(t *testing.T) {
+	t.Parallel()
+	var updateCmd string
+	logins := 0
+	exec := &fnExecutor{fn: func(cmd string) (string, error) {
+		switch {
+		case strings.Contains(cmd, "Core/Login"):
+			logins++
+			return `{"success":true,"sessionID":"sess"}`, nil
+		case strings.Contains(cmd, "Core/UpdateApplication"):
+			updateCmd = cmd
+			return `{"Id":"task-1","Name":"Updating Application"}`, nil
+		default:
+			t.Fatalf("unexpected AMP API endpoint in cmd: %q", cmd)
+			return "", nil
+		}
+	}}
+
+	out, err := ampUpdateControl().ExecCommand(context.Background(), exec, "update")
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if logins != 1 {
+		t.Errorf("logins = %d, want 1", logins)
+	}
+	if !strings.Contains(updateCmd, "http://127.0.0.1:8081/API/Core/UpdateApplication") {
+		t.Errorf("update must hit Core/UpdateApplication on the loopback ADS API, got: %q", updateCmd)
+	}
+	if !strings.Contains(updateCmd, "docker exec AMP_X") {
+		t.Errorf("update API call must be wrapped for in-container exec, got: %q", updateCmd)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Error("update should return a human-readable confirmation for the UI")
+	}
+}
+
+// TestAmpExecCommand_UpdateKicksRecovery verifies a successful update triggers
+// the post-update recovery hook (which, in production, waits for the update to
+// finish then restarts the container) with the authenticated API client.
+func TestAmpExecCommand_UpdateKicksRecovery(t *testing.T) {
+	t.Parallel()
+	exec := &fnExecutor{fn: func(cmd string) (string, error) {
+		if strings.Contains(cmd, "Core/Login") {
+			return `{"success":true,"sessionID":"sess"}`, nil
+		}
+		return `{"Id":"task-1"}`, nil
+	}}
+	kicked := false
+	c := ampUpdateControl()
+	c.afterUpdateRestart = func(client *ampAPIClient, _ Executor) {
+		kicked = true
+		if client == nil {
+			t.Error("recovery hook must receive the authenticated API client")
+		}
+	}
+	if _, err := c.ExecCommand(context.Background(), exec, "update"); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !kicked {
+		t.Error("successful update must kick the post-update recovery hook")
+	}
+}
+
+// TestAmpExecCommand_UpdateFailureSkipsRecovery verifies a failed update does NOT
+// trigger the recovery restart — nothing to recover, and restarting would be a
+// surprise side effect of a no-op update.
+func TestAmpExecCommand_UpdateFailureSkipsRecovery(t *testing.T) {
+	t.Parallel()
+	exec := &fnExecutor{fn: func(cmd string) (string, error) {
+		if strings.Contains(cmd, "Core/Login") {
+			return `{"success":true,"sessionID":"sess"}`, nil
+		}
+		return `{"Status":false,"Reason":"boom"}`, nil
+	}}
+	kicked := false
+	c := ampUpdateControl()
+	c.afterUpdateRestart = func(*ampAPIClient, Executor) { kicked = true }
+	if _, err := c.ExecCommand(context.Background(), exec, "update"); err == nil {
+		t.Fatal("expected update failure")
+	}
+	if kicked {
+		t.Error("a failed update must not kick the recovery restart")
+	}
+}
+
+// ── waitForUpdateThenRestart orchestration ──────────────────────────────────
+
+// stepClock returns a nowFn that advances by step on every call, so poll loops
+// reach their deadlines deterministically without real sleeps.
+func stepClock(step time.Duration) func() time.Time {
+	base := time.Unix(1_700_000_000, 0)
+	n := 0
+	return func() time.Time {
+		t := base.Add(time.Duration(n) * step)
+		n++
+		return t
+	}
+}
+
+// TestWaitForUpdateThenRestart_WaitsForTaskToClear verifies the watcher restarts
+// only after the AMP update task has appeared and then cleared.
+func TestWaitForUpdateThenRestart_WaitsForTaskToClear(t *testing.T) {
+	t.Parallel()
+	// Task present for the first 3 polls, then gone.
+	counts := []int{1, 1, 1, 0}
+	i := 0
+	statusFn := func() (int, error) {
+		n := counts[i]
+		if i < len(counts)-1 {
+			i++
+		}
+		return n, nil
+	}
+	restarted := false
+	err := waitForUpdateThenRestart(statusFn, func() error { restarted = true; return nil },
+		func(time.Duration) {}, stepClock(ampUpdatePollInterval))
+	if err != nil {
+		t.Fatalf("waitForUpdateThenRestart: %v", err)
+	}
+	if !restarted {
+		t.Error("must restart after the update task clears")
+	}
+	if i < 3 {
+		t.Errorf("restarted too early: only polled %d times before the task cleared", i)
+	}
+}
+
+// TestWaitForUpdateThenRestart_RestartsIfTaskNeverAppears verifies that if no
+// update task ever appears within the grace window, the watcher still restarts
+// (so a fast/no-op update isn't left un-recovered forever).
+func TestWaitForUpdateThenRestart_RestartsIfTaskNeverAppears(t *testing.T) {
+	t.Parallel()
+	restarted := false
+	err := waitForUpdateThenRestart(
+		func() (int, error) { return 0, nil },
+		func() error { restarted = true; return nil },
+		func(time.Duration) {},
+		stepClock(ampUpdateAppearGrace), // each poll jumps a full grace window
+	)
+	if err != nil {
+		t.Fatalf("waitForUpdateThenRestart: %v", err)
+	}
+	if !restarted {
+		t.Error("must restart even when no update task ever appears")
+	}
+}
+
+// TestWaitForUpdateThenRestart_RestartsAtMaxWait verifies the safety cap: a task
+// that never clears still triggers a restart once the max wait elapses.
+func TestWaitForUpdateThenRestart_RestartsAtMaxWait(t *testing.T) {
+	t.Parallel()
+	restarted := false
+	err := waitForUpdateThenRestart(
+		func() (int, error) { return 1, nil }, // task never clears
+		func() error { restarted = true; return nil },
+		func(time.Duration) {},
+		stepClock(ampUpdateMaxWait), // blow past the cap on the second poll
+	)
+	if err != nil {
+		t.Fatalf("waitForUpdateThenRestart: %v", err)
+	}
+	if !restarted {
+		t.Error("must restart at the max-wait cap even if the task never clears")
+	}
+}
+
+// TestWaitForUpdateThenRestart_PropagatesRestartError verifies a restart failure
+// is surfaced (the caller logs it).
+func TestWaitForUpdateThenRestart_PropagatesRestartError(t *testing.T) {
+	t.Parallel()
+	err := waitForUpdateThenRestart(
+		func() (int, error) { return 0, nil },
+		func() error { return errors.New("restart boom") },
+		func(time.Duration) {},
+		stepClock(ampUpdateAppearGrace),
+	)
+	if err == nil || !strings.Contains(err.Error(), "restart boom") {
+		t.Fatalf("expected restart error to propagate, got: %v", err)
+	}
+}
+
+// TestAMPAPIRunningTaskCount_ParsesAndRetries verifies the running-task count is
+// read from Core/GetStatus.RunningTasks and that a session expiry re-logs in.
+func TestAMPAPIRunningTaskCount_ParsesAndRetries(t *testing.T) {
+	t.Parallel()
+	// Count from a populated RunningTasks array.
+	exec := &fnExecutor{fn: func(cmd string) (string, error) {
+		if strings.Contains(cmd, "Core/Login") {
+			return `{"success":true,"sessionID":"s"}`, nil
+		}
+		return `{"State":75,"RunningTasks":[{"Id":"a"},{"Id":"b"}]}`, nil
+	}}
+	c := newAMPAPIClient(exec, identityWrap, "u", "p", 0)
+	n, err := c.runningTaskCount()
+	if err != nil {
+		t.Fatalf("runningTaskCount: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("count = %d, want 2", n)
+	}
+
+	// Empty array → 0 (update finished).
+	execDone := &fnExecutor{fn: func(cmd string) (string, error) {
+		if strings.Contains(cmd, "Core/Login") {
+			return `{"success":true,"sessionID":"s"}`, nil
+		}
+		return `{"State":999,"RunningTasks":[]}`, nil
+	}}
+	cDone := newAMPAPIClient(execDone, identityWrap, "u", "p", 0)
+	if n, err := cDone.runningTaskCount(); err != nil || n != 0 {
+		t.Fatalf("empty RunningTasks: n=%d err=%v, want 0/nil", n, err)
+	}
+}
+
+// TestAmpExecCommand_UpdateMissingCredentials verifies update fails fast with a
+// clear message — and contacts nothing — when the AMP API creds are unset.
+func TestAmpExecCommand_UpdateMissingCredentials(t *testing.T) {
+	t.Parallel()
+	called := false
+	exec := &fnExecutor{fn: func(string) (string, error) { called = true; return "", nil }}
+	c := &ampControl{instance: "Dune01", useContainer: true, container: "AMP_X", ampUser: "amp", containerRuntime: "docker"} // no api creds
+	_, err := c.ExecCommand(context.Background(), exec, "update")
+	if err == nil {
+		t.Fatal("expected error when AMP API credentials are not configured")
+	}
+	if !strings.Contains(err.Error(), "amp_api_user") {
+		t.Errorf("error should name the missing config, got: %v", err)
+	}
+	if called {
+		t.Error("must not contact the AMP API without credentials")
+	}
+}
+
+// TestAmpExecCommand_UpdateRejectionPropagates verifies an AMP ActionResult
+// rejection (e.g. already up to date) surfaces its reason rather than being
+// swallowed.
+func TestAmpExecCommand_UpdateRejectionPropagates(t *testing.T) {
+	t.Parallel()
+	exec := &fnExecutor{fn: func(cmd string) (string, error) {
+		if strings.Contains(cmd, "Core/Login") {
+			return `{"success":true,"sessionID":"sess"}`, nil
+		}
+		return `{"Status":false,"Reason":"Application is already up to date."}`, nil
+	}}
+	_, err := ampUpdateControl().ExecCommand(context.Background(), exec, "update")
+	if err == nil {
+		t.Fatal("expected an AMP rejection to propagate")
+	}
+	if !strings.Contains(err.Error(), "already up to date") {
+		t.Errorf("error should surface the AMP reason, got: %v", err)
+	}
+}
+
+// TestAmpExecCommand_UpdateLoginFailureAborts verifies a login failure aborts
+// the update without attempting Core/UpdateApplication.
+func TestAmpExecCommand_UpdateLoginFailureAborts(t *testing.T) {
+	t.Parallel()
+	updateCalled := false
+	exec := &fnExecutor{fn: func(cmd string) (string, error) {
+		if strings.Contains(cmd, "Core/UpdateApplication") {
+			updateCalled = true
+		}
+		return `{"success":false,"resultReason":"bad creds"}`, nil
+	}}
+	if _, err := ampUpdateControl().ExecCommand(context.Background(), exec, "update"); err == nil {
+		t.Fatal("expected login failure to abort the update")
+	}
+	if updateCalled {
+		t.Error("must not call UpdateApplication when login fails")
+	}
+}
+
+// TestAmpExecCommand_UnknownCommandStillErrors guards that adding "update" did
+// not weaken rejection of genuinely unsupported commands.
+func TestAmpExecCommand_UnknownCommandStillErrors(t *testing.T) {
+	t.Parallel()
+	exec := &fnExecutor{fn: func(string) (string, error) { return "", nil }}
+	_, err := ampUpdateControl().ExecCommand(context.Background(), exec, "frobnicate")
+	if err == nil || !strings.Contains(err.Error(), "does not support") {
+		t.Fatalf("unknown command should be rejected, got: %v", err)
+	}
+}
+
+// TestAMPAPIUpdateApplication_AcceptsRunningTaskAndVoid verifies the API client
+// treats a RunningTask object, a bare {}, and an empty body (void return on some
+// AMP builds) all as success — only an explicit ActionResult failure is an error.
+func TestAMPAPIUpdateApplication_AcceptsRunningTaskAndVoid(t *testing.T) {
+	t.Parallel()
+	for _, resp := range []string{`{"Id":"t","Name":"Updating"}`, ``, `{}`} {
+		resp := resp
+		exec := &fnExecutor{fn: func(cmd string) (string, error) {
+			if strings.Contains(cmd, "Core/Login") {
+				return `{"success":true,"sessionID":"s"}`, nil
+			}
+			return resp, nil
+		}}
+		c := newAMPAPIClient(exec, identityWrap, "u", "p", 0)
+		if _, err := c.updateApplication(); err != nil {
+			t.Errorf("resp %q: unexpected error: %v", resp, err)
+		}
+	}
+}
+
+// TestAMPAPIUpdateApplication_RetriesOnSessionExpiry verifies a stale-session
+// rejection triggers one re-login and a successful retry.
+func TestAMPAPIUpdateApplication_RetriesOnSessionExpiry(t *testing.T) {
+	t.Parallel()
+	logins, updates := 0, 0
+	exec := &fnExecutor{fn: func(cmd string) (string, error) {
+		if strings.Contains(cmd, "Core/Login") {
+			logins++
+			return `{"success":true,"sessionID":"s"}`, nil
+		}
+		updates++
+		if updates == 1 {
+			return `{"Status":false,"Reason":"Invalid session ID."}`, nil
+		}
+		return `{"Id":"t","Name":"Updating"}`, nil
+	}}
+	c := newAMPAPIClient(exec, identityWrap, "u", "p", 0)
+	if _, err := c.updateApplication(); err != nil {
+		t.Fatalf("updateApplication: %v", err)
+	}
+	if logins != 2 {
+		t.Errorf("logins = %d, want 2 (one re-login on session expiry)", logins)
+	}
+	if updates != 2 {
+		t.Errorf("update attempts = %d, want 2", updates)
+	}
+}

--- a/cmd/dune-admin/control_amp_update_test.go
+++ b/cmd/dune-admin/control_amp_update_test.go
@@ -174,6 +174,10 @@ func stepClock(step time.Duration) func() time.Time {
 	}
 }
 
+// noopCtxSleep is a sleepFn stub that never blocks and never reports
+// cancellation — used by tests that don't care about ctx cancellation.
+func noopCtxSleep(context.Context, time.Duration) error { return nil }
+
 // TestWaitForUpdateThenRestart_WaitsForTaskToClear verifies the watcher restarts
 // only after the AMP update task has appeared and then cleared.
 func TestWaitForUpdateThenRestart_WaitsForTaskToClear(t *testing.T) {
@@ -189,8 +193,8 @@ func TestWaitForUpdateThenRestart_WaitsForTaskToClear(t *testing.T) {
 		return n, nil
 	}
 	restarted := false
-	err := waitForUpdateThenRestart(statusFn, func() error { restarted = true; return nil },
-		func(time.Duration) {}, stepClock(ampUpdatePollInterval))
+	err := waitForUpdateThenRestart(context.Background(), statusFn, func() error { restarted = true; return nil },
+		noopCtxSleep, stepClock(ampUpdatePollInterval))
 	if err != nil {
 		t.Fatalf("waitForUpdateThenRestart: %v", err)
 	}
@@ -209,9 +213,10 @@ func TestWaitForUpdateThenRestart_RestartsIfTaskNeverAppears(t *testing.T) {
 	t.Parallel()
 	restarted := false
 	err := waitForUpdateThenRestart(
+		context.Background(),
 		func() (int, error) { return 0, nil },
 		func() error { restarted = true; return nil },
-		func(time.Duration) {},
+		noopCtxSleep,
 		stepClock(ampUpdateAppearGrace), // each poll jumps a full grace window
 	)
 	if err != nil {
@@ -228,9 +233,10 @@ func TestWaitForUpdateThenRestart_RestartsAtMaxWait(t *testing.T) {
 	t.Parallel()
 	restarted := false
 	err := waitForUpdateThenRestart(
+		context.Background(),
 		func() (int, error) { return 1, nil }, // task never clears
 		func() error { restarted = true; return nil },
-		func(time.Duration) {},
+		noopCtxSleep,
 		stepClock(ampUpdateMaxWait), // blow past the cap on the second poll
 	)
 	if err != nil {
@@ -246,13 +252,50 @@ func TestWaitForUpdateThenRestart_RestartsAtMaxWait(t *testing.T) {
 func TestWaitForUpdateThenRestart_PropagatesRestartError(t *testing.T) {
 	t.Parallel()
 	err := waitForUpdateThenRestart(
+		context.Background(),
 		func() (int, error) { return 0, nil },
 		func() error { return errors.New("restart boom") },
-		func(time.Duration) {},
+		noopCtxSleep,
 		stepClock(ampUpdateAppearGrace),
 	)
 	if err == nil || !strings.Contains(err.Error(), "restart boom") {
 		t.Fatalf("expected restart error to propagate, got: %v", err)
+	}
+}
+
+// TestWaitForUpdateThenRestart_CtxCancelledStopsWithoutRestart verifies that
+// when the caller's context is cancelled mid-poll, the loop returns the
+// cancellation error immediately and does NOT restart the container — a
+// cancelled watcher (e.g. dune-admin shutting down) must not still fire a
+// container restart behind the operator's back.
+func TestWaitForUpdateThenRestart_CtxCancelledStopsWithoutRestart(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	polls := 0
+	statusFn := func() (int, error) {
+		polls++
+		return 1, nil // task never clears on its own — only cancellation ends this
+	}
+	cancelOnFirstSleep := func(ctx context.Context, _ time.Duration) error {
+		cancel()
+		return ctx.Err()
+	}
+	restarted := false
+	err := waitForUpdateThenRestart(
+		ctx,
+		statusFn,
+		func() error { restarted = true; return nil },
+		cancelOnFirstSleep,
+		stepClock(time.Second), // small steps so grace/max-wait never trip first
+	)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForUpdateThenRestart error = %v, want context.Canceled", err)
+	}
+	if restarted {
+		t.Error("a cancelled watcher must not restart the container")
+	}
+	if polls != 1 {
+		t.Errorf("polls = %d, want exactly 1 (loop must stop right after cancellation)", polls)
 	}
 }
 
@@ -310,7 +353,9 @@ func TestAmpExecCommand_UpdateMissingCredentials(t *testing.T) {
 
 // TestAmpExecCommand_UpdateRejectionPropagates verifies an AMP ActionResult
 // rejection (e.g. already up to date) surfaces its reason rather than being
-// swallowed.
+// swallowed, and names the actual failing action rather than the mislabeled
+// "SetConfig" (parseActionResult is shared with setConfig; postUpdate must
+// pass its own action label instead of inheriting setConfig's).
 func TestAmpExecCommand_UpdateRejectionPropagates(t *testing.T) {
 	t.Parallel()
 	exec := &fnExecutor{fn: func(cmd string) (string, error) {
@@ -325,6 +370,12 @@ func TestAmpExecCommand_UpdateRejectionPropagates(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "already up to date") {
 		t.Errorf("error should surface the AMP reason, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "SetConfig") {
+		t.Errorf("update error must not say SetConfig (wrong action), got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "UpdateApplication") {
+		t.Errorf("update error should name UpdateApplication as the failing action, got: %v", err)
 	}
 }
 

--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -214,6 +214,18 @@ type appConfig struct {
 	AmpPgLib     string `yaml:"amp_pg_lib"     json:"amp_pg_lib"`
 	AmpBackupDir string `yaml:"amp_backup_dir" json:"amp_backup_dir"`
 
+	// AmpContainerStopTimeout is the seconds `<runtime> restart` waits for a
+	// graceful stop before SIGKILL in container mode. 0 → the built-in default
+	// (ampContainerStopTimeout). The runtime default of 10s is too short for the
+	// game shards + in-container Postgres/RabbitMQ and can leave the container
+	// wedged in "stopping" when podman escalates to SIGKILL.
+	AmpContainerStopTimeout int `yaml:"amp_container_stop_timeout" json:"amp_container_stop_timeout"`
+	// AmpUpdateAutoRestart controls whether an AMP "update" automatically restarts
+	// the container once the SteamCMD update finishes (so it boots on the new
+	// files). nil/unset → true. Set false to have update only trigger the update
+	// and leave restarting to the operator.
+	AmpUpdateAutoRestart *bool `yaml:"amp_update_auto_restart" json:"amp_update_auto_restart"`
+
 	// ── Embedded market bot ────────────────────────────────────────────────
 	// MarketBotEnabled starts the market bot as an in-process goroutine.
 	// Pointer so we can distinguish "unset" (default-on) from "explicitly false".

--- a/cmd/dune-admin/server_registry.go
+++ b/cmd/dune-admin/server_registry.go
@@ -88,6 +88,11 @@ type ServerConfig struct {
 	AmpPgLib            string `yaml:"amp_pg_lib"            json:"amp_pg_lib"`
 	AmpBackupDir        string `yaml:"amp_backup_dir"        json:"amp_backup_dir"`
 
+	// Container-restart stop timeout (seconds; 0 → built-in default) and whether
+	// an AMP update auto-restarts the container when it finishes (nil → true).
+	AmpContainerStopTimeout int   `yaml:"amp_container_stop_timeout" json:"amp_container_stop_timeout"`
+	AmpUpdateAutoRestart    *bool `yaml:"amp_update_auto_restart"    json:"amp_update_auto_restart"`
+
 	// Director proxy.
 	DirectorURL string `yaml:"director_url" json:"director_url"`
 

--- a/cmd/dune-admin/servers_columns.go
+++ b/cmd/dune-admin/servers_columns.go
@@ -59,6 +59,8 @@ var serverColumnAlters = []string{
 	"ALTER TABLE servers ADD COLUMN amp_pg_bin TEXT NOT NULL DEFAULT ''",
 	"ALTER TABLE servers ADD COLUMN amp_pg_lib TEXT NOT NULL DEFAULT ''",
 	"ALTER TABLE servers ADD COLUMN amp_backup_dir TEXT NOT NULL DEFAULT ''",
+	"ALTER TABLE servers ADD COLUMN amp_container_stop_timeout INTEGER NOT NULL DEFAULT 0",
+	"ALTER TABLE servers ADD COLUMN amp_update_auto_restart INTEGER",
 	"ALTER TABLE servers ADD COLUMN director_url TEXT NOT NULL DEFAULT ''",
 	"ALTER TABLE servers ADD COLUMN market_bot_enabled INTEGER",
 	"ALTER TABLE servers ADD COLUMN web_interface_host_override TEXT NOT NULL DEFAULT ''",
@@ -86,6 +88,7 @@ const serverColumnNames = `ssh_host, ssh_user, ssh_key, ssh_mode, ssh_extra_opts
 	broker_exec_prefix, backup_dir, server_ini_dir, default_ini_dir,
 	amp_instance, amp_container, amp_user, amp_log_path, amp_use_container, amp_container_runtime,
 	amp_data_root, amp_api_user, amp_api_pass, amp_api_port, amp_pg_bin, amp_pg_lib, amp_backup_dir,
+	amp_container_stop_timeout, amp_update_auto_restart,
 	director_url, market_bot_enabled, web_interface_host_override, timezone`
 
 // writeServerColumns updates the typed columns for an existing server row.
@@ -100,7 +103,8 @@ func writeServerColumns(db dbExecer, id int, cfg ServerConfig) error {
 		broker_jwt_secret=?, broker_exec_prefix=?, backup_dir=?, server_ini_dir=?, default_ini_dir=?,
 		amp_instance=?, amp_container=?, amp_user=?, amp_log_path=?, amp_use_container=?,
 		amp_container_runtime=?, amp_data_root=?, amp_api_user=?, amp_api_pass=?, amp_api_port=?,
-		amp_pg_bin=?, amp_pg_lib=?, amp_backup_dir=?, director_url=?, market_bot_enabled=?,
+		amp_pg_bin=?, amp_pg_lib=?, amp_backup_dir=?,
+		amp_container_stop_timeout=?, amp_update_auto_restart=?, director_url=?, market_bot_enabled=?,
 		web_interface_host_override=?, timezone=?
 		WHERE id=?`,
 		cfg.SSHHost, cfg.SSHUser, cfg.SSHKey, cfg.SSHMode, cfg.SSHExtraOpts, b2i(cfg.AutoDiscover),
@@ -111,7 +115,8 @@ func writeServerColumns(db dbExecer, id int, cfg ServerConfig) error {
 		cfg.BrokerJWTSecret, cfg.BrokerExecPrefix, cfg.BackupDir, cfg.ServerIniDir, cfg.DefaultIniDir,
 		cfg.AmpInstance, cfg.AmpContainer, cfg.AmpUser, cfg.AmpLogPath, boolPtrToNullInt(cfg.AmpUseContainer),
 		cfg.AmpContainerRuntime, cfg.AmpDataRoot, cfg.AmpAPIUser, cfg.AmpAPIPass, cfg.AmpAPIPort,
-		cfg.AmpPgBin, cfg.AmpPgLib, cfg.AmpBackupDir, cfg.DirectorURL, boolPtrToNullInt(cfg.MarketBotEnabled),
+		cfg.AmpPgBin, cfg.AmpPgLib, cfg.AmpBackupDir,
+		cfg.AmpContainerStopTimeout, boolPtrToNullInt(cfg.AmpUpdateAutoRestart), cfg.DirectorURL, boolPtrToNullInt(cfg.MarketBotEnabled),
 		cfg.WebInterfaceHostOverride, cfg.Timezone,
 		id)
 	if err != nil {
@@ -125,7 +130,7 @@ func writeServerColumns(db dbExecer, id int, cfg ServerConfig) error {
 func readServerColumns(db dbRowQueryer, id int) (ServerConfig, error) {
 	var cfg ServerConfig
 	var autoDiscover, brokerTLS int
-	var ampUseContainer, marketBotEnabled sql.NullInt64
+	var ampUseContainer, marketBotEnabled, ampUpdateAutoRestart sql.NullInt64
 	err := db.QueryRow(`SELECT `+serverColumnNames+` FROM servers WHERE id=?`, id).Scan(
 		&cfg.SSHHost, &cfg.SSHUser, &cfg.SSHKey, &cfg.SSHMode, &cfg.SSHExtraOpts, &autoDiscover,
 		&cfg.DBHost, &cfg.DBPort, &cfg.DBUser, &cfg.DBPass, &cfg.DBName, &cfg.DBSchema, &cfg.Control,
@@ -135,7 +140,8 @@ func readServerColumns(db dbRowQueryer, id int) (ServerConfig, error) {
 		&cfg.BrokerJWTSecret, &cfg.BrokerExecPrefix, &cfg.BackupDir, &cfg.ServerIniDir, &cfg.DefaultIniDir,
 		&cfg.AmpInstance, &cfg.AmpContainer, &cfg.AmpUser, &cfg.AmpLogPath, &ampUseContainer,
 		&cfg.AmpContainerRuntime, &cfg.AmpDataRoot, &cfg.AmpAPIUser, &cfg.AmpAPIPass, &cfg.AmpAPIPort,
-		&cfg.AmpPgBin, &cfg.AmpPgLib, &cfg.AmpBackupDir, &cfg.DirectorURL, &marketBotEnabled,
+		&cfg.AmpPgBin, &cfg.AmpPgLib, &cfg.AmpBackupDir,
+		&cfg.AmpContainerStopTimeout, &ampUpdateAutoRestart, &cfg.DirectorURL, &marketBotEnabled,
 		&cfg.WebInterfaceHostOverride, &cfg.Timezone)
 	if err != nil {
 		return ServerConfig{}, err
@@ -144,6 +150,7 @@ func readServerColumns(db dbRowQueryer, id int) (ServerConfig, error) {
 	cfg.AutoDiscover = autoDiscover != 0
 	cfg.BrokerTLS = brokerTLS != 0
 	cfg.AmpUseContainer = nullIntToBoolPtr(ampUseContainer)
+	cfg.AmpUpdateAutoRestart = nullIntToBoolPtr(ampUpdateAutoRestart)
 	cfg.MarketBotEnabled = nullIntToBoolPtr(marketBotEnabled)
 	return cfg, nil
 }

--- a/cmd/dune-admin/servers_store_test.go
+++ b/cmd/dune-admin/servers_store_test.go
@@ -78,6 +78,45 @@ func TestServersStore_GetUpdateDelete(t *testing.T) {
 	}
 }
 
+// TestServersStore_RoundTripsAmpUpdateFields guards the DB column plumbing for
+// the two AMP update/restart knobs: a mis-ordered column would silently scramble
+// their values. It checks both a set config and the unset (default) case.
+func TestServersStore_RoundTripsAmpUpdateFields(t *testing.T) {
+	db := openMemUnifiedStore(t)
+	s := newServersStore(db)
+
+	no := false
+	id, err := s.insertServer(ServerConfig{
+		Name: "amp", Control: "amp", AmpInstance: "Dune01",
+		AmpContainerStopTimeout: 90,
+		AmpUpdateAutoRestart:    &no,
+	}, 0)
+	if err != nil {
+		t.Fatalf("insertServer: %v", err)
+	}
+	got, ok, err := s.getServer(id)
+	if err != nil || !ok {
+		t.Fatalf("getServer: ok=%v err=%v", ok, err)
+	}
+	if got.AmpContainerStopTimeout != 90 {
+		t.Errorf("AmpContainerStopTimeout = %d, want 90 (column mis-order?)", got.AmpContainerStopTimeout)
+	}
+	if got.AmpUpdateAutoRestart == nil || *got.AmpUpdateAutoRestart {
+		t.Errorf("AmpUpdateAutoRestart = %v, want non-nil false", got.AmpUpdateAutoRestart)
+	}
+
+	// Unset must round-trip as nil / 0 so config defaults (auto-restart on, 60s)
+	// apply at construction.
+	id2, _ := s.insertServer(ServerConfig{Name: "amp2", Control: "amp"}, 1)
+	got2, _, _ := s.getServer(id2)
+	if got2.AmpUpdateAutoRestart != nil {
+		t.Errorf("unset AmpUpdateAutoRestart = %v, want nil", got2.AmpUpdateAutoRestart)
+	}
+	if got2.AmpContainerStopTimeout != 0 {
+		t.Errorf("unset AmpContainerStopTimeout = %d, want 0", got2.AmpContainerStopTimeout)
+	}
+}
+
 func TestServersStore_HasAnyAndNextPosition(t *testing.T) {
 	db := openMemUnifiedStore(t)
 	s := newServersStore(db)


### PR DESCRIPTION
## Summary

The **Update** and **Restart** buttons in Server Health → Server Control are broken for the AMP control plane. This fixes both, with the new tuning knobs exposed as config.

### 1. Update was a hard error

`ACTIONS` ships an Update button and `bgCmdAllowlist` allows `"update"`, but `ampControl.ExecCommand`'s switch only handles start/stop/restart → every AMP user clicking Update hits the `default` branch:

```
Error: exec: amp control does not support "update"
```

Implemented `update` as AMP's SteamCMD update via the instance Web API `Core/UpdateApplication` — the same action as the AMP dashboard's Update button (`amp_api.go`: `updateApplication()` / `postUpdate()`; empty/`{}`/RunningTask = success, `{"Status":false}` = surfaced error; one relogin retry, mirroring `setConfig`).

### 2. Update crashed a running server → now auto-recovers

`Core/UpdateApplication` rewrites the game files in place while the `DuneSandboxServer` shards are still running, which segfaults them. In the containerised setup neither `ampinstmgr` stop nor AMP's app-stop reap those shards — only a container restart cycles them — and you can't restart before updating because the ADS that runs the update lives inside that same container. So `update` now: trigger the update → a background watcher polls `Core/GetStatus` `RunningTasks` until it finishes → restart the container so it boots clean on the new files. The HTTP call returns immediately (SteamCMD updates take minutes). See `waitForUpdateThenRestart` (pure, unit-tested with an injected clock/sleep).

This auto-restart is the opinionated part — happy to adjust. It's gated by config (below) and defaults on.

### 3. Restart could wedge the container

`restartGame`'s container path used bare `<runtime> restart`, i.e. podman/docker's **10s** stop default. The shards + in-container Postgres + RabbitMQ take longer than 10s to stop gracefully, so the runtime escalates to SIGKILL, which has been observed to leave the container wedged in `stopping` ("given PID did not die within timeout"), needing a manual host-level kill. Now passes an explicit graceful-stop timeout (default 60s) so it exits cleanly on SIGINT.

## New config (per-server, both optional)

- `amp_container_stop_timeout` (int seconds, default 60) — the `restart -t N` graceful-stop window.
- `amp_update_auto_restart` (bool, default true) — set false to trigger the SteamCMD update only and leave restarting to the operator.

Threaded through the existing per-server config path (Config/ServerConfig structs, `servers` table columns, connection mapping, `control.go`). Documented in `SETUP_AMP.md`.

## Testing

- New `control_amp_update_test.go`: update calls `Core/UpdateApplication` (wrapped for in-container exec), missing-credentials guard, AMP-rejection propagation, login-failure abort, void/RunningTask acceptance, session-expiry retry, recovery-hook wiring, auto-restart-disabled path, configured stop-timeout, and the `waitForUpdateThenRestart` orchestration (task-clears / never-appears / max-wait / restart-error).
- `servers_store_test.go`: round-trip for the two new columns (guards column ordering).
- Updated the existing restart tests for the new `-t` timeout.
- `make verify`, `make gosec`, `make lint-md`, and `go test -race ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
