### PR TITLE
fix(web): clear high-severity pnpm audit findings

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -52,7 +52,7 @@
     "react-leaflet": "^5.0.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.12.2",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^8.3.0",
     "recharts": "^3.10.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
@@ -72,7 +72,8 @@
       "@internationalized/date": "3.12.2",
       "tar@<=7.5.15": ">=7.5.16",
       "vite@>=8.0.0 <=8.0.15": ">=8.0.16",
-      "dompurify@<3.4.9": ">=3.4.9"
+      "dompurify@<3.4.9": ">=3.4.9",
+      "brace-expansion@<=5.0.7": ">=5.0.8"
     }
   },
   "devDependencies": {

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   tar@<=7.5.15: '>=7.5.16'
   vite@>=8.0.0 <=8.0.15: '>=8.0.16'
   dompurify@<3.4.9: '>=3.4.9'
+  brace-expansion@<=5.0.7: '>=5.0.8'
 
 importers:
 
@@ -134,9 +135,9 @@ importers:
       react-resizable-panels:
         specifier: ^4.12.2
         version: 4.12.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-router-dom:
-        specifier: ^7.18.1
-        version: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-router:
+        specifier: ^8.3.0
+        version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       recharts:
         specifier: ^3.10.0
         version: 3.10.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react-is@16.13.1)(react@19.2.8)(redux@5.0.1)
@@ -1609,9 +1610,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.7:
     resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
@@ -1680,9 +1681,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
@@ -2948,19 +2948,12 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  react-router-dom@7.18.1:
-    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
-    engines: {node: '>=20.0.0'}
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
+    engines: {node: '>=22.22.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.18.1:
-    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -3075,9 +3068,6 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -4995,7 +4985,7 @@ snapshots:
 
   baseline-browser-mapping@2.11.1: {}
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5053,7 +5043,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@1.1.1: {}
+  cookie-es@3.1.1: {}
 
   cose-base@1.0.3:
     dependencies:
@@ -6273,7 +6263,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minipass@7.1.3: {}
 
@@ -6568,17 +6558,10 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  react-router-dom@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
+      cookie-es: 3.1.1
       react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-router: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-
-  react-router@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.8
-      set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.8(react@19.2.8)
 
@@ -6743,8 +6726,6 @@ snapshots:
   semver@7.7.2: {}
 
   semver@7.8.5: {}
-
-  set-cookie-parser@2.7.2: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/web/src/components/app/AppCore.tsx
+++ b/web/src/components/app/AppCore.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Toast, toast } from '@heroui/react'
 import { AppLayout } from '@heroui-pro/react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { useAtom, useSetAtom } from 'jotai'
 import { useStatus } from '../../hooks/useStatus'

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { createRoot } from 'react-dom/client'
-import { HashRouter } from 'react-router-dom'
+import { HashRouter } from 'react-router'
 import './index.css'
 import './i18n'
 import { applyTheme, loadTheme, loadAnimations, setAnimations } from './theme'

--- a/web/src/tabs/DashboardTab/DashboardTab.tsx
+++ b/web/src/tabs/DashboardTab/DashboardTab.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { Button, Chip, Skeleton, Spinner, toast } from '@heroui/react'
 import { Icon, Panel, PageHeader, LoadingState } from '../../dune-ui'
 import { api } from '../../api/client'

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
             },
             {
               name: 'router-vendor',
-              test: /node_modules[\\/]react-router-dom[\\/]/,
+              test: /node_modules[\\/]react-router[\\/]/,
               priority: 45,
             },
             {


### PR DESCRIPTION
Fixes the two high-severity findings failing `make pnpm-audit` in CI.

## react-router — GHSA-qwww-vcr4-c8h2

RSC mode CSRF bypass. Only patched in `react-router@>=8.3.0`, and v8 removed the `react-router-dom` package entirely, so 7.18.1 is permanently vulnerable. An override was not possible, so this migrates off it.

- `react-router-dom: ^7.18.1` becomes `react-router: ^8.3.0`
- Three import sites swapped: `main.tsx` (`HashRouter`), `AppCore.tsx` (`useLocation`, `useNavigate`), `DashboardTab.tsx` (`useNavigate`). Per the v8 migration note everything except `RouterProvider` and `HydratedRouter` moves to `react-router`, so these are direct swaps.
- `vite.config.ts` chunk rule still matched `node_modules/react-router-dom/`, which silently stopped matching and folded the router into the generic vendor chunk. Updated, and the 38 kB `router-vendor` chunk is back.

The routing surface here is small and none of the v8 breaking changes apply. There are no data routers, loaders, middleware or meta APIs in use, and `AppRoutes` is our own component rather than react-router's `<Routes>`.

Worth noting: v8 is ESM only and sets a Node floor of 22.22.0. CI pins `node-version: '22'`, which resolves to the latest 22.x, so that is satisfied.

## brace-expansion — GHSA-mh99-v99m-4gvg

Unbounded expansion DoS. Transitive via `eslint > minimatch` with no upstream release to bump to, so this adds a pnpm override to `>=5.0.8`.

## Testing

- `make pnpm-audit` reports no known vulnerabilities
- `pnpm build` (tsc + vite) clean
- `pnpm lint` clean at `--max-warnings 0`
- `make verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)