### PR TITLE
feat(players): allow adding arbitrary custom tags

### DIFF
--- a/web/src/locales/de/translation.json
+++ b/web/src/locales/de/translation.json
@@ -1076,6 +1076,7 @@
         "activeTagsLabel": "Aktive Tags",
         "addCount_one": "Hinzufügen ({{count}})",
         "addCount_other": "Hinzufügen ({{count}})",
+        "addCustom": "Benutzerdefinierten Tag hinzufügen: \"{{tag}}\"",
         "addTags": "Tags hinzufügen",
         "filterPlaceholder": "Zum Entfernen filtern…",
         "noTags": "Keine Tags",

--- a/web/src/locales/en-US/translation.json
+++ b/web/src/locales/en-US/translation.json
@@ -1076,6 +1076,7 @@
         "activeTagsLabel": "Active tags",
         "addCount_one": "Add ({{count}})",
         "addCount_other": "Add ({{count}})",
+        "addCustom": "Add custom tag: \"{{tag}}\"",
         "addTags": "Add Tags",
         "filterPlaceholder": "Filter to remove…",
         "noTags": "No tags",

--- a/web/src/locales/es/translation.json
+++ b/web/src/locales/es/translation.json
@@ -1091,6 +1091,7 @@
         "addCount_one": "Añadir ({{count}})",
         "addCount_many": "Añadir ({{count}})",
         "addCount_other": "Añadir ({{count}})",
+        "addCustom": "Añadir etiqueta personalizada: \"{{tag}}\"",
         "addTags": "Añadir etiquetas",
         "filterPlaceholder": "Filtrar para eliminar…",
         "noTags": "Sin etiquetas",

--- a/web/src/locales/fr/translation.json
+++ b/web/src/locales/fr/translation.json
@@ -1091,6 +1091,7 @@
         "addCount_one": "Ajouter ({{count}})",
         "addCount_many": "Ajouter ({{count}})",
         "addCount_other": "Ajouter ({{count}})",
+        "addCustom": "Ajouter une étiquette personnalisée : \"{{tag}}\"",
         "addTags": "Ajouter des étiquettes",
         "filterPlaceholder": "Filtrer pour supprimer…",
         "noTags": "Aucune étiquette",

--- a/web/src/locales/ja/translation.json
+++ b/web/src/locales/ja/translation.json
@@ -1076,6 +1076,7 @@
         "activeTagsLabel": "アクティブタグ",
         "addCount_one": "追加 ({{count}})",
         "addCount_other": "追加 ({{count}})",
+        "addCustom": "カスタムタグを追加: \"{{tag}}\"",
         "addTags": "タグを追加",
         "filterPlaceholder": "削除するタグをフィルター…",
         "noTags": "タグがありません",

--- a/web/src/locales/pl/translation.json
+++ b/web/src/locales/pl/translation.json
@@ -1106,6 +1106,7 @@
         "addCount_few": "Dodaj ({{count}})",
         "addCount_many": "Dodaj ({{count}})",
         "addCount_other": "Dodaj ({{count}})",
+        "addCustom": "Dodaj niestandardowy tag: \"{{tag}}\"",
         "addTags": "Dodaj tagi",
         "filterPlaceholder": "Filtruj do usunięcia…",
         "noTags": "Brak tagów",

--- a/web/src/locales/pt-BR/translation.json
+++ b/web/src/locales/pt-BR/translation.json
@@ -1091,6 +1091,7 @@
         "addCount_one": "Adicionar ({{count}})",
         "addCount_many": "Adicionar ({{count}})",
         "addCount_other": "Adicionar ({{count}})",
+        "addCustom": "Adicionar tag personalizada: \"{{tag}}\"",
         "addTags": "Adicionar tags",
         "filterPlaceholder": "Filtrar para remover…",
         "noTags": "Sem tags",

--- a/web/src/locales/ru/translation.json
+++ b/web/src/locales/ru/translation.json
@@ -1106,6 +1106,7 @@
         "addCount_few": "Добавить ({{count}})",
         "addCount_many": "Добавить ({{count}})",
         "addCount_other": "Добавить ({{count}})",
+        "addCustom": "Добавить пользовательский тег: \"{{tag}}\"",
         "addTags": "Добавить теги",
         "filterPlaceholder": "Фильтр для удаления…",
         "noTags": "Нет тегов",

--- a/web/src/locales/tr/translation.json
+++ b/web/src/locales/tr/translation.json
@@ -1076,6 +1076,7 @@
         "activeTagsLabel": "Aktif etiketler",
         "addCount_one": "Ekle ({{count}})",
         "addCount_other": "Ekle ({{count}})",
+        "addCustom": "Özel etiket ekle: \"{{tag}}\"",
         "addTags": "Etiket Ekle",
         "filterPlaceholder": "Kaldırmak için filtrele…",
         "noTags": "Etiket yok",

--- a/web/src/locales/zh-CN/translation.json
+++ b/web/src/locales/zh-CN/translation.json
@@ -1076,6 +1076,7 @@
         "activeTagsLabel": "活跃标签",
         "addCount_one": "添加 ({{count}})",
         "addCount_other": "添加 ({{count}})",
+        "addCustom": "添加自定义标签：\"{{tag}}\"",
         "addTags": "添加标签",
         "filterPlaceholder": "筛选要移除的标签…",
         "noTags": "无标签",

--- a/web/src/tabs/PlayersTab/views/ActionsView/components/AddTagsPanel.tsx
+++ b/web/src/tabs/PlayersTab/views/ActionsView/components/AddTagsPanel.tsx
@@ -6,6 +6,8 @@ import { gameplayTagsSyncAtom } from '../../../../../data/store'
 import { useDebounce } from '../hooks/useDebounce'
 import type { AddTagsPanelProps } from './interfaces'
 
+const normalizeTag = (value: string): string => value.trim().replace(/\s+/g, ' ')
+
 export const AddTagsPanel: React.FC<AddTagsPanelProps> = React.memo(({ tags, pendingTags, onAdd }) => {
   const { t } = useTranslation()
   const [query, setQuery] = React.useState('')
@@ -22,6 +24,41 @@ export const AddTagsPanel: React.FC<AddTagsPanelProps> = React.memo(({ tags, pen
       .slice(0, 100)
   }, [debouncedQuery, tags, pendingTags, allTags])
 
+  const custom = normalizeTag(debouncedQuery)
+  const customLower = custom.toLowerCase()
+  const isKnownTag = (allTags ?? []).some((tg) => tg.toLowerCase() === customLower)
+  const isAlreadyApplied = tags.some((tg) => tg.toLowerCase() === customLower)
+    || pendingTags.some((tg) => tg.toLowerCase() === customLower)
+  const showCustom = custom !== '' && !isKnownTag && !isAlreadyApplied
+  const showDropdown = query.length > 0 && (matches.length > 0 || showCustom)
+
+  const selectOption = (value: string): void => {
+    onAdd(value)
+    setQuery('')
+  }
+
+  const renderOption = (value: string, isCustom: boolean): React.ReactNode => (
+    <div
+      key={isCustom ? `__custom__${value}` : value}
+      className="px-3 py-1.5 text-xs cursor-pointer hover:bg-surface-hover"
+      onMouseDown={(e) => {
+        e.preventDefault()
+        selectOption(value)
+      }}
+    >
+      {isCustom
+        ? <span className="text-accent">{t('players.actions.tags.addCustom', { tag: value })}</span>
+        : <span className="font-mono">{value}</span>}
+    </div>
+  )
+
+  const renderDropdown = (): React.ReactNode => (
+    <div className="absolute z-50 w-full mt-1 max-h-52 overflow-y-auto rounded-[var(--radius)] border border-border bg-surface">
+      {matches.map((m) => renderOption(m, false))}
+      {showCustom ? renderOption(custom, true) : null}
+    </div>
+  )
+
   return (
     <div className="relative">
       <SearchField value={query} onChange={setQuery} variant="secondary" aria-label={t('players.actions.tags.searchPlaceholder')}>
@@ -31,23 +68,7 @@ export const AddTagsPanel: React.FC<AddTagsPanelProps> = React.memo(({ tags, pen
           <SearchField.ClearButton />
         </SearchField.Group>
       </SearchField>
-      {query && matches.length > 0 && (
-        <div className="absolute z-50 w-full mt-1 max-h-52 overflow-y-auto rounded-[var(--radius)] border border-border bg-surface">
-          {matches.map((t) => (
-            <div
-              key={t}
-              className="px-3 py-1.5 text-xs font-mono cursor-pointer hover:bg-surface-hover"
-              onMouseDown={(e) => {
-                e.preventDefault()
-                onAdd(t)
-                setQuery('')
-              }}
-            >
-              {t}
-            </div>
-          ))}
-        </div>
-      )}
+      {showDropdown ? renderDropdown() : null}
     </div>
   )
 })


### PR DESCRIPTION
## Summary
- Frontend-only. The backend already persists free-form tags (`handleUpdatePlayerTags`/`upsertPlayerTags` have no allow-list); the UI was the only gate, restricting adds to the known `gameplayTags` list.
- `AddTagsPanel` now offers an "Add custom tag" dropdown option (with trim + whitespace-collapse normalization) whenever the typed value isn't an exact known/already-applied/pending tag, while keeping known-tag suggestions.

## Test plan
- [x] `pnpm build` && `pnpm lint` pass
- [ ] Manual: type a known-tag substring, confirm existing suggestions still work
- [ ] Manual: type a brand-new value, confirm an "Add custom tag" row appears and persists correctly

Addresses #101