### PR TITLE
fix(livemap): add missing Deep Desert resources (titanium, spice)

### DIFF
--- a/web/src/tabs/LiveMapTab/constants.ts
+++ b/web/src/tabs/LiveMapTab/constants.ts
@@ -251,6 +251,9 @@ const HEATMAP_COLORS: Record<string, string> = {
   jasmium: 'rgb(180,100,220)', erythrite: 'rgb(220,60,60)',
   t6_resource_a: 'rgb(100,220,220)', t6_resource_b: 'rgb(60,180,220)',
   sandworm_territory: 'rgb(255,80,30)',
+  titanium_ore: 'rgb(180,180,190)',
+  spice_field_small: 'rgb(230,150,60)', spice_field_medium: 'rgb(220,120,40)',
+  spice_field_large: 'rgb(200,90,20)',
 }
 
 const DD_ROWS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I']
@@ -266,6 +269,7 @@ const HEATMAP_TYPES: Record<string, string[]> = {
     'aluminum_ore', 'basalt', 'carbon_fiber', 'copper_ore',
     'fiber', 'fuel', 'iron_ore',
     'sandworm_territory', 'scrap_metal', 'stone', 't6_resource_a', 't6_resource_b',
+    'titanium_ore', 'spice_field_small', 'spice_field_medium', 'spice_field_large',
   ],
 }
 


### PR DESCRIPTION
## Summary
- Deep Desert's Live Map density/heatmap layer was missing `titanium_ore` and `spice_field_small/medium/large` — the icon/label definitions already existed for these types, they just weren't wired into `HEATMAP_TYPES.DeepDesert`/`HEATMAP_COLORS`.

## Rotation/mirroring — investigated, not changed
The reporter's other complaint (resource locations look rotated/mirrored) was investigated but **not fixed** in this PR. The coordinate transform (`worldToLatLng`) only supports `flipX`/`flipY` (mirror reflections) — it structurally cannot express a 90°-rotation, which is what the reporter's own description suggests ("rotated 90 degree counterclockwise... or mirrored... or something else" — even they weren't sure). Guessing `flipY: true` (matching Hagga Basin) could just as easily make it wrong in a different way if the real defect is an axis swap. This needs the reporter's visual confirmation against the in-game grid before a fix is safe to commit — see the PR for the specific thing to check.

## Asset caveat
The new resource types only render if the CDN's `deepdesert-spawns.json`/heatmap PNGs actually contain that data. If the layer stays blank after this merges, check the Network tab for a 404 on the new asset filenames — that's an upstream asset-pipeline gap, not a code bug.

## Test plan
- [x] `pnpm build` && `pnpm lint` — pass
- [ ] Manual: enable Deep Desert's density overlay, confirm Titanium/Small/Medium/Large Spice appear as toggleable checkboxes with colored legend swatches, and that toggling actually paints a layer (not just an empty toggle)
- [ ] Manual (rotation): compare the zone-letter/number grid overlay against known in-game landmarks — report back whether it's a simple vertical mirror (fixable with `flipY`) or something more complex (needs a new axis-swap capability)

Addresses #213