### PR TITLE
fix(web-proxy): dial the rewritten vmHost so kubectl Director/File Browser proxy works

### DIFF
--- a/cmd/dune-admin/control_kubectl.go
+++ b/cmd/dune-admin/control_kubectl.go
@@ -128,23 +128,31 @@ func (c *kubectlControl) vmHostIP() string {
 // raw host:port addresses reported by the battlegroup CRD. Empty addresses are
 // skipped. The game's director and file browser serve over http on node ports
 // (matching director_url's http convention).
+//
+// Target uses the same rewritten host as URL (#275): the mesh web proxy dials
+// Target (schemeAndDialFor in web_proxy.go), and the raw CRD address is often a
+// public/WAN node IP the executor can't route to — dialing it 502s even though
+// the displayed (rewritten) URL is reachable. Deriving both from rewriteHost
+// keeps them from drifting apart again.
 func webInterfacesFromAddresses(vmHost, directorAddr, fileBrowserAddr string) []webInterface {
 	var out []webInterface
-	if url := webInterfaceURL(vmHost, directorAddr); url != "" {
-		out = append(out, webInterface{Label: directorInterfaceLabel, URL: url, Target: strings.TrimSpace(directorAddr)})
+	if host := rewriteHost(vmHost, directorAddr); host != "" {
+		out = append(out, webInterface{Label: directorInterfaceLabel, URL: "http://" + host + "/", Target: host})
 	}
-	if url := webInterfaceURL(vmHost, fileBrowserAddr); url != "" {
-		out = append(out, webInterface{Label: "File Browser", URL: url, Target: strings.TrimSpace(fileBrowserAddr)})
+	if host := rewriteHost(vmHost, fileBrowserAddr); host != "" {
+		out = append(out, webInterface{Label: "File Browser", URL: "http://" + host + "/", Target: host})
 	}
 	return out
 }
 
-// webInterfaceURL turns a CRD-reported host:port into an operator-reachable URL.
-// The CRD advertises a node IP that is often a public/WAN address the operator
-// can't route to, so the host is rewritten to the VM IP dune-admin connects to
-// (vmHost), keeping the node port. Falls back to the reported host when vmHost
-// is unknown (local executor).
-func webInterfaceURL(vmHost, addr string) string {
+// rewriteHost turns a CRD-reported host:port into the operator-reachable
+// host:port dune-admin (and the mesh web proxy) should use — both to display and
+// to dial. The CRD advertises a node IP that is often a public/WAN address the
+// operator/executor can't route to, so the host is rewritten to the VM IP
+// dune-admin connects to (vmHost), keeping the node port. Falls back to the
+// reported host when vmHost is unknown (local executor). Returns "" for an
+// empty/blank addr or when the resulting host is empty.
+func rewriteHost(vmHost, addr string) string {
 	addr = strings.TrimSpace(addr)
 	if addr == "" {
 		return ""
@@ -160,7 +168,18 @@ func webInterfaceURL(vmHost, addr string) string {
 		return ""
 	}
 	if port != "" {
-		return "http://" + net.JoinHostPort(host, port) + "/"
+		return net.JoinHostPort(host, port)
+	}
+	return host
+}
+
+// webInterfaceURL turns a CRD-reported host:port into an operator-reachable URL.
+// Thin wrapper over rewriteHost for callers that only need the URL (e.g. tests
+// exercising the host-rewrite behavior directly).
+func webInterfaceURL(vmHost, addr string) string {
+	host := rewriteHost(vmHost, addr)
+	if host == "" {
+		return ""
 	}
 	return "http://" + host + "/"
 }

--- a/cmd/dune-admin/web_interfaces_discover_test.go
+++ b/cmd/dune-admin/web_interfaces_discover_test.go
@@ -7,6 +7,12 @@ import "testing"
 // operator may not be able to route to, so the host is rewritten to the VM IP
 // dune-admin connects to (vmHost) while keeping the node port. Empty addresses
 // are skipped.
+//
+// Target must match the URL host (#275): the proxy dials Target, and a raw,
+// unroutable CRD address there produces a 502 even though the displayed URL
+// (host-rewritten to vmHost) is reachable. Pre-fix, Target kept the raw CRD
+// address while URL was rewritten — this test enforces they derive from the
+// same rewrite.
 func TestWebInterfacesFromAddresses(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -16,24 +22,24 @@ func TestWebInterfacesFromAddresses(t *testing.T) {
 		want     []webInterface
 	}{
 		{
-			name:     "rewrites the CRD node IP to the VM IP, keeps the port",
+			name:     "rewrites the CRD node IP to the VM IP, keeps the port, Target matches URL host",
 			vmHost:   "192.168.0.67",
 			director: "207.216.171.194:31592",
 			files:    "207.216.171.194:18888",
 			want: []webInterface{
-				{Label: "Battlegroup Director", URL: "http://192.168.0.67:31592/", Target: "207.216.171.194:31592"},
-				{Label: "File Browser", URL: "http://192.168.0.67:18888/", Target: "207.216.171.194:18888"},
+				{Label: "Battlegroup Director", URL: "http://192.168.0.67:31592/", Target: "192.168.0.67:31592"},
+				{Label: "File Browser", URL: "http://192.168.0.67:18888/", Target: "192.168.0.67:18888"},
 			},
 		},
 		{
-			name:     "only file browser",
+			name:     "only file browser, Target matches URL host",
 			vmHost:   "192.168.0.67",
 			director: "",
 			files:    "207.216.171.194:18888",
-			want:     []webInterface{{Label: "File Browser", URL: "http://192.168.0.67:18888/", Target: "207.216.171.194:18888"}},
+			want:     []webInterface{{Label: "File Browser", URL: "http://192.168.0.67:18888/", Target: "192.168.0.67:18888"}},
 		},
 		{
-			name:     "no vmHost (local executor) falls back to the reported host",
+			name:     "no vmHost (local executor) falls back to the reported host for both URL and Target",
 			vmHost:   "",
 			director: "207.216.171.194:31592",
 			files:    "",
@@ -45,6 +51,13 @@ func TestWebInterfacesFromAddresses(t *testing.T) {
 			director: "  ",
 			files:    "",
 			want:     nil,
+		},
+		{
+			name:     "CRD address with no port: Target is the bare rewritten host, matching URL",
+			vmHost:   "192.168.0.67",
+			director: "207.216.171.194",
+			files:    "",
+			want:     []webInterface{{Label: "Battlegroup Director", URL: "http://192.168.0.67/", Target: "192.168.0.67"}},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- kubectl-discovered Director/File Browser links displayed a vmHost-rewritten URL but the mesh web proxy dialed the raw CRD address (often an unroutable public/WAN node IP) — causing a 502 through the proxy and on direct access. This is a regression since v0.42.0's reverse-proxy feature.
- Extracted `rewriteHost(vmHost, addr)` as the single source of truth so `Target` (what the proxy dials) and `URL` (what's displayed) always agree — they can no longer drift apart.
- Falls back to the raw address for both when `vmHost` is empty (local executor), preserving current behavior for non-split setups.

## Test plan
- [x] `TestWebInterfacesFromAddresses` updated first (TDD red→green): `Target` now asserted to match the rewritten URL host, plus a new no-port edge case
- [x] `make verify` (vet/test-race/lint pass; vulncheck fails on a pre-existing, unrelated golang.org/x/text advisory, also present on main)
- [x] `make gosec` — 0 issues
- [ ] Manual: confirm Director/File Browser load without 502 on a live kubectl deployment — build+deploy this branch, check the web-proxy startup log line shows the upstream as the vmHost/SSH-reachable IP (not the raw CRD address), click both links in Server Health, curl the local proxy port directly

## Note for reviewers
Overlaps `#261` (also touches web-proxy internals) in an additive-only way — confirmed no textual conflict (disjoint files: this touches `control_kubectl.go` + its discover test; #261 touches `web_interfaces.go`/`web_proxy.go`). One stale-comment flag: #261 adds a doc comment to `schemeAndDialFor` claiming "Target is the raw CRD host:port" — after this fix, Target is the rewritten host:port. Worth a follow-up comment tweak whichever merges second.

Addresses #275