### PR TITLE
feat(players): separate sort from multi-facet filtering

### DIFF
--- a/web/src/locales/de/translation.json
+++ b/web/src/locales/de/translation.json
@@ -1240,8 +1240,7 @@
       "online": "Online",
       "offline": "Offline",
       "empty": "No players found",
-      "faction": "Filter by faction",
-      "factionAll": "All factions"
+      "faction": "Filter by faction"
     },
     "sort": {
       "label": "Sort by",

--- a/web/src/locales/de/translation.json
+++ b/web/src/locales/de/translation.json
@@ -1239,7 +1239,21 @@
       "all": "All",
       "online": "Online",
       "offline": "Offline",
-      "empty": "No players found"
+      "empty": "No players found",
+      "faction": "Filter by faction",
+      "factionAll": "All factions"
+    },
+    "sort": {
+      "label": "Sort by",
+      "columns": {
+        "id": "ID",
+        "name": "Name",
+        "class": "Class",
+        "map": "Map",
+        "faction_id": "Faction"
+      },
+      "ascLabel": "Sort ascending",
+      "descLabel": "Sort descending"
     },
     "intelAudit": {
       "title": "Intel-Prüfung",

--- a/web/src/locales/en-US/translation.json
+++ b/web/src/locales/en-US/translation.json
@@ -1240,8 +1240,7 @@
       "online": "Online",
       "offline": "Offline",
       "empty": "No players found",
-      "faction": "Filter by faction",
-      "factionAll": "All factions"
+      "faction": "Filter by faction"
     },
     "sort": {
       "label": "Sort by",

--- a/web/src/locales/en-US/translation.json
+++ b/web/src/locales/en-US/translation.json
@@ -1239,7 +1239,21 @@
       "all": "All",
       "online": "Online",
       "offline": "Offline",
-      "empty": "No players found"
+      "empty": "No players found",
+      "faction": "Filter by faction",
+      "factionAll": "All factions"
+    },
+    "sort": {
+      "label": "Sort by",
+      "columns": {
+        "id": "ID",
+        "name": "Name",
+        "class": "Class",
+        "map": "Map",
+        "faction_id": "Faction"
+      },
+      "ascLabel": "Sort ascending",
+      "descLabel": "Sort descending"
     },
     "intelAudit": {
       "title": "Intel Audit",

--- a/web/src/locales/es/translation.json
+++ b/web/src/locales/es/translation.json
@@ -1257,8 +1257,7 @@
       "online": "Online",
       "offline": "Offline",
       "empty": "No players found",
-      "faction": "Filter by faction",
-      "factionAll": "All factions"
+      "faction": "Filter by faction"
     },
     "sort": {
       "label": "Sort by",

--- a/web/src/locales/es/translation.json
+++ b/web/src/locales/es/translation.json
@@ -1256,7 +1256,21 @@
       "all": "All",
       "online": "Online",
       "offline": "Offline",
-      "empty": "No players found"
+      "empty": "No players found",
+      "faction": "Filter by faction",
+      "factionAll": "All factions"
+    },
+    "sort": {
+      "label": "Sort by",
+      "columns": {
+        "id": "ID",
+        "name": "Name",
+        "class": "Class",
+        "map": "Map",
+        "faction_id": "Faction"
+      },
+      "ascLabel": "Sort ascending",
+      "descLabel": "Sort descending"
     },
     "intelAudit": {
       "title": "Auditoría de intel",

--- a/web/src/locales/fr/translation.json
+++ b/web/src/locales/fr/translation.json
@@ -1257,8 +1257,7 @@
       "online": "Online",
       "offline": "Offline",
       "empty": "No players found",
-      "faction": "Filter by faction",
-      "factionAll": "All factions"
+      "faction": "Filter by faction"
     },
     "sort": {
       "label": "Sort by",

--- a/web/src/locales/fr/translation.json
+++ b/web/src/locales/fr/translation.json
@@ -1256,7 +1256,21 @@
       "all": "All",
       "online": "Online",
       "offline": "Offline",
-      "empty": "No players found"
+      "empty": "No players found",
+      "faction": "Filter by faction",
+      "factionAll": "All factions"
+    },
+    "sort": {
+      "label": "Sort by",
+      "columns": {
+        "id": "ID",
+        "name": "Name",
+        "class": "Class",
+        "map": "Map",
+        "faction_id": "Faction"
+      },
+      "ascLabel": "Sort ascending",
+      "descLabel": "Sort descending"
     },
     "intelAudit": {
       "title": "Audit d'intel",

--- a/web/src/locales/ja/translation.json
+++ b/web/src/locales/ja/translation.json
@@ -1240,8 +1240,7 @@
       "online": "Online",
       "offline": "Offline",
       "empty": "No players found",
-      "faction": "Filter by faction",
-      "factionAll": "All factions"
+      "faction": "Filter by faction"
     },
     "sort": {
       "label": "Sort by",

--- a/web/src/locales/ja/translation.json
+++ b/web/src/locales/ja/translation.json
@@ -1239,7 +1239,21 @@
       "all": "All",
       "online": "Online",
       "offline": "Offline",
-      "empty": "No players found"
+      "empty": "No players found",
+      "faction": "Filter by faction",
+      "factionAll": "All factions"
+    },
+    "sort": {
+      "label": "Sort by",
+      "columns": {
+        "id": "ID",
+        "name": "Name",
+        "class": "Class",
+        "map": "Map",
+        "faction_id": "Faction"
+      },
+      "ascLabel": "Sort ascending",
+      "descLabel": "Sort descending"
     },
     "intelAudit": {
       "title": "インテル監査",

--- a/web/src/locales/pl/translation.json
+++ b/web/src/locales/pl/translation.json
@@ -1274,8 +1274,7 @@
       "online": "Online",
       "offline": "Offline",
       "empty": "No players found",
-      "faction": "Filter by faction",
-      "factionAll": "All factions"
+      "faction": "Filter by faction"
     },
     "sort": {
       "label": "Sort by",

--- a/web/src/locales/pl/translation.json
+++ b/web/src/locales/pl/translation.json
@@ -1273,7 +1273,21 @@
       "all": "All",
       "online": "Online",
       "offline": "Offline",
-      "empty": "No players found"
+      "empty": "No players found",
+      "faction": "Filter by faction",
+      "factionAll": "All factions"
+    },
+    "sort": {
+      "label": "Sort by",
+      "columns": {
+        "id": "ID",
+        "name": "Name",
+        "class": "Class",
+        "map": "Map",
+        "faction_id": "Faction"
+      },
+      "ascLabel": "Sort ascending",
+      "descLabel": "Sort descending"
     },
     "intelAudit": {
       "title": "Audyt intelu",

--- a/web/src/locales/pt-BR/translation.json
+++ b/web/src/locales/pt-BR/translation.json
@@ -1257,8 +1257,7 @@
       "online": "Online",
       "offline": "Offline",
       "empty": "No players found",
-      "faction": "Filter by faction",
-      "factionAll": "All factions"
+      "faction": "Filter by faction"
     },
     "sort": {
       "label": "Sort by",

--- a/web/src/locales/pt-BR/translation.json
+++ b/web/src/locales/pt-BR/translation.json
@@ -1256,7 +1256,21 @@
       "all": "All",
       "online": "Online",
       "offline": "Offline",
-      "empty": "No players found"
+      "empty": "No players found",
+      "faction": "Filter by faction",
+      "factionAll": "All factions"
+    },
+    "sort": {
+      "label": "Sort by",
+      "columns": {
+        "id": "ID",
+        "name": "Name",
+        "class": "Class",
+        "map": "Map",
+        "faction_id": "Faction"
+      },
+      "ascLabel": "Sort ascending",
+      "descLabel": "Sort descending"
     },
     "intelAudit": {
       "title": "Auditoria de intel",

--- a/web/src/locales/ru/translation.json
+++ b/web/src/locales/ru/translation.json
@@ -1274,8 +1274,7 @@
       "online": "Online",
       "offline": "Offline",
       "empty": "No players found",
-      "faction": "Filter by faction",
-      "factionAll": "All factions"
+      "faction": "Filter by faction"
     },
     "sort": {
       "label": "Sort by",

--- a/web/src/locales/ru/translation.json
+++ b/web/src/locales/ru/translation.json
@@ -1273,7 +1273,21 @@
       "all": "All",
       "online": "Online",
       "offline": "Offline",
-      "empty": "No players found"
+      "empty": "No players found",
+      "faction": "Filter by faction",
+      "factionAll": "All factions"
+    },
+    "sort": {
+      "label": "Sort by",
+      "columns": {
+        "id": "ID",
+        "name": "Name",
+        "class": "Class",
+        "map": "Map",
+        "faction_id": "Faction"
+      },
+      "ascLabel": "Sort ascending",
+      "descLabel": "Sort descending"
     },
     "intelAudit": {
       "title": "Аудит интеллекта",

--- a/web/src/locales/tr/translation.json
+++ b/web/src/locales/tr/translation.json
@@ -1240,8 +1240,7 @@
       "online": "Online",
       "offline": "Offline",
       "empty": "No players found",
-      "faction": "Filter by faction",
-      "factionAll": "All factions"
+      "faction": "Filter by faction"
     },
     "sort": {
       "label": "Sort by",

--- a/web/src/locales/tr/translation.json
+++ b/web/src/locales/tr/translation.json
@@ -1239,7 +1239,21 @@
       "all": "All",
       "online": "Online",
       "offline": "Offline",
-      "empty": "No players found"
+      "empty": "No players found",
+      "faction": "Filter by faction",
+      "factionAll": "All factions"
+    },
+    "sort": {
+      "label": "Sort by",
+      "columns": {
+        "id": "ID",
+        "name": "Name",
+        "class": "Class",
+        "map": "Map",
+        "faction_id": "Faction"
+      },
+      "ascLabel": "Sort ascending",
+      "descLabel": "Sort descending"
     },
     "intelAudit": {
       "title": "Intel Denetimi",

--- a/web/src/locales/zh-CN/translation.json
+++ b/web/src/locales/zh-CN/translation.json
@@ -1240,8 +1240,7 @@
       "online": "Online",
       "offline": "Offline",
       "empty": "No players found",
-      "faction": "Filter by faction",
-      "factionAll": "All factions"
+      "faction": "Filter by faction"
     },
     "sort": {
       "label": "Sort by",

--- a/web/src/locales/zh-CN/translation.json
+++ b/web/src/locales/zh-CN/translation.json
@@ -1239,7 +1239,21 @@
       "all": "All",
       "online": "Online",
       "offline": "Offline",
-      "empty": "No players found"
+      "empty": "No players found",
+      "faction": "Filter by faction",
+      "factionAll": "All factions"
+    },
+    "sort": {
+      "label": "Sort by",
+      "columns": {
+        "id": "ID",
+        "name": "Name",
+        "class": "Class",
+        "map": "Map",
+        "faction_id": "Faction"
+      },
+      "ascLabel": "Sort ascending",
+      "descLabel": "Sort descending"
     },
     "intelAudit": {
       "title": "情报点审计",

--- a/web/src/tabs/PlayersTab/PlayersTab.tsx
+++ b/web/src/tabs/PlayersTab/PlayersTab.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { Button, SearchField, Spinner, toast } from '@heroui/react'
 import { Segment } from '@heroui-pro/react'
 import { useTranslation } from 'react-i18next'
-import type { TFunction } from 'i18next'
 import { api } from '../../api/client'
 import type { Player } from '../../api/client'
 import { Icon, SideNav } from '../../dune-ui'
@@ -17,34 +16,10 @@ import { InventoryView } from './views/InventoryView'
 import { VehiclesView } from './views/VehiclesView'
 import { GiveItemsView } from './views/GiveItemsView'
 import { ActionsView } from './views/ActionsView'
-import { FACTIONS } from './types'
+import { comparePlayers, factionLabel } from './playerListHelpers'
 import type { DetailTab, PlayerSortKey, PlayerStatusFilter, SortDir } from './types'
 
 const POLL_MS = 30_000
-
-// Faction display name for the sort/filter axis — id 0 is "no faction picked
-// yet" (players.detail.unaligned), not the in-game "None" faction (id 3).
-const factionLabel = (factionId: number, t: TFunction): string => {
-  if (factionId === 0) return t('players.detail.unaligned')
-  const known = FACTIONS.find((f) => f.id === factionId)
-  return known ? known.name : String(factionId)
-}
-
-const collate = (a: string, b: string): number =>
-  a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
-
-// Sort value per axis (#281): name/class/map sort on their raw string, faction
-// sorts on its display label (not the raw id), id sorts numerically.
-const sortValue = (p: Player, key: PlayerSortKey, t: TFunction): string | number => {
-  switch (key) {
-    case 'id': return p.id
-    case 'faction_id': return factionLabel(p.faction_id, t)
-    case 'class': return p.class
-    case 'map': return p.map
-    case 'name':
-    default: return p.name
-  }
-}
 
 export const PlayersTab: React.FC = () => {
   const { t } = useTranslation()
@@ -113,21 +88,15 @@ export const PlayersTab: React.FC = () => {
     : _byStatus.filter((p) => factionFilter.has(p.faction_id))
 
   // SORT is a single axis + direction, orthogonal to the FILTER facets above
-  // (#281) — no more hard online-first grouping. Non-name axes tie-break on
-  // name so equal-value groups (e.g. same faction) still read alphabetically.
-  const filtered = [..._byFaction].sort((a, b) => {
-    const av = sortValue(a, sortKey, t)
-    const bv = sortValue(b, sortKey, t)
-    let primary = typeof av === 'number' && typeof bv === 'number'
-      ? av - bv
-      : collate(String(av), String(bv))
-    if (primary === 0 && sortKey !== 'name') primary = collate(a.name, b.name)
-    return sortDir === 'asc' ? primary : -primary
-  })
+  // (#281) — no more hard online-first grouping.
+  const unalignedLabel = t('players.detail.unaligned')
+  const filtered = [..._byFaction].sort(
+    (a, b) => comparePlayers(a, b, sortKey, sortDir, unalignedLabel),
+  )
 
   const factionOptions = Array.from(new Set(players.map((p) => p.faction_id)))
     .sort((a, b) => a - b)
-    .map((id) => ({ id, label: factionLabel(id, t) }))
+    .map((id) => ({ id, label: factionLabel(id, unalignedLabel) }))
 
   const navItems = filtered.map((p) => {
     const statusDotColor = p.online_status === 'Online'

--- a/web/src/tabs/PlayersTab/PlayersTab.tsx
+++ b/web/src/tabs/PlayersTab/PlayersTab.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Button, SearchField, Spinner, toast } from '@heroui/react'
 import { Segment } from '@heroui-pro/react'
 import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
 import { api } from '../../api/client'
 import type { Player } from '../../api/client'
 import { Icon, SideNav } from '../../dune-ui'
@@ -9,15 +10,41 @@ import { useAutoRefresh } from '../../hooks/useAutoRefresh'
 import { usePermissions } from '../../hooks/usePermissions'
 import { DiscordBadge } from './components/DiscordBadge'
 import { PlayerDetailPanel } from './components/PlayerDetailPanel'
+import { PlayerListControls } from './components/PlayerListControls'
 import { ServerDashboard } from './components/ServerDashboard'
 import { StatusDot } from './components/StatusDot'
 import { InventoryView } from './views/InventoryView'
 import { VehiclesView } from './views/VehiclesView'
 import { GiveItemsView } from './views/GiveItemsView'
 import { ActionsView } from './views/ActionsView'
-import type { DetailTab } from './types'
+import { FACTIONS } from './types'
+import type { DetailTab, PlayerSortKey, PlayerStatusFilter, SortDir } from './types'
 
 const POLL_MS = 30_000
+
+// Faction display name for the sort/filter axis — id 0 is "no faction picked
+// yet" (players.detail.unaligned), not the in-game "None" faction (id 3).
+const factionLabel = (factionId: number, t: TFunction): string => {
+  if (factionId === 0) return t('players.detail.unaligned')
+  const known = FACTIONS.find((f) => f.id === factionId)
+  return known ? known.name : String(factionId)
+}
+
+const collate = (a: string, b: string): number =>
+  a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
+
+// Sort value per axis (#281): name/class/map sort on their raw string, faction
+// sorts on its display label (not the raw id), id sorts numerically.
+const sortValue = (p: Player, key: PlayerSortKey, t: TFunction): string | number => {
+  switch (key) {
+    case 'id': return p.id
+    case 'faction_id': return factionLabel(p.faction_id, t)
+    case 'class': return p.class
+    case 'map': return p.map
+    case 'name':
+    default: return p.name
+  }
+}
 
 export const PlayersTab: React.FC = () => {
   const { t } = useTranslation()
@@ -41,7 +68,10 @@ export const PlayersTab: React.FC = () => {
   const [players, setPlayers] = React.useState<Player[]>([])
   const [loading, setLoading] = React.useState(false)
   const [search, setSearch] = React.useState('')
-  const [statusFilter, setStatusFilter] = React.useState<'all' | 'online' | 'offline'>('all')
+  const [statusFilter, setStatusFilter] = React.useState<PlayerStatusFilter>('all')
+  const [factionFilter, setFactionFilter] = React.useState<Set<number>>(new Set())
+  const [sortKey, setSortKey] = React.useState<PlayerSortKey>('name')
+  const [sortDir, setSortDir] = React.useState<SortDir>('asc')
   const [selected, setSelected] = React.useState<Player | null>(null)
   const [activeTab, setActiveTab] = React.useState<DetailTab>('overview')
 
@@ -78,11 +108,26 @@ export const PlayersTab: React.FC = () => {
     : statusFilter === 'offline'
       ? _searched.filter((p) => p.online_status !== 'Online')
       : _searched
-  const filtered = [..._byStatus].sort((a, b) => {
-    const aOn = a.online_status === 'Online' ? 1 : 0
-    const bOn = b.online_status === 'Online' ? 1 : 0
-    return bOn !== aOn ? bOn - aOn : a.name.localeCompare(b.name)
+  const _byFaction = factionFilter.size === 0
+    ? _byStatus
+    : _byStatus.filter((p) => factionFilter.has(p.faction_id))
+
+  // SORT is a single axis + direction, orthogonal to the FILTER facets above
+  // (#281) — no more hard online-first grouping. Non-name axes tie-break on
+  // name so equal-value groups (e.g. same faction) still read alphabetically.
+  const filtered = [..._byFaction].sort((a, b) => {
+    const av = sortValue(a, sortKey, t)
+    const bv = sortValue(b, sortKey, t)
+    let primary = typeof av === 'number' && typeof bv === 'number'
+      ? av - bv
+      : collate(String(av), String(bv))
+    if (primary === 0 && sortKey !== 'name') primary = collate(a.name, b.name)
+    return sortDir === 'asc' ? primary : -primary
   })
+
+  const factionOptions = Array.from(new Set(players.map((p) => p.faction_id)))
+    .sort((a, b) => a - b)
+    .map((id) => ({ id, label: factionLabel(id, t) }))
 
   const navItems = filtered.map((p) => {
     const statusDotColor = p.online_status === 'Online'
@@ -140,27 +185,17 @@ export const PlayersTab: React.FC = () => {
         )}
         width="w-80"
         listHeader={(
-          <Segment
-            aria-label={t('players.filter.label')}
-            variant="ghost"
-            size="sm"
-            className="w-full"
-            selectedKey={statusFilter}
-            onSelectionChange={(key) => setStatusFilter(key as 'all' | 'online' | 'offline')}
-          >
-            <Segment.Item id="all">
-              <Segment.Separator />
-              {t('players.filter.all')}
-            </Segment.Item>
-            <Segment.Item id="online">
-              <Segment.Separator />
-              {t('players.filter.online')}
-            </Segment.Item>
-            <Segment.Item id="offline">
-              <Segment.Separator />
-              {t('players.filter.offline')}
-            </Segment.Item>
-          </Segment>
+          <PlayerListControls
+            sortKey={sortKey}
+            onSortKeyChange={setSortKey}
+            sortDir={sortDir}
+            onToggleSortDir={() => setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))}
+            statusFilter={statusFilter}
+            onStatusFilterChange={setStatusFilter}
+            factionFilter={factionFilter}
+            onFactionFilterChange={setFactionFilter}
+            factionOptions={factionOptions}
+          />
         )}
         emptyContent={t('players.filter.empty')}
       >

--- a/web/src/tabs/PlayersTab/components/PlayerListControls.tsx
+++ b/web/src/tabs/PlayersTab/components/PlayerListControls.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Button, ListBox, Select } from '@heroui/react'
+import { Button, Checkbox, ListBox, Select } from '@heroui/react'
 import { Segment } from '@heroui-pro/react'
 import { useTranslation } from 'react-i18next'
 import { Icon } from '../../../dune-ui'
@@ -22,6 +22,40 @@ export const PlayerListControls: React.FC<PlayerListControlsProps> = ({
   factionOptions,
 }): React.ReactElement => {
   const { t } = useTranslation()
+
+  const toggleFaction = (id: number, isSelected: boolean): void => {
+    const next = new Set(factionFilter)
+    if (isSelected) next.add(id)
+    else next.delete(id)
+    onFactionFilterChange(next)
+  }
+
+  // Faction facet is a Checkbox group (frontend.md: "Checkbox (filter/option)
+  // — use Checkbox"), not a Select — RAC's Select is the wrong primitive for
+  // a filter facet and every other selectionMode="multiple" usage in this
+  // codebase is on DataTable/DataGrid row selection, not a dropdown. Renders
+  // nothing until the player list has loaded at least one faction_id.
+  const renderFactionFilter = (): React.ReactNode => {
+    if (factionOptions.length === 0) return null
+    return (
+      <div className="flex flex-col gap-1">
+        <span className="text-[10px] uppercase tracking-wide text-muted">
+          {t('players.filter.faction')}
+        </span>
+        <div className="flex flex-wrap gap-x-3 gap-y-1">
+          {factionOptions.map((f) => (
+            <Checkbox
+              key={f.id}
+              isSelected={factionFilter.has(f.id)}
+              onChange={(isSelected) => toggleFaction(f.id, isSelected)}
+            >
+              {f.label}
+            </Checkbox>
+          ))}
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="flex flex-col gap-2">
@@ -81,29 +115,7 @@ export const PlayerListControls: React.FC<PlayerListControlsProps> = ({
         </Segment.Item>
       </Segment>
 
-      <Select
-        aria-label={t('players.filter.faction')}
-        selectionMode="multiple"
-        value={[...factionFilter]}
-        onChange={(keys) => onFactionFilterChange(new Set(keys as number[]))}
-        placeholder={t('players.filter.factionAll')}
-        className="w-full"
-      >
-        <Select.Trigger className="h-8 text-xs">
-          <Select.Value />
-          <Select.Indicator />
-        </Select.Trigger>
-        <Select.Popover>
-          <ListBox selectionMode="multiple">
-            {factionOptions.map((f) => (
-              <ListBox.Item key={f.id} id={f.id} textValue={f.label}>
-                {f.label}
-                <ListBox.ItemIndicator />
-              </ListBox.Item>
-            ))}
-          </ListBox>
-        </Select.Popover>
-      </Select>
+      {renderFactionFilter()}
     </div>
   )
 }

--- a/web/src/tabs/PlayersTab/components/PlayerListControls.tsx
+++ b/web/src/tabs/PlayersTab/components/PlayerListControls.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react'
+import { Button, ListBox, Select } from '@heroui/react'
+import { Segment } from '@heroui-pro/react'
+import { useTranslation } from 'react-i18next'
+import { Icon } from '../../../dune-ui'
+import { PLAYER_COLUMNS } from '../types'
+import type { PlayerSortKey, PlayerStatusFilter } from '../types'
+import type { PlayerListControlsProps } from './interfaces'
+
+// SORT and FILTER are two orthogonal controls (#281): sort picks one axis +
+// direction; filters (status, faction) narrow the population and combine
+// freely with each other and with free-text search (handled by the caller).
+export const PlayerListControls: React.FC<PlayerListControlsProps> = ({
+  sortKey,
+  onSortKeyChange,
+  sortDir,
+  onToggleSortDir,
+  statusFilter,
+  onStatusFilterChange,
+  factionFilter,
+  onFactionFilterChange,
+  factionOptions,
+}): React.ReactElement => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-1.5">
+        <Select
+          aria-label={t('players.sort.label')}
+          selectedKey={sortKey}
+          onSelectionChange={(key) => onSortKeyChange(key as PlayerSortKey)}
+          className="flex-1 min-w-0"
+        >
+          <Select.Trigger className="h-8 text-xs">
+            <Icon name="arrow-up-down" className="size-3.5 text-muted shrink-0 mr-1" />
+            <Select.Value />
+            <Select.Indicator />
+          </Select.Trigger>
+          <Select.Popover>
+            <ListBox>
+              {PLAYER_COLUMNS.map((col) => (
+                <ListBox.Item key={col.key} id={col.key} textValue={t(col.label as never)}>
+                  {t(col.label as never)}
+                  <ListBox.ItemIndicator />
+                </ListBox.Item>
+              ))}
+            </ListBox>
+          </Select.Popover>
+        </Select>
+        <Button
+          isIconOnly
+          size="sm"
+          variant="ghost"
+          aria-label={sortDir === 'asc' ? t('players.sort.ascLabel') : t('players.sort.descLabel')}
+          onPress={onToggleSortDir}
+        >
+          <Icon name={sortDir === 'asc' ? 'arrow-up' : 'arrow-down'} />
+        </Button>
+      </div>
+
+      <Segment
+        aria-label={t('players.filter.label')}
+        variant="ghost"
+        size="sm"
+        className="w-full"
+        selectedKey={statusFilter}
+        onSelectionChange={(key) => onStatusFilterChange(key as PlayerStatusFilter)}
+      >
+        <Segment.Item id="all">
+          <Segment.Separator />
+          {t('players.filter.all')}
+        </Segment.Item>
+        <Segment.Item id="online">
+          <Segment.Separator />
+          {t('players.filter.online')}
+        </Segment.Item>
+        <Segment.Item id="offline">
+          <Segment.Separator />
+          {t('players.filter.offline')}
+        </Segment.Item>
+      </Segment>
+
+      <Select
+        aria-label={t('players.filter.faction')}
+        selectionMode="multiple"
+        value={[...factionFilter]}
+        onChange={(keys) => onFactionFilterChange(new Set(keys as number[]))}
+        placeholder={t('players.filter.factionAll')}
+        className="w-full"
+      >
+        <Select.Trigger className="h-8 text-xs">
+          <Select.Value />
+          <Select.Indicator />
+        </Select.Trigger>
+        <Select.Popover>
+          <ListBox selectionMode="multiple">
+            {factionOptions.map((f) => (
+              <ListBox.Item key={f.id} id={f.id} textValue={f.label}>
+                {f.label}
+                <ListBox.ItemIndicator />
+              </ListBox.Item>
+            ))}
+          </ListBox>
+        </Select.Popover>
+      </Select>
+    </div>
+  )
+}

--- a/web/src/tabs/PlayersTab/components/interfaces.ts
+++ b/web/src/tabs/PlayersTab/components/interfaces.ts
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import type { Player, SessionRecord, StatSnapshot } from '../../../api/client'
+import type { PlayerSortKey, PlayerStatusFilter, SortDir } from '../types'
 
 export interface PlayerCardProps {
   player: Player
@@ -48,4 +49,21 @@ export interface SolarisPoint {
 
 export interface StatusDotProps {
   status: string
+}
+
+export interface PlayerFactionOption {
+  id: number
+  label: string
+}
+
+export interface PlayerListControlsProps {
+  sortKey: PlayerSortKey
+  onSortKeyChange: (key: PlayerSortKey) => void
+  sortDir: SortDir
+  onToggleSortDir: () => void
+  statusFilter: PlayerStatusFilter
+  onStatusFilterChange: (status: PlayerStatusFilter) => void
+  factionFilter: Set<number>
+  onFactionFilterChange: (factions: Set<number>) => void
+  factionOptions: PlayerFactionOption[]
 }

--- a/web/src/tabs/PlayersTab/playerListHelpers.test.ts
+++ b/web/src/tabs/PlayersTab/playerListHelpers.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { collate, factionLabel, sortValue, comparePlayers } from './playerListHelpers'
+import type { Player } from '../../api/client'
+
+const UNALIGNED = 'Unaligned'
+
+const makePlayer = (overrides: Partial<Player>): Player => ({
+  id: 1,
+  account_id: 1,
+  controller_id: 1,
+  fls_id: 'fls-1',
+  name: 'Player',
+  class: 'PlayerCharacter',
+  map: 'HaggaBasin',
+  faction_id: 0,
+  online_status: 'Offline',
+  discord_user_id: '',
+  discord_avatar: '',
+  ...overrides,
+})
+
+describe('collate', () => {
+  it('is case-insensitive', () => {
+    expect(collate('bob', 'Bob')).toBe(0)
+    expect(collate('alice', 'Bob') < 0).toBe(true)
+  })
+
+  it('is numeric-aware — Bob2 sorts before Bob10', () => {
+    expect(collate('Bob2', 'Bob10') < 0).toBe(true)
+    expect(collate('Bob10', 'Bob2') > 0).toBe(true)
+  })
+})
+
+describe('factionLabel', () => {
+  it('maps id 0 to the unaligned label, not the "None" faction', () => {
+    expect(factionLabel(0, UNALIGNED)).toBe(UNALIGNED)
+  })
+
+  it('resolves known faction ids to their name', () => {
+    expect(factionLabel(1, UNALIGNED)).toBe('Atreides')
+    expect(factionLabel(2, UNALIGNED)).toBe('Harkonnen')
+    expect(factionLabel(4, UNALIGNED)).toBe('Smuggler')
+  })
+
+  it('id 3 ("None" faction) is distinct from unaligned (id 0)', () => {
+    expect(factionLabel(3, UNALIGNED)).toBe('None')
+    expect(factionLabel(3, UNALIGNED)).not.toBe(UNALIGNED)
+  })
+
+  it('falls back to the raw numeric string for unknown ids', () => {
+    expect(factionLabel(99, UNALIGNED)).toBe('99')
+  })
+})
+
+describe('sortValue', () => {
+  const p = makePlayer({ name: 'Zed', class: 'Fremen', map: 'DeepDesert', faction_id: 2, id: 42 })
+
+  it('returns the raw string for name/class/map', () => {
+    expect(sortValue(p, 'name', UNALIGNED)).toBe('Zed')
+    expect(sortValue(p, 'class', UNALIGNED)).toBe('Fremen')
+    expect(sortValue(p, 'map', UNALIGNED)).toBe('DeepDesert')
+  })
+
+  it('returns the faction display label, not the raw id', () => {
+    expect(sortValue(p, 'faction_id', UNALIGNED)).toBe('Harkonnen')
+  })
+
+  it('returns the numeric id for the id axis', () => {
+    expect(sortValue(p, 'id', UNALIGNED)).toBe(42)
+  })
+})
+
+describe('comparePlayers', () => {
+  it('sorts by name ascending, numeric/case-insensitive', () => {
+    const a = makePlayer({ id: 1, name: 'Bob10' })
+    const b = makePlayer({ id: 2, name: 'bob2' })
+    expect(comparePlayers(a, b, 'name', 'asc', UNALIGNED) > 0).toBe(true)
+    expect(comparePlayers(b, a, 'name', 'asc', UNALIGNED) < 0).toBe(true)
+  })
+
+  it('reverses order for desc', () => {
+    const a = makePlayer({ id: 1, name: 'Alice' })
+    const b = makePlayer({ id: 2, name: 'Bob' })
+    expect(comparePlayers(a, b, 'name', 'asc', UNALIGNED) < 0).toBe(true)
+    expect(comparePlayers(a, b, 'name', 'desc', UNALIGNED) > 0).toBe(true)
+  })
+
+  it('sorts the id axis numerically, not lexicographically', () => {
+    const a = makePlayer({ id: 2, name: 'Z' })
+    const b = makePlayer({ id: 10, name: 'A' })
+    // Lexicographic string sort would put "10" before "2"; numeric must not.
+    expect(comparePlayers(a, b, 'id', 'asc', UNALIGNED) < 0).toBe(true)
+  })
+
+  it('faction axis groups by faction, tie-broken by name within the group', () => {
+    const atreides1 = makePlayer({ id: 1, name: 'Zed', faction_id: 1 })
+    const atreides2 = makePlayer({ id: 2, name: 'Amy', faction_id: 1 })
+    const harkonnen = makePlayer({ id: 3, name: 'Aaron', faction_id: 2 })
+    const sorted = [atreides1, harkonnen, atreides2].sort(
+      (x, y) => comparePlayers(x, y, 'faction_id', 'asc', UNALIGNED),
+    )
+    // Atreides < Harkonnen alphabetically; within Atreides, Amy < Zed.
+    expect(sorted.map((p) => p.name)).toEqual(['Amy', 'Zed', 'Aaron'])
+  })
+
+  it('name axis has no secondary tie-break beyond itself', () => {
+    const a = makePlayer({ id: 1, name: 'Same' })
+    const b = makePlayer({ id: 2, name: 'Same' })
+    expect(comparePlayers(a, b, 'name', 'asc', UNALIGNED)).toBe(0)
+  })
+})

--- a/web/src/tabs/PlayersTab/playerListHelpers.ts
+++ b/web/src/tabs/PlayersTab/playerListHelpers.ts
@@ -1,0 +1,52 @@
+import type { Player } from '../../api/client'
+import { FACTIONS } from './types'
+import type { PlayerSortKey, SortDir } from './types'
+
+// collate is the shared string comparator for every sort axis (#281): numeric
+// so "Bob2" sorts before "Bob10", case-insensitive so casing doesn't split an
+// otherwise-alphabetical run.
+export const collate = (a: string, b: string): number =>
+  a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
+
+// factionLabel resolves a faction_id to its display name. id 0 means "no
+// faction picked yet" (unalignedLabel, e.g. t('players.detail.unaligned')) —
+// distinct from the in-game "None" faction (id 3, in FACTIONS). Unknown ids
+// fall back to their raw numeric string defensively.
+export const factionLabel = (factionId: number, unalignedLabel: string): string => {
+  if (factionId === 0) return unalignedLabel
+  const known = FACTIONS.find((f) => f.id === factionId)
+  return known ? known.name : String(factionId)
+}
+
+// sortValue is the per-axis sort key extracted from a player: name/class/map
+// sort on their raw string, faction sorts on its display label (not the raw
+// id, so it groups by human-readable faction name), id sorts numerically.
+export const sortValue = (p: Player, key: PlayerSortKey, unalignedLabel: string): string | number => {
+  switch (key) {
+    case 'id': return p.id
+    case 'faction_id': return factionLabel(p.faction_id, unalignedLabel)
+    case 'class': return p.class
+    case 'map': return p.map
+    case 'name':
+    default: return p.name
+  }
+}
+
+// comparePlayers is the full SORT comparator (#281): a single axis + direction,
+// orthogonal to the FILTER facets applied before it. Non-name axes tie-break
+// on name so equal-value groups (e.g. same faction) still read alphabetically.
+export const comparePlayers = (
+  a: Player,
+  b: Player,
+  key: PlayerSortKey,
+  dir: SortDir,
+  unalignedLabel: string,
+): number => {
+  const av = sortValue(a, key, unalignedLabel)
+  const bv = sortValue(b, key, unalignedLabel)
+  let primary = typeof av === 'number' && typeof bv === 'number'
+    ? av - bv
+    : collate(String(av), String(bv))
+  if (primary === 0 && key !== 'name') primary = collate(a.name, b.name)
+  return dir === 'asc' ? primary : -primary
+}

--- a/web/src/tabs/PlayersTab/types.ts
+++ b/web/src/tabs/PlayersTab/types.ts
@@ -5,6 +5,10 @@ export type ActionSection
 
 export type PlayerSortKey = 'id' | 'name' | 'class' | 'map' | 'faction_id'
 
+export type SortDir = 'asc' | 'desc'
+
+export type PlayerStatusFilter = 'all' | 'online' | 'offline'
+
 export type PacksData = {
   packs: Record<string, {
     name: string
@@ -26,12 +30,16 @@ export const ACTION_SECTIONS: { key: ActionSection, label: string }[] = [
   { key: 'experimental', label: 'players.actions.sections.experimental' },
 ]
 
+// Sort-axis menu (#281): `label` is an i18n key, resolved with `t(label as
+// never)` at render time in PlayerListControls — same dynamic-key pattern as
+// ACTION_SECTIONS above. Order here is the dropdown display order — Name
+// first as the primary/default axis, ID last as the least-used one.
 export const PLAYER_COLUMNS: { key: PlayerSortKey, label: string }[] = [
-  { key: 'id', label: 'ID' },
-  { key: 'name', label: 'Name' },
-  { key: 'class', label: 'Class' },
-  { key: 'map', label: 'Map' },
-  { key: 'faction_id', label: 'Faction' },
+  { key: 'name', label: 'players.sort.columns.name' },
+  { key: 'faction_id', label: 'players.sort.columns.faction_id' },
+  { key: 'class', label: 'players.sort.columns.class' },
+  { key: 'map', label: 'players.sort.columns.map' },
+  { key: 'id', label: 'players.sort.columns.id' },
 ]
 
 export const XP_TRACKS = ['Combat', 'Crafting', 'Gathering', 'Exploration', 'Sabotage']


### PR DESCRIPTION
## Summary
- Splits the PlayersTab list into an orthogonal SORT (Name/Faction/Class/Map/ID axis + direction, `localeCompare` with `{numeric:true, sensitivity:'base'}` for clean A–Z) and FILTER (Status kept, new multi-select Faction via a Checkbox group).
- Extracted `playerListHelpers.ts` (collate/factionLabel/sortValue/comparePlayers) with 14 new unit tests, following this codebase's `helpers.test.ts` convention.
- The Faction filter intentionally uses a `Checkbox` group rather than HeroUI's `Select` — matches every other multi-select control in this codebase (DataTable/DataGrid row-selection is the only other `selectionMode="multiple"` precedent, never a dropdown `Select`) and per `frontend.md`'s own guidance for filter/option controls.

## Scope note
Level and Recency sort/filter axes (asked for in the issue) are **deferred** — neither field exists in the `Player` payload or `cmdFetchPlayers`'s SELECT today. A follow-up would need: `ps.last_login_time` for recency (cheap, one column) and a derived-from-XP level computation (heavier, per-player aggregation). See `cmd/dune-admin/db.go`.

## Test plan
- [x] `pnpm build` && `pnpm lint` pass
- [x] `pnpm exec vitest run` — 95/95 tests pass (14 new)
- [ ] Manual: cycle sort axis + direction, confirm clean A–Z ordering with no online/offline grouping
- [ ] Manual: select/deselect faction checkboxes, confirm the list actually filters
- [ ] Manual: combine sort + filter + search together

Addresses #281