### PR TITLE
feat(market): disable item directly from the Market Board

### DIFF
--- a/web/src/locales/en-US/translation.json
+++ b/web/src/locales/en-US/translation.json
@@ -649,6 +649,15 @@
       "tickingEnabled": "Ticking enabled"
     },
     "botControl": "Bot Control",
+    "disable": {
+      "alreadyDisabled": "Disabled",
+      "ariaLabel": "Disable {{name}} for the market bot",
+      "button": "Disable",
+      "confirmBody": "{{name}} will be blacklisted from the market bot. Its bot listings are removed on the next bot tick — no full market wipe. Player-owned orders are never affected.",
+      "confirmLabel": "Disable",
+      "confirmTitle": "Disable market item?",
+      "success": "{{name}} disabled — bot listings clear on the next tick."
+    },
     "itemDetail": {
       "activeListings": "Active Listings",
       "armorStats": "Armor Stats",
@@ -689,6 +698,7 @@
     },
     "subtitle": "Browse active exchange listings from bot and player sellers.",
     "table": {
+      "actions": "Actions",
       "ariaLabel": "Market items",
       "botStock": "Bot Stock",
       "category": "Category",

--- a/web/src/tabs/MarketTab/DisableItemAction.tsx
+++ b/web/src/tabs/MarketTab/DisableItemAction.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react'
+import { Button, toast } from '@heroui/react'
+import { useTranslation } from 'react-i18next'
+import { api } from '../../api/client'
+import { ConfirmDialog, Icon } from '../../dune-ui'
+import type { DisableItemActionProps } from './types'
+
+export const DisableItemAction: React.FC<DisableItemActionProps> = (
+  { item, botConfig, canManage, onDisabled, variant }: DisableItemActionProps,
+) => {
+  const { t } = useTranslation()
+  const [confirmOpen, setConfirmOpen] = React.useState(false)
+  const [saving, setSaving] = React.useState(false)
+
+  if (!canManage || !botConfig) return null
+
+  const name = item.display_name || item.template_id
+  const alreadyDisabled = botConfig.disabled_items.includes(item.template_id)
+
+  if (alreadyDisabled) {
+    return (
+      <span className="text-xs text-muted whitespace-nowrap">
+        {t('market.disable.alreadyDisabled')}
+      </span>
+    )
+  }
+
+  const handleConfirm = async (): Promise<void> => {
+    setSaving(true)
+    try {
+      const saved = await api.marketBot.saveConfig({
+        ...botConfig,
+        disabled_items: [...botConfig.disabled_items, item.template_id],
+      })
+      onDisabled(saved)
+      toast.success(t('market.disable.success', { name }))
+    }
+    catch (e: unknown) {
+      toast.danger(t('common.failed', { message: e instanceof Error ? e.message : String(e) }))
+    }
+    finally {
+      setSaving(false)
+      setConfirmOpen(false)
+    }
+  }
+
+  return (
+    <React.Fragment>
+      {variant === 'icon'
+        ? (
+            <Button
+              size="sm"
+              variant="danger-soft"
+              isIconOnly
+              aria-label={t('market.disable.ariaLabel', { name })}
+              isDisabled={saving}
+              onPress={() => setConfirmOpen(true)}
+            >
+              <Icon name="ban" />
+            </Button>
+          )
+        : (
+            <Button
+              size="sm"
+              variant="danger-soft"
+              isDisabled={saving}
+              onPress={() => setConfirmOpen(true)}
+            >
+              {t('market.disable.button')}
+            </Button>
+          )}
+      <ConfirmDialog
+        open={confirmOpen}
+        title={t('market.disable.confirmTitle')}
+        description={t('market.disable.confirmBody', { name })}
+        confirmLabel={t('market.disable.confirmLabel')}
+        onConfirm={() => { void handleConfirm() }}
+        onCancel={() => setConfirmOpen(false)}
+      />
+    </React.Fragment>
+  )
+}

--- a/web/src/tabs/MarketTab/MarketGrid.tsx
+++ b/web/src/tabs/MarketTab/MarketGrid.tsx
@@ -7,6 +7,7 @@ import { iconUrl, categoryColor, qualityLabel, BG_PURPLE } from '../../utils/ico
 import { itemDataSyncAtom } from '../../data/store'
 import type { MarketGridProps } from './types'
 import { QualityArc } from './QualityArc'
+import { DisableItemAction } from './DisableItemAction'
 
 // Max volume for bar scaling (most wearable/weapon items top out around 30V)
 const VOL_MAX = 30
@@ -32,7 +33,9 @@ const RARITY_BORDER: Record<string, string> = {
   memento: 'border-rarity-memento/60',
 }
 
-export const MarketGrid: React.FC<MarketGridProps> = ({ items, onSelect }: MarketGridProps) => {
+export const MarketGrid: React.FC<MarketGridProps> = (
+  { items, onSelect, canManageBot, botConfig, onItemDisabled }: MarketGridProps,
+) => {
   const { t } = useTranslation()
   const itemData = useAtomValue(itemDataSyncAtom)
 
@@ -68,85 +71,97 @@ export const MarketGrid: React.FC<MarketGridProps> = ({ items, onSelect }: Marke
           const volPct = volume > 0 ? Math.min(1, volume / VOL_MAX) * 100 : 0
 
           return (
-            <button
-              key={key}
-              className={`group flex flex-col rounded-[var(--radius)] border-2 ${border} bg-surface text-left transition-all overflow-hidden hover:shadow-md`}
-              onClick={() => onSelect(item)}
-            >
-              {/* Icon area */}
-              <div
-                className="relative w-full aspect-square flex items-center justify-center shrink-0"
-                style={isSchematic
-                  ? SCHEMATIC_BG
-                  : { background: isNamedSet ? BG_PURPLE : categoryColor(item.category, rarity) }}
+            <div key={key} className="relative group">
+              <button
+                className={`flex flex-col w-full rounded-[var(--radius)] border-2 ${border} bg-surface text-left transition-all overflow-hidden hover:shadow-md`}
+                onClick={() => onSelect(item)}
               >
-                {/* Item image */}
-                {img
-                  ? (
-                      <img
-                        src={img}
-                        alt={item.display_name}
-                        className="w-full h-full object-contain p-2 transition-transform duration-200 group-hover:scale-105"
-                        onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none' }}
+                {/* Icon area */}
+                <div
+                  className="relative w-full aspect-square flex items-center justify-center shrink-0"
+                  style={isSchematic
+                    ? SCHEMATIC_BG
+                    : { background: isNamedSet ? BG_PURPLE : categoryColor(item.category, rarity) }}
+                >
+                  {/* Item image */}
+                  {img
+                    ? (
+                        <img
+                          src={img}
+                          alt={item.display_name}
+                          className="w-full h-full object-contain p-2 transition-transform duration-200 group-hover:scale-105"
+                          onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none' }}
+                        />
+                      )
+                    : (
+                        <span className="text-3xl text-white/20 font-bold uppercase select-none">
+                          {item.display_name.charAt(0)}
+                        </span>
+                      )}
+
+                  {/* Quality arc — top-right corner, only for gradeable items */}
+                  {entry?.is_gradeable && (
+                    <div className="absolute top-1 right-1 pointer-events-none">
+                      <QualityArc quality={item.quality} size={20} />
+                    </div>
+                  )}
+
+                  {/* Left weight/volume bar — teal, scales with volume */}
+                  {volume > 0 && (
+                    <div className="absolute left-1.5 bottom-1.5 w-1 rounded-full overflow-hidden" style={{ height: '40%' }}>
+                      <div className="absolute inset-0 bg-white/10" />
+                      <div
+                        className="absolute bottom-0 left-0 right-0 rounded-full"
+                        style={{ height: `${volPct}%`, background: '#4dd0c4' }}
                       />
-                    )
-                  : (
-                      <span className="text-3xl text-white/20 font-bold uppercase select-none">
-                        {item.display_name.charAt(0)}
+                    </div>
+                  )}
+
+                  {/* Bottom gradient blending into card body */}
+                  <div className="absolute inset-x-0 bottom-0 h-1/4 bg-gradient-to-t from-surface to-transparent pointer-events-none" />
+                </div>
+
+                {/* Card body */}
+                <div className="px-2.5 pb-2.5 pt-1 flex flex-col gap-1 min-w-0">
+                  <span className="text-xs font-medium leading-snug line-clamp-2 text-foreground">
+                    {item.display_name}
+                  </span>
+                  <div className="flex items-center justify-between gap-1">
+                    {item.quality > 0
+                      ? <span className="text-[10px] text-muted truncate">{qualityLabel(item.quality)}</span>
+                      : <span />}
+                    {rarity && (
+                      <span
+                        className="text-[10px] capitalize font-medium shrink-0"
+                        style={{ color: `var(--rarity-${rarity})` }}
+                      >
+                        {rarity}
                       </span>
                     )}
-
-                {/* Quality arc — top-right corner, only for gradeable items */}
-                {entry?.is_gradeable && (
-                  <div className="absolute top-1 right-1 pointer-events-none">
-                    <QualityArc quality={item.quality} size={20} />
                   </div>
-                )}
-
-                {/* Left weight/volume bar — teal, scales with volume */}
-                {volume > 0 && (
-                  <div className="absolute left-1.5 bottom-1.5 w-1 rounded-full overflow-hidden" style={{ height: '40%' }}>
-                    <div className="absolute inset-0 bg-white/10" />
-                    <div
-                      className="absolute bottom-0 left-0 right-0 rounded-full"
-                      style={{ height: `${volPct}%`, background: '#4dd0c4' }}
-                    />
-                  </div>
-                )}
-
-                {/* Bottom gradient blending into card body */}
-                <div className="absolute inset-x-0 bottom-0 h-1/4 bg-gradient-to-t from-surface to-transparent pointer-events-none" />
-              </div>
-
-              {/* Card body */}
-              <div className="px-2.5 pb-2.5 pt-1 flex flex-col gap-1 min-w-0">
-                <span className="text-xs font-medium leading-snug line-clamp-2 text-foreground">
-                  {item.display_name}
-                </span>
-                <div className="flex items-center justify-between gap-1">
-                  {item.quality > 0
-                    ? <span className="text-[10px] text-muted truncate">{qualityLabel(item.quality)}</span>
-                    : <span />}
-                  {rarity && (
-                    <span
-                      className="text-[10px] capitalize font-medium shrink-0"
-                      style={{ color: `var(--rarity-${rarity})` }}
-                    >
-                      {rarity}
+                  <div className="flex items-center justify-between gap-1 pt-1.5 border-t border-border/40 mt-0.5">
+                    <span className="text-sm font-mono text-accent font-semibold truncate">
+                      {item.lowest_price.toLocaleString()}
                     </span>
-                  )}
+                    <span className="text-[10px] text-muted shrink-0">
+                      ×
+                      {item.total_stock.toLocaleString()}
+                    </span>
+                  </div>
                 </div>
-                <div className="flex items-center justify-between gap-1 pt-1.5 border-t border-border/40 mt-0.5">
-                  <span className="text-sm font-mono text-accent font-semibold truncate">
-                    {item.lowest_price.toLocaleString()}
-                  </span>
-                  <span className="text-[10px] text-muted shrink-0">
-                    ×
-                    {item.total_stock.toLocaleString()}
-                  </span>
-                </div>
+              </button>
+
+              {/* Disable action — sibling overlay, not nested in the card button (#288) */}
+              <div className="absolute top-1 left-1 z-10 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+                <DisableItemAction
+                  item={item}
+                  botConfig={botConfig}
+                  canManage={canManageBot}
+                  onDisabled={onItemDisabled}
+                  variant="icon"
+                />
               </div>
-            </button>
+            </div>
           )
         })}
       </div>

--- a/web/src/tabs/MarketTab/MarketTab.tsx
+++ b/web/src/tabs/MarketTab/MarketTab.tsx
@@ -3,7 +3,7 @@ import { useAtom } from 'jotai'
 import { Button, Spinner } from '@heroui/react'
 import { useTranslation } from 'react-i18next'
 import { api } from '../../api/client'
-import type { MarketItem } from '../../api/client'
+import type { MarketItem, BotConfig } from '../../api/client'
 import { usePermissions } from '../../hooks/usePermissions'
 import { Icon, LoadingState, PageHeader } from '../../dune-ui'
 import { MarketSidebar } from './MarketSidebar'
@@ -33,6 +33,8 @@ export const MarketTab: React.FC = () => {
   // Show Bot Control whenever the bot is configured (embedded or remote),
   // even if currently disabled/not running.
   const [botConfigured, setBotConfigured] = React.useState(false)
+  const [botConfig, setBotConfig] = React.useState<BotConfig | null>(null)
+  const canManageBot = can('market-bot:manage')
 
   React.useEffect(() => {
     api.marketBot
@@ -42,6 +44,13 @@ export const MarketTab: React.FC = () => {
       .then((s) => setBotConfigured(s.configured ?? (s.mode !== undefined && s.mode !== 'none')))
       .catch(() => setBotConfigured(false))
   }, [])
+
+  // Fetch the bot config so per-row disable actions (#288) can read/update
+  // disabled_items without opening the bot drawer.
+  React.useEffect(() => {
+    if (!canManageBot) return
+    api.marketBot.config().then(setBotConfig).catch(() => {})
+  }, [canManageBot])
 
   const load = (): void => {
     Promise.resolve()
@@ -136,10 +145,22 @@ export const MarketTab: React.FC = () => {
               )
             : view === 'grid'
               ? (
-                  <MarketGrid items={items} onSelect={setSelected} />
+                  <MarketGrid
+                    items={items}
+                    onSelect={setSelected}
+                    canManageBot={canManageBot}
+                    botConfig={botConfig}
+                    onItemDisabled={setBotConfig}
+                  />
                 )
               : (
-                  <MarketTable items={items} onSelect={setSelected} />
+                  <MarketTable
+                    items={items}
+                    onSelect={setSelected}
+                    canManageBot={canManageBot}
+                    botConfig={botConfig}
+                    onItemDisabled={setBotConfig}
+                  />
                 )}
         </div>
 

--- a/web/src/tabs/MarketTab/MarketTable.tsx
+++ b/web/src/tabs/MarketTab/MarketTable.tsx
@@ -6,6 +6,7 @@ import { Icon as IconifyIcon } from '@iconify/react'
 import type { MarketItem } from '../../api/client'
 import { ItemIcon } from '../../components/ItemIcon'
 import { qualityLabel } from '../../utils/icons'
+import { DisableItemAction } from './DisableItemAction'
 import type { MarketTableKey, MarketTableProps } from './types'
 
 const RARITY_COLORS: Record<string, string> = {
@@ -18,7 +19,9 @@ const RARITY_COLORS: Record<string, string> = {
   memento: 'text-rarity-memento',
 }
 
-export const MarketTable: React.FC<MarketTableProps> = ({ items, onSelect }) => {
+export const MarketTable: React.FC<MarketTableProps> = (
+  { items, onSelect, canManageBot, botConfig, onItemDisabled }: MarketTableProps,
+) => {
   const { t } = useTranslation()
 
   const COLUMNS: Column<MarketTableKey>[] = [
@@ -30,6 +33,7 @@ export const MarketTable: React.FC<MarketTableProps> = ({ items, onSelect }) => 
     { key: 'lowest_price', label: t('market.table.lowestPrice'), width: 150 },
     { key: 'total_stock', label: t('market.table.stock'), width: 80 },
     { key: 'listing_count', label: t('market.table.listings'), width: 90 },
+    ...(canManageBot ? [{ key: 'actions' as const, label: t('market.table.actions'), width: 130, sortable: false }] : []),
   ]
 
   return (
@@ -52,6 +56,7 @@ export const MarketTable: React.FC<MarketTableProps> = ({ items, onSelect }) => 
           case 'lowest_price': return it.lowest_price
           case 'total_stock': return it.total_stock
           case 'listing_count': return it.listing_count
+          case 'actions': return ''
         }
       }}
       onRowAction={onSelect}
@@ -102,6 +107,16 @@ export const MarketTable: React.FC<MarketTableProps> = ({ items, onSelect }) => 
             return <span className="text-muted">{it.total_stock.toLocaleString()}</span>
           case 'listing_count':
             return <span className="text-muted">{it.listing_count}</span>
+          case 'actions':
+            return (
+              <DisableItemAction
+                item={it}
+                botConfig={botConfig}
+                canManage={canManageBot}
+                onDisabled={onItemDisabled}
+                variant="button"
+              />
+            )
         }
       }}
     />

--- a/web/src/tabs/MarketTab/types.ts
+++ b/web/src/tabs/MarketTab/types.ts
@@ -1,4 +1,4 @@
-import type { MarketItem } from '../../api/client'
+import type { MarketItem, BotConfig } from '../../api/client'
 
 export type MarketView = 'grid' | 'table'
 
@@ -23,13 +23,29 @@ export type Node = {
 export type MarketGridProps = {
   items: MarketItem[]
   onSelect: (item: MarketItem) => void
+  canManageBot: boolean
+  botConfig: BotConfig | null
+  onItemDisabled: (cfg: BotConfig) => void
 }
 
-export type MarketTableKey = 'display_name' | 'quality' | 'category' | 'tier' | 'rarity' | 'lowest_price' | 'total_stock' | 'listing_count'
+export type MarketTableKey = 'display_name' | 'quality' | 'category' | 'tier' | 'rarity' | 'lowest_price' | 'total_stock' | 'listing_count' | 'actions'
 
 export type MarketTableProps = {
   items: MarketItem[]
   onSelect: (item: MarketItem) => void
+  canManageBot: boolean
+  botConfig: BotConfig | null
+  onItemDisabled: (cfg: BotConfig) => void
+}
+
+export type DisableItemActionVariant = 'button' | 'icon'
+
+export type DisableItemActionProps = {
+  item: MarketItem
+  botConfig: BotConfig | null
+  canManage: boolean
+  onDisabled: (cfg: BotConfig) => void
+  variant: DisableItemActionVariant
 }
 
 export type MarketFilters = {


### PR DESCRIPTION
## Summary
- Per-row "Disable" action in Market Board table + hover icon in grid view, gated on `market-bot:manage`.
- Reuses the existing `saveConfig(disabled_items)` write path — same one the bot drawer's Disabled Items tab already uses.
- Confirmation dialog clarifies: next-tick removal only, no full market wipe, player orders untouched.
- Player-order safety re-confirmed by direct backend reading (not just this PR's own claim): the only write here is a `disabled_items` config PUT. The existing bot-tick prune (`internal/marketbot/exchange.go`) is scoped to `owner_id=<bot> AND is_npc_order=TRUE` — non-NPC (player) orders cannot be touched by this change.

## Test plan
- [ ] As a `market-bot:manage` user, disable an item from the table view — confirm dialog, success toast, row shows "Disabled"
- [ ] Same from grid view via hover icon
- [ ] Confirm ItemDetail doesn't open when the disable control is pressed
- [ ] Open Bot drawer → Disabled Items tab — verify the item now appears there
- [ ] As a non-manage user, confirm no disable control renders
- [ ] Confirm existing player-owned listings for a disabled item remain untouched; only bot listings clear on the next tick

Addresses #288