### PR TITLE
feat(livemap): filter markers by dimension/partition

### DIFF
--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -6525,11 +6525,24 @@ func validateMapKey(key string) error {
 // is a real dimension, not "unset") returns a clause bound to $2, since $1 is
 // always the map key in every caller. alias lets the same helper serve both
 // the actors alias ("a") and the base-markers totem alias ("t").
+//
+// The comparison goes through COALESCE(dimension_index, 0) rather than a bare
+// `= $2`, matching the COALESCE(..., 0) already used when the column is
+// displayed (mapMarker.DimensionIndex) and by cmdFetchMapDimensions when
+// listing options: a NULL dimension_index is treated as bucket 0 everywhere,
+// consistently. A bare `dimension_index = $2` would silently exclude NULL rows
+// even when $2 = 0, because SQL NULL = 0 is neither true nor false — those
+// rows would still be labelled "dimension 0" on display and would have no
+// dimension option in the selector to reach them, only reappearing under "all
+// dimensions". The game server's own save_actors routine already does
+// `coalesce(in_server_info.dimension_index, 0)` on write, so NULL should be
+// rare in practice (legacy/edge-case rows only) — but the read path must not
+// assume that holds.
 func dimensionFilterSQL(alias string, dimension *int) (string, []any) {
 	if dimension == nil {
 		return "", nil
 	}
-	return fmt.Sprintf(" AND %s.dimension_index = $2", alias), []any{*dimension}
+	return fmt.Sprintf(" AND COALESCE(%s.dimension_index, 0) = $2", alias), []any{*dimension}
 }
 
 // cmdFetchMapMarkers returns every plottable entity (players + vehicles) on the
@@ -6665,14 +6678,20 @@ func cmdFetchBaseMarkers(ctx context.Context, pool *pgxpool.Pool, mapKey string,
 // cmdFetchMapDimensions returns the distinct dimension_index values present for
 // the given map's actors, sorted ascending, so the frontend can populate a
 // dimension selector (#274). Always returns a non-nil slice.
+//
+// Groups on COALESCE(dimension_index, 0) rather than filtering NULL rows out,
+// so it agrees with dimensionFilterSQL and the marker queries' display
+// COALESCE: a map with only NULL-dimension actors still reports dimension 0 as
+// a selectable option, instead of omitting the only dimension those actors
+// could ever be filtered into.
 func cmdFetchMapDimensions(ctx context.Context, pool *pgxpool.Pool, mapKey string) ([]int, error) {
 	if err := validateMapKey(mapKey); err != nil {
 		return nil, err
 	}
 	rows, err := pool.Query(ctx, `
-		SELECT DISTINCT dimension_index
+		SELECT DISTINCT COALESCE(dimension_index, 0)
 		FROM dune.actors
-		WHERE map = $1 AND dimension_index IS NOT NULL
+		WHERE map = $1
 		ORDER BY 1`, mapKey)
 	if err != nil {
 		return nil, fmt.Errorf("query map dimensions: %w", err)

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -6518,15 +6518,33 @@ func validateMapKey(key string) error {
 	return nil
 }
 
+// dimensionFilterSQL builds the optional dimension_index filter shared by
+// cmdFetchMapMarkers/cmdFetchBaseMarkers (#274). A nil dimension means "all
+// dimensions" — the pre-#274 behaviour, kept for backward compatibility — and
+// returns no clause/args. A non-nil dimension (including the zero value, which
+// is a real dimension, not "unset") returns a clause bound to $2, since $1 is
+// always the map key in every caller. alias lets the same helper serve both
+// the actors alias ("a") and the base-markers totem alias ("t").
+func dimensionFilterSQL(alias string, dimension *int) (string, []any) {
+	if dimension == nil {
+		return "", nil
+	}
+	return fmt.Sprintf(" AND %s.dimension_index = $2", alias), []any{*dimension}
+}
+
 // cmdFetchMapMarkers returns every plottable entity (players + vehicles) on the
 // given map, reading positions from dune.actors.transform. Bases are added in
-// Phase 2b. The map key is validated, then passed as a bound parameter.
-func cmdFetchMapMarkers(ctx context.Context, pool *pgxpool.Pool, mapKey string) ([]mapMarker, error) {
+// Phase 2b. The map key is validated, then passed as a bound parameter. dimension
+// optionally narrows results to a single dimension_index (#274) — nil returns
+// every dimension merged, matching pre-#274 behaviour.
+func cmdFetchMapMarkers(ctx context.Context, pool *pgxpool.Pool, mapKey string, dimension *int) ([]mapMarker, error) {
 	if err := validateMapKey(mapKey); err != nil {
 		return nil, err
 	}
 
 	markers := []mapMarker{}
+
+	dimClause, dimArgs := dimensionFilterSQL("a", dimension)
 
 	// Players: position is the player's pawn actor transform.
 	// fls_id must be accounts."user" (hex UUID) — that is what RMQ PlayerId and
@@ -6537,6 +6555,7 @@ func cmdFetchMapMarkers(ctx context.Context, pool *pgxpool.Pool, mapKey string) 
 		       COALESCE(NULLIF(ps.character_name, ''), 'Unknown') AS name,
 		       COALESCE(ps.online_status::text, '') AS online_status,
 		       COALESCE(a.partition_id, 0) AS partition_id,
+		       COALESCE(a.dimension_index, 0) AS dimension_index,
 		       COALESCE(ac."user", '') AS fls_id,
 		       ((a.transform).location).x,
 		       ((a.transform).location).y,
@@ -6544,14 +6563,15 @@ func cmdFetchMapMarkers(ctx context.Context, pool *pgxpool.Pool, mapKey string) 
 		FROM dune.actors a
 		JOIN dune.player_state ps ON ps.player_pawn_id = a.id
 		LEFT JOIN dune.accounts ac ON ac.id = ps.account_id
-		WHERE a.map = $1 AND a.transform IS NOT NULL`, mapKey)
+		WHERE a.map = $1 AND a.transform IS NOT NULL`+dimClause,
+		append([]any{mapKey}, dimArgs...)...)
 	if err != nil {
 		return nil, fmt.Errorf("query player markers: %w", err)
 	}
 	defer playerRows.Close()
 	for playerRows.Next() {
 		m := mapMarker{Type: "player", Map: mapKey}
-		if err := playerRows.Scan(&m.ID, &m.Name, &m.OnlineStatus, &m.PartitionID, &m.FLSID, &m.X, &m.Y, &m.Z); err != nil {
+		if err := playerRows.Scan(&m.ID, &m.Name, &m.OnlineStatus, &m.PartitionID, &m.DimensionIndex, &m.FLSID, &m.X, &m.Y, &m.Z); err != nil {
 			return nil, fmt.Errorf("scan player marker: %w", err)
 		}
 		markers = append(markers, m)
@@ -6565,19 +6585,21 @@ func cmdFetchMapMarkers(ctx context.Context, pool *pgxpool.Pool, mapKey string) 
 		SELECT a.id,
 		       a.class,
 		       COALESCE(a.partition_id, 0) AS partition_id,
+		       COALESCE(a.dimension_index, 0) AS dimension_index,
 		       ((a.transform).location).x,
 		       ((a.transform).location).y,
 		       ((a.transform).location).z
 		FROM dune.vehicles v
 		JOIN dune.actors a ON a.id = v.id
-		WHERE a.map = $1 AND a.transform IS NOT NULL`, mapKey)
+		WHERE a.map = $1 AND a.transform IS NOT NULL`+dimClause,
+		append([]any{mapKey}, dimArgs...)...)
 	if err != nil {
 		return nil, fmt.Errorf("query vehicle markers: %w", err)
 	}
 	defer vehicleRows.Close()
 	for vehicleRows.Next() {
 		m := mapMarker{Type: "vehicle", Map: mapKey}
-		if err := vehicleRows.Scan(&m.ID, &m.Class, &m.PartitionID, &m.X, &m.Y, &m.Z); err != nil {
+		if err := vehicleRows.Scan(&m.ID, &m.Class, &m.PartitionID, &m.DimensionIndex, &m.X, &m.Y, &m.Z); err != nil {
 			return nil, fmt.Errorf("scan vehicle marker: %w", err)
 		}
 		m.Class = shortClass(m.Class)
@@ -6588,7 +6610,7 @@ func cmdFetchMapMarkers(ctx context.Context, pool *pgxpool.Pool, mapKey string) 
 		return nil, fmt.Errorf("iterate vehicle markers: %w", err)
 	}
 
-	bases, err := cmdFetchBaseMarkers(ctx, pool, mapKey)
+	bases, err := cmdFetchBaseMarkers(ctx, pool, mapKey, dimension)
 	if err != nil {
 		return nil, err
 	}
@@ -6599,11 +6621,15 @@ func cmdFetchMapMarkers(ctx context.Context, pool *pgxpool.Pool, mapKey string) 
 
 // cmdFetchBaseMarkers returns base-totem map markers for the given map. Each
 // building's canonical totem actor (lowest owner_entity_id) is joined to
-// permission_actor for the display name, mirroring cmdListBases.
-func cmdFetchBaseMarkers(ctx context.Context, pool *pgxpool.Pool, mapKey string) ([]mapMarker, error) {
+// permission_actor for the display name, mirroring cmdListBases. dimension
+// optionally narrows results to a single dimension_index (#274) — nil returns
+// every dimension.
+func cmdFetchBaseMarkers(ctx context.Context, pool *pgxpool.Pool, mapKey string, dimension *int) ([]mapMarker, error) {
+	dimClause, dimArgs := dimensionFilterSQL("t", dimension)
 	rows, err := pool.Query(ctx, `
 		SELECT b.id,
 		       COALESCE(NULLIF(pa.actor_name, ''), 'Base') AS name,
+		       COALESCE(t.dimension_index, 0) AS dimension_index,
 		       ((t.transform).location).x,
 		       ((t.transform).location).y,
 		       ((t.transform).location).z
@@ -6616,7 +6642,8 @@ func cmdFetchBaseMarkers(ctx context.Context, pool *pgxpool.Pool, mapKey string)
 		JOIN dune.actor_fgl_entities afe ON afe.entity_id = first_inst.owner_entity_id
 		JOIN dune.actors t ON t.id = afe.actor_id AND t.class ILIKE '%Totem%'
 		LEFT JOIN dune.permission_actor pa ON pa.actor_id = t.id
-		WHERE t.map = $1 AND t.transform IS NOT NULL`, mapKey)
+		WHERE t.map = $1 AND t.transform IS NOT NULL`+dimClause,
+		append([]any{mapKey}, dimArgs...)...)
 	if err != nil {
 		return nil, fmt.Errorf("query base markers: %w", err)
 	}
@@ -6624,7 +6651,7 @@ func cmdFetchBaseMarkers(ctx context.Context, pool *pgxpool.Pool, mapKey string)
 	var out []mapMarker
 	for rows.Next() {
 		m := mapMarker{Type: "base", Map: mapKey}
-		if err := rows.Scan(&m.ID, &m.Name, &m.X, &m.Y, &m.Z); err != nil {
+		if err := rows.Scan(&m.ID, &m.Name, &m.DimensionIndex, &m.X, &m.Y, &m.Z); err != nil {
 			return nil, fmt.Errorf("scan base marker: %w", err)
 		}
 		out = append(out, m)
@@ -6633,6 +6660,36 @@ func cmdFetchBaseMarkers(ctx context.Context, pool *pgxpool.Pool, mapKey string)
 		return nil, fmt.Errorf("iterate base markers: %w", err)
 	}
 	return out, nil
+}
+
+// cmdFetchMapDimensions returns the distinct dimension_index values present for
+// the given map's actors, sorted ascending, so the frontend can populate a
+// dimension selector (#274). Always returns a non-nil slice.
+func cmdFetchMapDimensions(ctx context.Context, pool *pgxpool.Pool, mapKey string) ([]int, error) {
+	if err := validateMapKey(mapKey); err != nil {
+		return nil, err
+	}
+	rows, err := pool.Query(ctx, `
+		SELECT DISTINCT dimension_index
+		FROM dune.actors
+		WHERE map = $1 AND dimension_index IS NOT NULL
+		ORDER BY 1`, mapKey)
+	if err != nil {
+		return nil, fmt.Errorf("query map dimensions: %w", err)
+	}
+	defer rows.Close()
+	dims := []int{}
+	for rows.Next() {
+		var d int
+		if err := rows.Scan(&d); err != nil {
+			return nil, fmt.Errorf("scan dimension: %w", err)
+		}
+		dims = append(dims, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate map dimensions: %w", err)
+	}
+	return dims, nil
 }
 
 // ── storage container commands ────────────────────────────────────────────────

--- a/cmd/dune-admin/db_cmd_map_dimensions_test.go
+++ b/cmd/dune-admin/db_cmd_map_dimensions_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"reflect"
 	"testing"
 )
@@ -14,6 +15,10 @@ import (
 //     is a real, distinct selection, not "unset"
 //   - use the caller-supplied table alias so it composes into both the
 //     player/vehicle query (alias "a") and the base query (alias "t")
+//   - wrap the column in COALESCE(..., 0) rather than compare it bare, so a
+//     NULL dimension_index is treated as bucket 0 — see
+//     TestDimensionFilterSQL_NullRowsMatchDimensionZero below for why a bare
+//     `= $2` would be a bug.
 func TestDimensionFilterSQL(t *testing.T) {
 	t.Parallel()
 
@@ -38,21 +43,21 @@ func TestDimensionFilterSQL(t *testing.T) {
 			name:       "dimension zero is a real filter, not absent",
 			alias:      "a",
 			dimension:  &zero,
-			wantClause: " AND a.dimension_index = $2",
+			wantClause: " AND COALESCE(a.dimension_index, 0) = $2",
 			wantArgs:   []any{0},
 		},
 		{
 			name:       "non-zero dimension",
 			alias:      "a",
 			dimension:  &three,
-			wantClause: " AND a.dimension_index = $2",
+			wantClause: " AND COALESCE(a.dimension_index, 0) = $2",
 			wantArgs:   []any{3},
 		},
 		{
 			name:       "alias is respected for the base-markers query",
 			alias:      "t",
 			dimension:  &three,
-			wantClause: " AND t.dimension_index = $2",
+			wantClause: " AND COALESCE(t.dimension_index, 0) = $2",
 			wantArgs:   []any{3},
 		},
 	}
@@ -69,5 +74,81 @@ func TestDimensionFilterSQL(t *testing.T) {
 				t.Errorf("args = %#v, want %#v", args, tt.wantArgs)
 			}
 		})
+	}
+}
+
+// TestDimensionFilterSQL_NullRowsMatchDimensionZero locks in the fix for the
+// bug found in review: a NULL dimension_index is displayed to the client as
+// dimension 0 (mapMarker's own COALESCE(a.dimension_index, 0)) and would never
+// appear as its own option in cmdFetchMapDimensions (which also now groups on
+// COALESCE(dimension_index, 0)), so the filter MUST agree and also treat NULL
+// as bucket 0 — otherwise a NULL-dimension actor is shown as "dimension 0" but
+// vanishes the moment the operator actually selects dimension 0, only
+// reappearing under "all dimensions".
+//
+// This package has no pgx mock, so rather than asserting the produced clause
+// text only, this executes the actual clause dimensionFilterSQL returns
+// against a real database (SQLite in-memory, via the modernc.org/sqlite
+// driver already registered by store.go) with a genuine NULL dimension_index
+// row, proving the fix end-to-end rather than by construction:
+//   - dimension=0 must return both the true-zero row AND the NULL row
+//   - dimension=1 must return only the dimension-1 row, not the NULL row
+//   - no filter (nil dimension) must return every row, NULL included
+//
+// SQLite accepts the same "$N" placeholder syntax used against Postgres and
+// evaluates COALESCE identically, so the clause under test is exercised
+// unmodified — only the surrounding query (a throwaway local table) differs
+// from the real dune.actors query.
+func TestDimensionFilterSQL_NullRowsMatchDimensionZero(t *testing.T) {
+	t.Parallel()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec(`CREATE TABLE actors (id INTEGER, dimension_index INTEGER)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO actors (id, dimension_index) VALUES
+			(1, 0),    -- true dimension 0
+			(2, NULL), -- legacy/edge-case row with no dimension recorded
+			(3, 1)     -- a different, concrete dimension
+	`); err != nil {
+		t.Fatalf("seed rows: %v", err)
+	}
+
+	queryIDs := func(dimension *int) []int {
+		t.Helper()
+		clause, args := dimensionFilterSQL("actors", dimension)
+		rows, err := db.Query(`SELECT id FROM actors WHERE 1 = 1`+clause, append([]any{0}, args...)...)
+		if err != nil {
+			t.Fatalf("query (dimension=%v): %v", dimension, err)
+		}
+		defer func() { _ = rows.Close() }()
+		var ids []int
+		for rows.Next() {
+			var id int
+			if err := rows.Scan(&id); err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			ids = append(ids, id)
+		}
+		return ids
+	}
+
+	zero := 0
+	one := 1
+
+	if got := queryIDs(&zero); !reflect.DeepEqual(got, []int{1, 2}) {
+		t.Errorf("dimension=0: got ids %v, want [1 2] (the NULL row must be treated as dimension 0)", got)
+	}
+	if got := queryIDs(&one); !reflect.DeepEqual(got, []int{3}) {
+		t.Errorf("dimension=1: got ids %v, want [3] (the NULL row must NOT match a concrete non-zero dimension)", got)
+	}
+	if got := queryIDs(nil); !reflect.DeepEqual(got, []int{1, 2, 3}) {
+		t.Errorf("dimension=nil (all dimensions): got ids %v, want [1 2 3]", got)
 	}
 }

--- a/cmd/dune-admin/db_cmd_map_dimensions_test.go
+++ b/cmd/dune-admin/db_cmd_map_dimensions_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// dimensionFilterSQL is the pure, testable unit backing the optional dimension
+// filter on cmdFetchMapMarkers/cmdFetchBaseMarkers. It must:
+//   - return no clause and no args when dimension is nil (all dimensions —
+//     preserves pre-#274 behaviour for callers that omit the param)
+//   - return a clause bound to $2 (the map key always occupies $1) and args
+//     containing the dimension when set, including the zero value: dimension 0
+//     is a real, distinct selection, not "unset"
+//   - use the caller-supplied table alias so it composes into both the
+//     player/vehicle query (alias "a") and the base query (alias "t")
+func TestDimensionFilterSQL(t *testing.T) {
+	t.Parallel()
+
+	zero := 0
+	three := 3
+
+	tests := []struct {
+		name       string
+		alias      string
+		dimension  *int
+		wantClause string
+		wantArgs   []any
+	}{
+		{
+			name:       "nil dimension means all dimensions",
+			alias:      "a",
+			dimension:  nil,
+			wantClause: "",
+			wantArgs:   nil,
+		},
+		{
+			name:       "dimension zero is a real filter, not absent",
+			alias:      "a",
+			dimension:  &zero,
+			wantClause: " AND a.dimension_index = $2",
+			wantArgs:   []any{0},
+		},
+		{
+			name:       "non-zero dimension",
+			alias:      "a",
+			dimension:  &three,
+			wantClause: " AND a.dimension_index = $2",
+			wantArgs:   []any{3},
+		},
+		{
+			name:       "alias is respected for the base-markers query",
+			alias:      "t",
+			dimension:  &three,
+			wantClause: " AND t.dimension_index = $2",
+			wantArgs:   []any{3},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			clause, args := dimensionFilterSQL(tt.alias, tt.dimension)
+			if clause != tt.wantClause {
+				t.Errorf("clause = %q, want %q", clause, tt.wantClause)
+			}
+			if !reflect.DeepEqual(args, tt.wantArgs) {
+				t.Errorf("args = %#v, want %#v", args, tt.wantArgs)
+			}
+		})
+	}
+}

--- a/cmd/dune-admin/handlers_map.go
+++ b/cmd/dune-admin/handlers_map.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 )
 
 // handleListMaps returns the distinct map names present in dune.actors, for use
@@ -23,15 +24,35 @@ func handleListMaps(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, maps)
 }
 
+// parseDimensionParam reads the optional ?dimension= query parameter shared by
+// /map/markers and /map/dimensions (#274). Absence (or an empty string) means
+// "all dimensions" and returns (nil, nil) — preserving pre-#274 behaviour for
+// any caller that omits the param. A present value must be a non-negative
+// integer; dimension 0 is a real, distinct selection, not "unset".
+func parseDimensionParam(r *http.Request) (*int, error) {
+	raw := r.URL.Query().Get("dimension")
+	if raw == "" {
+		return nil, nil
+	}
+	d, err := strconv.Atoi(raw)
+	if err != nil || d < 0 {
+		return nil, fmt.Errorf("invalid dimension: %q", raw)
+	}
+	return &d, nil
+}
+
 // handleGetMapMarkers returns the Live Map markers (players + vehicles, plus
 // bases in Phase 2b) for the requested map. The ?map= input is validated before
 // the DB is touched, so bad input fails fast with 400 and a valid map with no DB
-// connection surfaces 503.
+// connection surfaces 503. The optional ?dimension= narrows results to a single
+// dimension_index (#274); omitting it preserves the pre-#274 all-dimensions
+// behaviour.
 //
 // @Summary Live Map markers for a map
 // @Tags map
 // @Produce json
 // @Param map query string true "Map key (HaggaBasin | DeepDesert)"
+// @Param dimension query int false "Dimension index to filter to (omit for all dimensions)"
 // @Success 200 {array} mapMarker
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
@@ -43,18 +64,55 @@ func handleGetMapMarkers(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, err, http.StatusBadRequest)
 		return
 	}
+	dimension, err := parseDimensionParam(r)
+	if err != nil {
+		jsonErr(w, err, http.StatusBadRequest)
+		return
+	}
 	db := dbFromCtx(r)
 	if db == nil {
 		jsonErr(w, fmt.Errorf("database not connected"), http.StatusServiceUnavailable)
 		return
 	}
-	markers, err := cmdFetchMapMarkers(r.Context(), db, mapKey)
+	markers, err := cmdFetchMapMarkers(r.Context(), db, mapKey, dimension)
 	if err != nil {
 		componentLog("handlers").Error().Str("map_key", mapKey).Err(err).Msg("fetch map markers failed")
 		jsonErr(w, fmt.Errorf("internal error"), http.StatusInternalServerError)
 		return
 	}
 	jsonOK(w, markers)
+}
+
+// handleGetMapDimensions returns the distinct dimension indices available for
+// the requested map, so the frontend can populate a dimension selector (#274).
+//
+// @Summary Live Map available dimensions for a map
+// @Tags map
+// @Produce json
+// @Param map query string true "Map key (HaggaBasin | DeepDesert)"
+// @Success 200 {array} int
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Failure 503 {object} map[string]string
+// @Router /api/v1/map/dimensions [get]
+func handleGetMapDimensions(w http.ResponseWriter, r *http.Request) {
+	mapKey := r.URL.Query().Get("map")
+	if err := validateMapKey(mapKey); err != nil {
+		jsonErr(w, err, http.StatusBadRequest)
+		return
+	}
+	db := dbFromCtx(r)
+	if db == nil {
+		jsonErr(w, fmt.Errorf("database not connected"), http.StatusServiceUnavailable)
+		return
+	}
+	dims, err := cmdFetchMapDimensions(r.Context(), db, mapKey)
+	if err != nil {
+		componentLog("handlers").Error().Str("map_key", mapKey).Err(err).Msg("fetch map dimensions failed")
+		jsonErr(w, fmt.Errorf("internal error"), http.StatusInternalServerError)
+		return
+	}
+	jsonOK(w, dims)
 }
 
 func handleGetMapCalibration(w http.ResponseWriter, r *http.Request) {

--- a/cmd/dune-admin/handlers_map_test.go
+++ b/cmd/dune-admin/handlers_map_test.go
@@ -33,6 +33,12 @@ func TestHandleGetMapMarkers_Input(t *testing.T) {
 		{name: "missing map param", query: "", wantStatus: http.StatusBadRequest},
 		{name: "unsupported map", query: "?map=Atlantis", wantStatus: http.StatusBadRequest},
 		{name: "valid map, db down", query: "?map=HaggaBasin", wantStatus: http.StatusServiceUnavailable},
+		// #274: dimension is optional and validated before the DB guard, so a bad
+		// value 400s even with no DB connected — map validation and dimension
+		// parsing are both pure input checks that must run first.
+		{name: "non-numeric dimension", query: "?map=HaggaBasin&dimension=abc", wantStatus: http.StatusBadRequest},
+		{name: "negative dimension", query: "?map=HaggaBasin&dimension=-1", wantStatus: http.StatusBadRequest},
+		{name: "valid map + valid dimension, db down", query: "?map=HaggaBasin&dimension=0", wantStatus: http.StatusServiceUnavailable},
 	}
 
 	for _, tt := range tests {
@@ -40,6 +46,76 @@ func TestHandleGetMapMarkers_Input(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/map/markers"+tt.query, nil)
 			rec := httptest.NewRecorder()
 			handleGetMapMarkers(rec, req)
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}
+
+// #274: parseDimensionParam is the pure unit deciding what caller input reaches
+// the query. Absence must mean "all dimensions" (nil, no error) to preserve
+// pre-#274 behaviour for any existing caller that omits the param.
+func TestParseDimensionParam(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		query   string
+		want    *int
+		wantErr bool
+	}{
+		{name: "absent means all dimensions", query: "", want: nil},
+		{name: "empty string means all dimensions", query: "?dimension=", want: nil},
+		{name: "zero is a real dimension", query: "?dimension=0", want: intPtr(0)},
+		{name: "positive dimension", query: "?dimension=3", want: intPtr(3)},
+		{name: "negative rejected", query: "?dimension=-1", wantErr: true},
+		{name: "non-numeric rejected", query: "?dimension=abc", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/map/markers"+tt.query, nil)
+			got, err := parseDimensionParam(req)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (value %v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if (got == nil) != (tt.want == nil) {
+				t.Fatalf("got = %v, want %v", got, tt.want)
+			}
+			if got != nil && *got != *tt.want {
+				t.Fatalf("got = %d, want %d", *got, *tt.want)
+			}
+		})
+	}
+}
+
+// #274: /api/v1/map/dimensions lists the available dimensions for a map so the
+// frontend can populate a selector. Input validation mirrors /map/markers.
+func TestHandleGetMapDimensions_Input(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		wantStatus int
+	}{
+		{name: "missing map param", query: "", wantStatus: http.StatusBadRequest},
+		{name: "unsupported map", query: "?map=Atlantis", wantStatus: http.StatusBadRequest},
+		{name: "valid map, db down", query: "?map=HaggaBasin", wantStatus: http.StatusServiceUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/map/dimensions"+tt.query, nil)
+			rec := httptest.NewRecorder()
+			handleGetMapDimensions(rec, req)
 			if rec.Code != tt.wantStatus {
 				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, tt.wantStatus, rec.Body.String())
 			}

--- a/cmd/dune-admin/model.go
+++ b/cmd/dune-admin/model.go
@@ -165,17 +165,18 @@ type baseRow struct {
 // or (Phase 2b) a base. Position is the location vector of dune.actors.transform.
 // Pixel placement and "last seen" age are computed client-side.
 type mapMarker struct {
-	Type         string  `json:"type"` // "player" | "vehicle" | "base"
-	ID           int64   `json:"id"`
-	Name         string  `json:"name"`
-	Class        string  `json:"class,omitempty"`
-	Map          string  `json:"map"`
-	PartitionID  int64   `json:"partition_id"`
-	X            float64 `json:"x"`
-	Y            float64 `json:"y"`
-	Z            float64 `json:"z"`
-	OnlineStatus string  `json:"online_status,omitempty"`
-	FLSID        string  `json:"fls_id,omitempty"`
+	Type           string  `json:"type"` // "player" | "vehicle" | "base"
+	ID             int64   `json:"id"`
+	Name           string  `json:"name"`
+	Class          string  `json:"class,omitempty"`
+	Map            string  `json:"map"`
+	PartitionID    int64   `json:"partition_id"`
+	DimensionIndex int     `json:"dimension_index"`
+	X              float64 `json:"x"`
+	Y              float64 `json:"y"`
+	Z              float64 `json:"z"`
+	OnlineStatus   string  `json:"online_status,omitempty"`
+	FLSID          string  `json:"fls_id,omitempty"`
 }
 
 // ── message types (used by db.go cmd* functions) ──────────────────────────────

--- a/cmd/dune-admin/server.go
+++ b/cmd/dune-admin/server.go
@@ -253,6 +253,7 @@ func buildMux() *http.ServeMux {
 	// ── live map ────────────────────────────────────────────────────────────────
 	handleAPI(mux, "GET /api/v1/maps", capWorldRead, handleListMaps)
 	handleAPI(mux, "GET /api/v1/map/markers", capWorldRead, handleGetMapMarkers)
+	handleAPI(mux, "GET /api/v1/map/dimensions", capWorldRead, handleGetMapDimensions)
 	handleAPI(mux, "GET /api/v1/map/calibration", capWorldRead, handleGetMapCalibration)
 	handleAPI(mux, "PUT /api/v1/map/calibration", capWorldWrite, handlePutMapCalibration)
 	handleAPI(mux, "DELETE /api/v1/map/calibration", capWorldWrite, handleDeleteMapCalibration)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -418,6 +418,7 @@ export type MapMarker = {
   class?: string
   map: string
   partition_id: number
+  dimension_index: number
   x: number
   y: number
   z: number
@@ -1368,7 +1369,11 @@ export const api = {
   },
 
   map: {
-    markers: (mapKey: string) => req<MapMarker[]>('GET', `/map/markers?map=${encodeURIComponent(mapKey)}`),
+    markers: (mapKey: string, dimension?: number | null) => {
+      const dimParam = dimension != null ? `&dimension=${dimension}` : ''
+      return req<MapMarker[]>('GET', `/map/markers?map=${encodeURIComponent(mapKey)}${dimParam}`)
+    },
+    dimensions: (mapKey: string) => req<number[]>('GET', `/map/dimensions?map=${encodeURIComponent(mapKey)}`),
     calibration: {
       get: (mapKey: string) => req<MapCalibration>('GET', `/map/calibration?map=${encodeURIComponent(mapKey)}`),
       save: (mapKey: string, c: Omit<MapCalibration, 'map_key'>) =>

--- a/web/src/locales/de/translation.json
+++ b/web/src/locales/de/translation.json
@@ -491,7 +491,10 @@
     "calibSaveFailed": "Kalibrierung konnte nicht gespeichert werden: {{message}}",
     "calibRemoveLast": "Letzten Punkt entfernen",
     "calibReset": "Auf Standard zurücksetzen",
-    "calibResetFailed": "Kalibrierung konnte nicht zurückgesetzt werden: {{message}}"
+    "calibResetFailed": "Kalibrierung konnte nicht zurückgesetzt werden: {{message}}",
+    "dimensionLabel": "Dimension",
+    "dimensionAll": "Alle Dimensionen",
+    "dimensionOption": "Dimension {{n}}"
   },
   "logs": {
     "antiCheatLabel": "Anti-Cheat-Ereignisse",

--- a/web/src/locales/en-US/translation.json
+++ b/web/src/locales/en-US/translation.json
@@ -491,7 +491,10 @@
     "calibSaveFailed": "Failed to save calibration: {{message}}",
     "calibRemoveLast": "Remove last point",
     "calibReset": "Reset to default",
-    "calibResetFailed": "Failed to reset calibration: {{message}}"
+    "calibResetFailed": "Failed to reset calibration: {{message}}",
+    "dimensionLabel": "Dimension",
+    "dimensionAll": "All dimensions",
+    "dimensionOption": "Dimension {{n}}"
   },
   "logs": {
     "antiCheatLabel": "Anti-cheat events",

--- a/web/src/locales/es/translation.json
+++ b/web/src/locales/es/translation.json
@@ -494,7 +494,10 @@
     "calibSaveFailed": "Error al guardar la calibración: {{message}}",
     "calibRemoveLast": "Eliminar último punto",
     "calibReset": "Restablecer a predeterminado",
-    "calibResetFailed": "Error al restablecer la calibración: {{message}}"
+    "calibResetFailed": "Error al restablecer la calibración: {{message}}",
+    "dimensionLabel": "Dimensión",
+    "dimensionAll": "Todas las dimensiones",
+    "dimensionOption": "Dimensión {{n}}"
   },
   "logs": {
     "antiCheatLabel": "Eventos antitrampas",

--- a/web/src/locales/fr/translation.json
+++ b/web/src/locales/fr/translation.json
@@ -494,7 +494,10 @@
     "calibSaveFailed": "Échec de l’enregistrement du calibrage : {{message}}",
     "calibRemoveLast": "Supprimer le dernier point",
     "calibReset": "Réinitialiser par défaut",
-    "calibResetFailed": "Échec de la réinitialisation du calibrage : {{message}}"
+    "calibResetFailed": "Échec de la réinitialisation du calibrage : {{message}}",
+    "dimensionLabel": "Dimension",
+    "dimensionAll": "Toutes les dimensions",
+    "dimensionOption": "Dimension {{n}}"
   },
   "logs": {
     "antiCheatLabel": "Événements anti-triche",

--- a/web/src/locales/ja/translation.json
+++ b/web/src/locales/ja/translation.json
@@ -491,7 +491,10 @@
     "calibSaveFailed": "キャリブレーションの保存に失敗しました: {{message}}",
     "calibRemoveLast": "最後のポイントを削除",
     "calibReset": "デフォルトにリセット",
-    "calibResetFailed": "キャリブレーションのリセットに失敗しました: {{message}}"
+    "calibResetFailed": "キャリブレーションのリセットに失敗しました: {{message}}",
+    "dimensionLabel": "ディメンション",
+    "dimensionAll": "すべてのディメンション",
+    "dimensionOption": "ディメンション {{n}}"
   },
   "logs": {
     "antiCheatLabel": "アンチチートイベント",

--- a/web/src/locales/pl/translation.json
+++ b/web/src/locales/pl/translation.json
@@ -497,7 +497,10 @@
     "calibSaveFailed": "Nie udało się zapisać kalibracji: {{message}}",
     "calibRemoveLast": "Usuń ostatni punkt",
     "calibReset": "Przywróć domyślne",
-    "calibResetFailed": "Nie udało się zresetować kalibracji: {{message}}"
+    "calibResetFailed": "Nie udało się zresetować kalibracji: {{message}}",
+    "dimensionLabel": "Wymiar",
+    "dimensionAll": "Wszystkie wymiary",
+    "dimensionOption": "Wymiar {{n}}"
   },
   "logs": {
     "antiCheatLabel": "Zdarzenia antycheat",

--- a/web/src/locales/pt-BR/translation.json
+++ b/web/src/locales/pt-BR/translation.json
@@ -494,7 +494,10 @@
     "calibSaveFailed": "Falha ao salvar a calibração: {{message}}",
     "calibRemoveLast": "Remover último ponto",
     "calibReset": "Redefinir para o padrão",
-    "calibResetFailed": "Falha ao redefinir a calibração: {{message}}"
+    "calibResetFailed": "Falha ao redefinir a calibração: {{message}}",
+    "dimensionLabel": "Dimensão",
+    "dimensionAll": "Todas as dimensões",
+    "dimensionOption": "Dimensão {{n}}"
   },
   "logs": {
     "antiCheatLabel": "Eventos anti-trapaça",

--- a/web/src/locales/ru/translation.json
+++ b/web/src/locales/ru/translation.json
@@ -497,7 +497,10 @@
     "calibSaveFailed": "Не удалось сохранить калибровку: {{message}}",
     "calibRemoveLast": "Удалить последнюю точку",
     "calibReset": "Сбросить по умолчанию",
-    "calibResetFailed": "Не удалось сбросить калибровку: {{message}}"
+    "calibResetFailed": "Не удалось сбросить калибровку: {{message}}",
+    "dimensionLabel": "Измерение",
+    "dimensionAll": "Все измерения",
+    "dimensionOption": "Измерение {{n}}"
   },
   "logs": {
     "antiCheatLabel": "События античита",

--- a/web/src/locales/tr/translation.json
+++ b/web/src/locales/tr/translation.json
@@ -491,7 +491,10 @@
     "calibSaveFailed": "Kalibrasyon kaydedilemedi: {{message}}",
     "calibRemoveLast": "Son noktayı kaldır",
     "calibReset": "Varsayılana sıfırla",
-    "calibResetFailed": "Kalibrasyon sıfırlanamadı: {{message}}"
+    "calibResetFailed": "Kalibrasyon sıfırlanamadı: {{message}}",
+    "dimensionLabel": "Boyut",
+    "dimensionAll": "Tüm boyutlar",
+    "dimensionOption": "Boyut {{n}}"
   },
   "logs": {
     "antiCheatLabel": "Hile karşıtı olaylar",

--- a/web/src/locales/zh-CN/translation.json
+++ b/web/src/locales/zh-CN/translation.json
@@ -491,7 +491,10 @@
     "calibSaveFailed": "保存校准失败: {{message}}",
     "calibRemoveLast": "移除最后一个点",
     "calibReset": "重置为默认",
-    "calibResetFailed": "重置校准失败: {{message}}"
+    "calibResetFailed": "重置校准失败: {{message}}",
+    "dimensionLabel": "维度",
+    "dimensionAll": "所有维度",
+    "dimensionOption": "维度 {{n}}"
   },
   "logs": {
     "antiCheatLabel": "反作弊事件",

--- a/web/src/tabs/LiveMapTab/LiveMapTab.tsx
+++ b/web/src/tabs/LiveMapTab/LiveMapTab.tsx
@@ -33,6 +33,12 @@ export const LiveMapTab: React.FC = () => {
   const { can } = usePermissions()
   const canPlayersWrite = can('players:write')
   const [mapKey, setMapKey] = React.useState<string>('HaggaBasin')
+  // #274: which dimension (world instance) of the current map to show. null =
+  // "all dimensions" (pre-#274 behaviour, merges every dimension's markers).
+  // Defaults to the first dimension reported for the map once loaded, so
+  // multi-dimension maps don't merge instances by default.
+  const [dimensions, setDimensions] = React.useState<number[]>([])
+  const [dimension, setDimension] = React.useState<number | null>(null)
   const [markers, setMarkers] = React.useState<MapMarker[]>([])
   const [loading, setLoading] = React.useState(false)
   const [unsupported, setUnsupported] = React.useState(false)
@@ -80,7 +86,7 @@ export const LiveMapTab: React.FC = () => {
     [baseCfg, calibrating, previewBounds, calibOverride, mapKey],
   )
 
-  const load = (key: string): void => {
+  const load = (key: string, dim: number | null): void => {
     if (isDragging.current) return
     const cfg = MAPS.find((m) => m.key === key)
     if (!cfg?.hasLiveData) {
@@ -95,7 +101,7 @@ export const LiveMapTab: React.FC = () => {
         setLoading(true)
         setUnsupported(false)
       })
-      .then(() => api.map.markers(key))
+      .then(() => api.map.markers(key, dim))
       .then((rows) => {
         if (isDragging.current) return
         setMarkers(rows)
@@ -110,12 +116,30 @@ export const LiveMapTab: React.FC = () => {
       .finally(() => { if (!isDragging.current) setLoading(false) })
   }
 
-  const loadCurrent = (): void => load(mapKey)
+  const loadCurrent = (): void => load(mapKey, dimension)
   React.useEffect(() => {
     const id = setTimeout(loadCurrent, 0)
     return () => clearTimeout(id)
-  }, [mapKey]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [mapKey, dimension]) // eslint-disable-line react-hooks/exhaustive-deps
   const { countdown, refresh } = useAutoRefresh(loadCurrent, POLL_MS)
+
+  // #274: fetch the available dimensions for the current map and default the
+  // selection to the first one — merging every dimension's markers is the bug
+  // this issue fixes, so "all dimensions" is opt-in, not the default.
+  React.useEffect(() => {
+    const cfg = MAPS.find((m) => m.key === mapKey)
+    const dimsPromise = cfg?.hasLiveData ? api.map.dimensions(mapKey) : Promise.resolve<number[]>([])
+    Promise.resolve()
+      .then(() => dimsPromise)
+      .then((dims) => {
+        setDimensions(dims)
+        setDimension(dims.length > 0 ? dims[0]! : null)
+      })
+      .catch(() => {
+        setDimensions([])
+        setDimension(null)
+      })
+  }, [mapKey])
 
   React.useEffect(() => {
     const cfg = MAPS.find((m) => m.key === mapKey)
@@ -380,6 +404,38 @@ export const LiveMapTab: React.FC = () => {
             </ListBox>
           </Select.Popover>
         </Select>
+
+        {dimensions.length > 0 && (
+          <Select
+            aria-label={t('liveMap.dimensionLabel')}
+            selectedKey={dimension === null ? 'all' : String(dimension)}
+            onSelectionChange={(k) => {
+              const key = String(k)
+              setDimension(key === 'all' ? null : Number(key))
+            }}
+            className="w-36"
+          >
+            <Select.Trigger>
+              <Icon name="layers" className="size-3.5 text-muted shrink-0 mr-1" />
+              <Select.Value />
+              <Select.Indicator />
+            </Select.Trigger>
+            <Select.Popover>
+              <ListBox>
+                <ListBox.Item key="all" id="all" textValue={t('liveMap.dimensionAll')}>
+                  {t('liveMap.dimensionAll')}
+                  <ListBox.ItemIndicator />
+                </ListBox.Item>
+                {dimensions.map((d) => (
+                  <ListBox.Item key={d} id={String(d)} textValue={t('liveMap.dimensionOption', { n: d })}>
+                    {t('liveMap.dimensionOption', { n: d })}
+                    <ListBox.ItemIndicator />
+                  </ListBox.Item>
+                ))}
+              </ListBox>
+            </Select.Popover>
+          </Select>
+        )}
 
         <div className="h-4 border-l border-border mx-0.5" />
 


### PR DESCRIPTION
## Summary
- Live Map merged every dimension (e.g. multiple Survival/Deep Desert instances) of a map onto one canvas with no way to switch — the backend selected `dimension_index` but never filtered on it.
- Adds an optional `?dimension=` param to `/map/markers` and `/map/base-markers`, a new `/map/dimensions` endpoint, and a dimension selector in `LiveMapTab` defaulting to the first available dimension. Omitting the param preserves the old "all dimensions" behavior.
- Filters on `dune.actors.dimension_index` rather than `partition_id` — partition is a spatial sub-cell *within* a dimension (confirmed via the control plane's dimension/partition model and RMQ chat routing key shape), not the world-instance identity.
- **NULL-handling fix included:** the initial version had NULL `dimension_index` rows displaying as "dimension 0" but being unreachable when filtering to dimension 0 (SQL `NULL = 0` is false) — caught by adversarial review. `dimensionFilterSQL` and `cmdFetchMapDimensions` now both `COALESCE(dimension_index, 0)` consistently with the existing display logic.

## SQL safety
The dimension value is bound as a query parameter (`$2`), never string-interpolated; only a compile-time literal alias (`"a"`/`"t"`) goes through `fmt.Sprintf`. Confirmed injection-safe by direct code review.

## Test plan
- [x] `TestDimensionFilterSQL`, `TestParseDimensionParam`, handler input tests, plus a new regression test (`TestDimensionFilterSQL_NullRowsMatchDimensionZero`) executed against an in-memory SQLite DB with a genuine NULL row — verified red-then-green
- [x] `make verify`/`make gosec` — pass (vulncheck fails on the same pre-existing, unrelated golang.org/x/text advisory)
- [x] `cd web && pnpm build && pnpm lint` — pass
- [ ] Manual: on a deployment with multiple live dimensions of the same map, confirm the selector populates and switching dimension shows only that dimension's actors

Addresses #274