### PR TITLE
feat(web-proxy): per-interface opt-out of URL rewriting

### DIFF
--- a/cmd/dune-admin/web_interfaces.go
+++ b/cmd/dune-admin/web_interfaces.go
@@ -19,6 +19,12 @@ import (
 type webInterface struct {
 	Label string `json:"label"`
 	URL   string `json:"url"`
+	// NoProxy opts this entry out of the mesh web proxy: the SPA opens URL
+	// as-is instead of a rewritten proxy port. For operators behind NAT/a
+	// reverse proxy where only fixed published ports are reachable, the
+	// proxy's rewritten URL is unreachable — this restores the pre-v0.42.0
+	// "just open the configured URL" behaviour on a per-entry basis. (#261)
+	NoProxy bool `json:"noProxy,omitempty"`
 	// Target is the raw host:port dune-admin can Dial through the executor to
 	// reach the service (the address before any host rewrite). Set for
 	// control-plane-discovered entries; empty for hand-configured links. Not
@@ -106,7 +112,7 @@ func saveWebInterfaces(list []webInterface) error {
 	}
 	clean := make([]webInterface, len(list))
 	for i, w := range list {
-		clean[i] = webInterface{Label: strings.TrimSpace(w.Label), URL: strings.TrimSpace(w.URL)}
+		clean[i] = webInterface{Label: strings.TrimSpace(w.Label), URL: strings.TrimSpace(w.URL), NoProxy: w.NoProxy}
 	}
 	data, err := json.MarshalIndent(clean, "", "  ")
 	if err != nil {

--- a/cmd/dune-admin/web_interfaces_test.go
+++ b/cmd/dune-admin/web_interfaces_test.go
@@ -1,6 +1,46 @@
 package main
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
+
+// saveWebInterfaces must preserve the NoProxy flag through its {Label,URL}
+// rebuild, and loadWebInterfaces must read it back unchanged. (#261 — the
+// rebuild previously dropped any field not explicitly copied, e.g. Target.)
+func TestSaveWebInterfaces_RoundTripsNoProxy(t *testing.T) {
+	prevPath := webIfacePath
+	prevIfaces := webIfaces
+	prevLoaded := webIfaceLoaded
+	t.Cleanup(func() {
+		webIfacePath = prevPath
+		webIfaces = prevIfaces
+		webIfaceLoaded = prevLoaded
+	})
+	webIfacePath = filepath.Join(t.TempDir(), "web-interfaces.json")
+
+	in := []webInterface{
+		{Label: "Panel", URL: "https://panel.example/", NoProxy: true},
+		{Label: "AMP", URL: "http://host:8080"}, // default NoProxy=false, unaffected
+	}
+	if err := saveWebInterfaces(in); err != nil {
+		t.Fatalf("saveWebInterfaces: %v", err)
+	}
+
+	// Force a reload from disk (not just the in-memory cache saveWebInterfaces
+	// also updates) to prove the flag survives the JSON round-trip.
+	webIfaceLoaded = false
+	got := getWebInterfaces()
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2", len(got))
+	}
+	if !got[0].NoProxy {
+		t.Errorf("Panel.NoProxy = false after round-trip, want true: %+v", got[0])
+	}
+	if got[1].NoProxy {
+		t.Errorf("AMP.NoProxy = true after round-trip, want false: %+v", got[1])
+	}
+}
 
 func TestValidateWebInterfaces(t *testing.T) {
 	t.Parallel()

--- a/cmd/dune-admin/web_proxy.go
+++ b/cmd/dune-admin/web_proxy.go
@@ -61,9 +61,13 @@ func resolveProxyTargets(ifaces []webInterface, listenPort int) []proxyTarget {
 // schemeAndDialFor returns the upstream scheme and host:port dune-admin can Dial
 // for a web interface: a discovered entry uses its Target (raw CRD host:port,
 // always plain HTTP), otherwise the absolute http(s) URL is parsed. Returns
-// ("", "") when the entry is not proxyable (same-origin/relative URL). Single
-// source of truth so resolveProxyTargets and withProxyPorts can't drift.
+// ("", "") when the entry is not proxyable (same-origin/relative URL, or the
+// operator opted out via NoProxy — see #261). Single source of truth so
+// resolveProxyTargets and withProxyPorts can't drift.
 func schemeAndDialFor(w webInterface) (scheme, dial string) {
+	if w.NoProxy {
+		return "", ""
+	}
 	if w.Target != "" {
 		return "http", w.Target
 	}
@@ -110,6 +114,9 @@ type webInterfaceOut struct {
 	URL         string `json:"url"`
 	ProxyPort   int    `json:"proxyPort,omitempty"`
 	ProxyScheme string `json:"proxyScheme,omitempty"`
+	// NoProxy is echoed back so the SPA edit form reflects the persisted
+	// opt-out. (#261)
+	NoProxy bool `json:"noProxy,omitempty"`
 }
 
 // withProxyPorts attaches each entry's proxy port + scheme (matched by dial
@@ -123,7 +130,7 @@ func withProxyPorts(ifaces []webInterface, targets []proxyTarget) []webInterface
 	out := make([]webInterfaceOut, 0, len(ifaces))
 	for _, w := range ifaces {
 		_, dial := schemeAndDialFor(w)
-		entry := webInterfaceOut{Label: w.Label, URL: w.URL, ProxyPort: portByAddr[dial]}
+		entry := webInterfaceOut{Label: w.Label, URL: w.URL, NoProxy: w.NoProxy, ProxyPort: portByAddr[dial]}
 		if entry.ProxyPort != 0 {
 			entry.ProxyScheme = proxyListenScheme
 		}

--- a/cmd/dune-admin/web_proxy_test.go
+++ b/cmd/dune-admin/web_proxy_test.go
@@ -22,10 +22,11 @@ func TestResolveProxyTargets(t *testing.T) {
 	ifaces := []webInterface{
 		{Label: "File Browser", URL: "http://vm:18888/", Target: "10.0.0.5:18888"},
 		{Label: "Battlegroup Director", URL: "http://vm:31003/", Target: "10.0.0.5:31003"},
-		{Label: "Wiki", URL: "https://wiki.example/"},         // manual absolute root → proxied, port from scheme
-		{Label: "Docs", URL: "https://docs.example/handbook"}, // non-root path → NOT proxied (would be dropped)
-		{Label: "Search", URL: "https://s.example/?q=x"},      // query → NOT proxied
-		{Label: "Local", URL: "/grafana"},                     // same-origin → NOT proxied
+		{Label: "Wiki", URL: "https://wiki.example/"},                  // manual absolute root → proxied, port from scheme
+		{Label: "Docs", URL: "https://docs.example/handbook"},          // non-root path → NOT proxied (would be dropped)
+		{Label: "Search", URL: "https://s.example/?q=x"},               // query → NOT proxied
+		{Label: "Local", URL: "/grafana"},                              // same-origin → NOT proxied
+		{Label: "Panel", URL: "https://panel.example/", NoProxy: true}, // opted out → NOT proxied despite being an otherwise-proxyable root URL
 	}
 	got := resolveProxyTargets(ifaces, 8080)
 	want := []proxyTarget{
@@ -35,6 +36,18 @@ func TestResolveProxyTargets(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got  %+v\nwant %+v", got, want)
+	}
+}
+
+// resolveProxyTargets must skip a NoProxy entry even when it's a discovered
+// entry with a Target set (defensive — the UI can only set NoProxy on
+// hand-configured entries today, but the guard must not be bypassable by Target).
+func TestResolveProxyTargets_NoProxySkipsDiscoveredTarget(t *testing.T) {
+	ifaces := []webInterface{
+		{Label: "Director", Target: "10.0.0.5:31003", NoProxy: true},
+	}
+	if got := resolveProxyTargets(ifaces, 8080); got != nil {
+		t.Errorf("NoProxy with Target set: got %+v, want nil", got)
 	}
 }
 
@@ -67,6 +80,26 @@ func TestWithProxyPorts(t *testing.T) {
 	}
 	if got[1].ProxyPort != 0 || got[1].ProxyScheme != "" {
 		t.Errorf("local = %+v, want proxyPort 0 + empty scheme (not proxied)", got[1])
+	}
+}
+
+// withProxyPorts must attach no port/scheme for a NoProxy entry — even one
+// with an otherwise-proxyable absolute root URL — and must echo NoProxy back
+// so the frontend edit form reflects the persisted flag. (#261)
+func TestWithProxyPorts_NoProxyEntryGetsNoPort(t *testing.T) {
+	ifaces := []webInterface{
+		{Label: "Panel", URL: "https://panel.example/", NoProxy: true},
+	}
+	targets := resolveProxyTargets(ifaces, 8080)
+	got := withProxyPorts(ifaces, targets)
+	if len(got) != 1 {
+		t.Fatalf("got %d entries, want 1", len(got))
+	}
+	if got[0].ProxyPort != 0 || got[0].ProxyScheme != "" {
+		t.Errorf("panel = %+v, want proxyPort 0 + empty scheme (opted out)", got[0])
+	}
+	if !got[0].NoProxy {
+		t.Errorf("panel = %+v, want NoProxy echoed back true", got[0])
 	}
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -503,6 +503,11 @@ export type ScheduledBackups = {
 export type WebInterface = {
   label: string
   url: string
+  // noProxy opts this entry out of the mesh web proxy: the SPA opens `url`
+  // as-is instead of a rewritten proxy port. For NAT/reverse-proxy setups
+  // where only fixed published ports are reachable, the proxy's rewritten
+  // URL is unreachable — this restores the pre-v0.42.0 behaviour per entry.
+  noProxy?: boolean
   // proxyPort, when set, is the local dune-admin port that reverse-proxies this
   // service over the mesh tunnel. The SPA opens it via the current host on that
   // port, so the (possibly unresolvable) game-side url is bypassed.

--- a/web/src/locales/de/translation.json
+++ b/web/src/locales/de/translation.json
@@ -65,6 +65,7 @@
     "ifaceSaveFailed": "Speichern fehlgeschlagen: {{message}}",
     "ifaceLabel": "Bezeichnung",
     "ifaceUrl": "URL (http:// oder /Pfad)",
+    "ifaceNoProxy": "Direkt öffnen (nicht über Proxy)",
     "editInterfaces": "Web-Oberflächen bearbeiten",
     "removeInterface": "Entfernen",
     "addInterface": "Oberfläche hinzufügen",

--- a/web/src/locales/en-US/translation.json
+++ b/web/src/locales/en-US/translation.json
@@ -65,6 +65,7 @@
     "ifaceSaveFailed": "Save failed: {{message}}",
     "ifaceLabel": "Label",
     "ifaceUrl": "URL (http:// or /path)",
+    "ifaceNoProxy": "Open directly (don't proxy)",
     "editInterfaces": "Edit web interfaces",
     "removeInterface": "Remove",
     "addInterface": "Add interface",

--- a/web/src/locales/es/translation.json
+++ b/web/src/locales/es/translation.json
@@ -65,6 +65,7 @@
     "ifaceSaveFailed": "Error al guardar: {{message}}",
     "ifaceLabel": "Etiqueta",
     "ifaceUrl": "URL (http:// o /ruta)",
+    "ifaceNoProxy": "Abrir directamente (sin proxy)",
     "editInterfaces": "Editar interfaces web",
     "removeInterface": "Eliminar",
     "addInterface": "Añadir interfaz",

--- a/web/src/locales/fr/translation.json
+++ b/web/src/locales/fr/translation.json
@@ -65,6 +65,7 @@
     "ifaceSaveFailed": "Échec de l'enregistrement : {{message}}",
     "ifaceLabel": "Libellé",
     "ifaceUrl": "URL (http:// ou /chemin)",
+    "ifaceNoProxy": "Ouvrir directement (sans proxy)",
     "editInterfaces": "Modifier les interfaces web",
     "removeInterface": "Supprimer",
     "addInterface": "Ajouter une interface",

--- a/web/src/locales/ja/translation.json
+++ b/web/src/locales/ja/translation.json
@@ -65,6 +65,7 @@
     "ifaceSaveFailed": "保存に失敗しました: {{message}}",
     "ifaceLabel": "ラベル",
     "ifaceUrl": "URL (http:// または /path)",
+    "ifaceNoProxy": "直接開く（プロキシを使用しない）",
     "editInterfaces": "Web インターフェースを編集",
     "removeInterface": "削除",
     "addInterface": "インターフェースを追加",

--- a/web/src/locales/pl/translation.json
+++ b/web/src/locales/pl/translation.json
@@ -65,6 +65,7 @@
     "ifaceSaveFailed": "Zapis nie powiódł się: {{message}}",
     "ifaceLabel": "Etykieta",
     "ifaceUrl": "URL (http:// lub /ścieżka)",
+    "ifaceNoProxy": "Otwórz bezpośrednio (bez proxy)",
     "editInterfaces": "Edytuj interfejsy webowe",
     "removeInterface": "Usuń",
     "addInterface": "Dodaj interfejs",

--- a/web/src/locales/pt-BR/translation.json
+++ b/web/src/locales/pt-BR/translation.json
@@ -65,6 +65,7 @@
     "ifaceSaveFailed": "Falha ao salvar: {{message}}",
     "ifaceLabel": "Rótulo",
     "ifaceUrl": "URL (http:// ou /caminho)",
+    "ifaceNoProxy": "Abrir diretamente (sem proxy)",
     "editInterfaces": "Editar interfaces web",
     "removeInterface": "Remover",
     "addInterface": "Adicionar interface",

--- a/web/src/locales/ru/translation.json
+++ b/web/src/locales/ru/translation.json
@@ -65,6 +65,7 @@
     "ifaceSaveFailed": "Не удалось сохранить: {{message}}",
     "ifaceLabel": "Метка",
     "ifaceUrl": "URL (http:// или /путь)",
+    "ifaceNoProxy": "Открыть напрямую (без прокси)",
     "editInterfaces": "Редактировать веб-интерфейсы",
     "removeInterface": "Удалить",
     "addInterface": "Добавить интерфейс",

--- a/web/src/locales/tr/translation.json
+++ b/web/src/locales/tr/translation.json
@@ -65,6 +65,7 @@
     "ifaceSaveFailed": "Kaydetme başarısız: {{message}}",
     "ifaceLabel": "Etiket",
     "ifaceUrl": "URL (http:// veya /yol)",
+    "ifaceNoProxy": "Doğrudan aç (proxy kullanma)",
     "editInterfaces": "Web arayüzlerini düzenle",
     "removeInterface": "Kaldır",
     "addInterface": "Arayüz ekle",

--- a/web/src/locales/zh-CN/translation.json
+++ b/web/src/locales/zh-CN/translation.json
@@ -65,6 +65,7 @@
     "ifaceSaveFailed": "保存失败：{{message}}",
     "ifaceLabel": "标签",
     "ifaceUrl": "URL（http:// 或 /path）",
+    "ifaceNoProxy": "直接打开（不使用代理）",
     "editInterfaces": "编辑 Web 界面",
     "removeInterface": "移除",
     "addInterface": "添加界面",

--- a/web/src/tabs/BattlegroupTab/components/WebInterfacesCard.tsx
+++ b/web/src/tabs/BattlegroupTab/components/WebInterfacesCard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Button, Skeleton, Spinner, toast } from '@heroui/react'
+import { Button, Checkbox, Skeleton, Spinner, toast } from '@heroui/react'
 import { Icon, FieldInput } from '../../../dune-ui'
 import { api } from '../../../api/client'
 import type { Status, WebInterface } from '../../../api/client'
@@ -41,6 +41,8 @@ export const WebInterfacesCard: React.FC<{ status: Status | null }> = ({ status 
   }
   const setField = (i: number, key: 'label' | 'url', v: string) =>
     setDraft((d) => d.map((row, idx) => (idx === i ? { ...row, [key]: v } : row)))
+  const setNoProxy = (i: number, v: boolean) =>
+    setDraft((d) => d.map((row, idx) => (idx === i ? { ...row, noProxy: v } : row)))
 
   const save = () => {
     const clean = draft.filter((r) => r.label.trim() && r.url.trim())
@@ -106,6 +108,17 @@ export const WebInterfacesCard: React.FC<{ status: Status | null }> = ({ status 
                 ariaLabel={t('serverHealth.ifaceUrl')}
                 className="flex-1 font-mono"
               />
+              {/* Opt this entry out of the mesh web proxy — the SPA opens the
+                  URL above as-is instead of a rewritten proxy port. For
+                  NAT/reverse-proxy setups where only fixed published ports
+                  are reachable, the rewritten URL is unreachable. (#261) */}
+              <Checkbox
+                isSelected={row.noProxy ?? false}
+                onChange={(v) => setNoProxy(i, v)}
+                className="shrink-0"
+              >
+                <span className="text-xs text-muted whitespace-nowrap">{t('serverHealth.ifaceNoProxy')}</span>
+              </Checkbox>
               <Button
                 size="sm"
                 variant="ghost"


### PR DESCRIPTION
## Summary
- Adds `NoProxy` to each Web Interfaces entry so operators behind NAT/a reverse proxy (only fixed published ports reachable) can force an entry to open its configured URL as-is instead of the mesh proxy's rewritten port.
- `schemeAndDialFor` (the single source of truth for `resolveProxyTargets`/`withProxyPorts`) short-circuits on `NoProxy`, so no proxy target/port is ever created for an opted-out entry.
- Frontend: checkbox in the Web Interfaces edit form; `noProxy` round-trips through save/load and the API response.

## Test plan
- [x] `make verify` (fmt-check, vet, test-race, lint) — pass; `vulncheck` fails on a pre-existing, unrelated marketbot dependency (golang.org/x/text GO-2026-5970, also present on main)
- [x] `make gosec` — 0 issues
- [x] `cd web && pnpm build && pnpm lint && pnpm exec vitest run` — pass (81/81 tests, incl. i18n locale parity)
- [ ] Manual: add/edit a web interface with an absolute URL, tick "Open directly (don't proxy)", save, confirm it opens the raw URL not the proxy port
- [ ] Manual: confirm an entry without the checkbox still proxies as before (regression check)
- [ ] Manual: reload the page, confirm the checkbox state persists

## Note for reviewers
Overlaps `#275` (also touches web-proxy internals) in an additive-only way — `web_interfaces.go`/`web_proxy.go` struct fields, `client.ts` type, `WebInterfacesCard.tsx` edit row, and locale files. Should merge cleanly by keeping both sides' additions.

Addresses #261