### PR TITLE
fix(vehicles): stop double-listing backups, show real owner and durability

### DIFF
--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -5902,41 +5902,17 @@ func cmdGetPlayerVehicles(pool *pgxpool.Pool, controllerID int64) Cmd {
 			return msgVehicles{err: err}
 		}
 		// #nosec G201 -- keyCol is a fixed internal allowlist (character_id|account_id)
-		rows, err := pool.Query(context.Background(), fmt.Sprintf(`
-			SELECT pa.actor_id, a.class, COALESCE(a.map, ''),
-			       COALESCE(rv.chassis_durability::float8, 1.0),
-			       COALESCE(pa.actor_name, rv.vehicle_name, ''),
-			       (rv.vehicle_id IS NOT NULL) AS is_recovered,
-			       false AS is_backup
-			FROM dune.permission_actor pa
-			JOIN dune.permission_actor_rank par ON par.permission_actor_id = pa.actor_id
-			JOIN dune.actors a ON a.id = pa.actor_id
-			LEFT JOIN dune.recovered_vehicles rv ON rv.vehicle_id = pa.actor_id AND rv.%[1]s = $2
-			WHERE par.player_id = $1 AND pa.actor_type = 2
-
-			UNION ALL
-
-			SELECT a.id, a.class, '' AS map,
-			       1.0 AS chassis_durability,
-			       '' AS vehicle_name,
-			       false AS is_recovered,
-			       true AS is_backup
-			FROM dune.backup_vehicles bv
-			JOIN dune.actors a ON a.id = bv.vehicle_id
-			WHERE bv.%[1]s = $2
-
-			ORDER BY class`, keyCol), controllerID, keyVal)
+		rows, err := pool.Query(context.Background(), fmt.Sprintf(vehiclesQuery, keyCol), controllerID, keyVal)
 		if err != nil {
 			return msgVehicles{err: err}
 		}
 		defer rows.Close()
 		var out []vehicleRow
 		for rows.Next() {
-			var r vehicleRow
-			if err := rows.Scan(&r.ID, &r.Class, &r.Map, &r.ChassisDurability, &r.VehicleName, &r.IsRecovered, &r.IsBackup); err != nil {
+			r, ok := scanVehicleRow(rows)
+			if !ok {
 				continue
 			}
-			r.Class = shortClass(r.Class)
 			out = append(out, r)
 		}
 		if err := rows.Err(); err != nil {

--- a/cmd/dune-admin/db_vehicles.go
+++ b/cmd/dune-admin/db_vehicles.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// vehiclesQuery lists one row per vehicle the player can reach. %[1]s is the
+// account_id/character_id key column resolved by playerKeyFor.
+//
+// Backups are a LEFT JOIN flag, not a second UNION arm. A vehicle backup leaves
+// the original actor in place, so the old UNION ALL emitted every backed-up
+// vehicle twice — once "normal", once "Backup" (#313).
+//
+// Chassis durability comes from dune.vehicle_modules. The previous source,
+// recovered_vehicles.chassis_durability, is only populated for recovered
+// vehicles and was COALESCEd to 1.0, so every vehicle displayed as 100%.
+const vehiclesQuery = `
+	SELECT pa.actor_id,
+	       a.class,
+	       COALESCE(a.map, ''),
+	       COALESCE(a.partition_id, 0),
+	       COALESCE(a.dimension_index, 0),
+	       COALESCE(pa.actor_name, ''),
+	       par.rank,
+	       COALESCE(ops.character_name, ''),
+	       COALESCE(ch.cur, 0),
+	       COALESCE(ch.maxd, 0),
+	       (rv.vehicle_id IS NOT NULL) AS is_recovered,
+	       (bv.vehicle_id IS NOT NULL) AS is_backup
+	FROM dune.permission_actor pa
+	JOIN dune.permission_actor_rank par
+	  ON par.permission_actor_id = pa.actor_id AND par.player_id = $1
+	JOIN dune.actors a ON a.id = pa.actor_id
+	LEFT JOIN dune.recovered_vehicles rv ON rv.vehicle_id = pa.actor_id AND rv.%[1]s = $2
+	LEFT JOIN dune.backup_vehicles   bv ON bv.vehicle_id = pa.actor_id AND bv.%[1]s = $2
+	-- Exactly one rank-1 holder per vehicle: the owner.
+	LEFT JOIN dune.permission_actor_rank opar
+	  ON opar.permission_actor_id = pa.actor_id AND opar.rank = 1
+	LEFT JOIN dune.player_state ops ON ops.player_controller_id = opar.player_id
+	LEFT JOIN LATERAL (
+	    SELECT (m.stats->'FVehicleModuleDurabilityStats'->1->>'CurrentDurability')::float8 AS cur,
+	           (m.stats->'FVehicleModuleDurabilityStats'->1->>'DecayedMaxDurability')::float8 AS maxd
+	    FROM dune.vehicle_modules m
+	    WHERE m.vehicle_id = pa.actor_id AND m.template_id ILIKE '%%Chassis%%'
+	    LIMIT 1
+	) ch ON TRUE
+	WHERE pa.actor_type = 2
+
+	UNION ALL
+
+	-- A backup whose vehicle actor is gone is the only remaining trace of it,
+	-- so it still has to be listed.
+	SELECT bv.vehicle_id, COALESCE(a.class, ''), '', 0, 0, '', 0, '', 0, 0, false, true
+	FROM dune.backup_vehicles bv
+	LEFT JOIN dune.actors a ON a.id = bv.vehicle_id
+	WHERE bv.%[1]s = $2
+	  AND NOT EXISTS (
+	      SELECT 1 FROM dune.permission_actor pa2
+	      WHERE pa2.actor_id = bv.vehicle_id AND pa2.actor_type = 2)
+
+	ORDER BY 2`
+
+// scanVehicleRow maps one result row into a vehicleRow, applying the display
+// rules. A row that fails to scan is skipped rather than failing the request.
+func scanVehicleRow(rows pgx.Rows) (vehicleRow, bool) {
+	var r vehicleRow
+	var rawName string
+	if err := rows.Scan(
+		&r.ID, &r.Class, &r.Map, &r.Partition, &r.Dimension, &rawName,
+		&r.AccessRank, &r.OwnerName, &r.ChassisCurrent, &r.ChassisMax,
+		&r.IsRecovered, &r.IsBackup,
+	); err != nil {
+		return vehicleRow{}, false
+	}
+	r.Class = vehicleClassLabel(r.Class)
+	r.VehicleName = cleanVehicleName(rawName)
+	r.Location = formatVehicleLocation(r.Map, r.Partition, r.Dimension)
+	r.IsOwner = vehicleIsOwner(r.AccessRank)
+	r.AccessLabel = vehicleAccessLabel(r.AccessRank)
+	r.ChassisPct, r.HasChassisPct = chassisConditionPct(r.ChassisCurrent, r.ChassisMax)
+	return r, true
+}
+
+// Vehicle display helpers. Kept pure and separate from the SQL in db.go so the
+// presentation rules behind #313 are unit-testable.
+
+// vehicleOwnerRank is the permission_actor_rank.rank value held by a vehicle's
+// owner. Every vehicle has exactly one; ranks above it are granted access.
+const vehicleOwnerRank = 1
+
+// cleanVehicleName drops the game's placeholder names. An unnamed vehicle
+// records '##<Type>' (e.g. ##MediumOrnithopter) or the literal 'None' on
+// dune.permission_actor.actor_name; only a player-chosen name should surface.
+// Mirrors the container-name handling in cmdFetchBases.
+func cleanVehicleName(name string) string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" || trimmed == "None" || strings.HasPrefix(trimmed, "##") {
+		return ""
+	}
+	return trimmed
+}
+
+// splitCamelCase inserts spaces at lower→upper boundaries only, so runs of
+// capitals stay intact: "LightOrnithopter" becomes "Light Ornithopter" while
+// "CHOAM" is left alone.
+func splitCamelCase(s string) string {
+	var b strings.Builder
+	runes := []rune(s)
+	for i, r := range runes {
+		if i > 0 && unicode.IsUpper(r) && unicode.IsLower(runes[i-1]) {
+			b.WriteRune(' ')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// vehicleClassLabel turns an Unreal class path into something readable.
+//
+// The path's object name repeats the package name
+// (/Game/…/BP_Buggy_CHOAM.BP_Buggy_CHOAM_C), so shortClass alone yields
+// "BP_Buggy_CHOAM.BP_Buggy_CHOAM" — long enough to be clipped in the table
+// (#313). Collapse the duplicate, drop the BP_ prefix, and space out the words.
+//
+// Scoped to vehicles rather than changing shortClass, which three other call
+// sites depend on.
+func vehicleClassLabel(raw string) string {
+	s := shortClass(raw)
+	if pkg, obj, found := strings.Cut(s, "."); found && pkg == obj {
+		s = obj
+	}
+	s = strings.TrimPrefix(s, "BP_")
+	return splitCamelCase(strings.ReplaceAll(s, "_", " "))
+}
+
+// vehicleIsOwner reports whether a rank denotes ownership rather than a grant.
+func vehicleIsOwner(rank int) bool { return rank == vehicleOwnerRank }
+
+// vehicleAccessLabel describes how a player holds a vehicle.
+func vehicleAccessLabel(rank int) string {
+	switch {
+	case rank == vehicleOwnerRank:
+		return "owner"
+	case rank > vehicleOwnerRank:
+		return "granted"
+	default:
+		return "unknown"
+	}
+}
+
+// formatVehicleLocation renders where a vehicle sits. Vehicles are spread
+// across partitions and dimensions on a multi-sietch server, so the map name
+// alone is ambiguous (#313). Missing pieces degrade rather than print zeros.
+func formatVehicleLocation(mapName string, partition int64, dimension int) string {
+	mapName = strings.TrimSpace(mapName)
+	if partition <= 0 {
+		return mapName
+	}
+	coords := fmt.Sprintf("p%d/d%d", partition, dimension)
+	if mapName == "" {
+		return coords
+	}
+	return mapName + " " + coords
+}
+
+// chassisConditionPct converts a module's durability into a percentage, but
+// only when a real maximum is known.
+//
+// Most vehicle_modules rows carry CurrentDurability with no DecayedMaxDurability
+// (the max only appears once a part has decayed), so there is usually no
+// denominator. Reporting a percentage anyway is what produced the old
+// always-100% column, which read from the empty recovered_vehicles table.
+func chassisConditionPct(current, max float64) (float64, bool) {
+	if max <= 0 {
+		return 0, false
+	}
+	return current / max * 100, true
+}

--- a/cmd/dune-admin/db_vehicles_test.go
+++ b/cmd/dune-admin/db_vehicles_test.go
@@ -1,0 +1,191 @@
+package main
+
+import "testing"
+
+// Vehicle actor names default to '##<Type>' (e.g. ##MediumOrnithopter) or
+// 'None' when the player never renamed the vehicle. Those are placeholders, not
+// names, and must not reach the UI (#313).
+func TestCleanVehicleName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"default hash name", "##MediumOrnithopter", ""},
+		{"default buggy", "##BuggyChoam", ""},
+		{"literal None", "None", ""},
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"real player name", "ICE-Scout-Stinger", "ICE-Scout-Stinger"},
+		{"real name is trimmed", "  Sand Rider  ", "Sand Rider"},
+		{"hash mid-string is kept", "Rig##2", "Rig##2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cleanVehicleName(tc.in); got != tc.want {
+				t.Errorf("cleanVehicleName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// permission_actor_rank.rank is 1 for the owner (exactly one per vehicle) and
+// 2+ for players granted access. The old query filtered on player_id without
+// distinguishing, so a vehicle you merely had access to looked like your own.
+func TestVehicleAccessLabel(t *testing.T) {
+	cases := []struct {
+		rank int
+		want string
+	}{
+		{1, "owner"},
+		{2, "granted"},
+		{3, "granted"},
+		{0, "unknown"},
+		{-1, "unknown"},
+	}
+	for _, tc := range cases {
+		if got := vehicleAccessLabel(tc.rank); got != tc.want {
+			t.Errorf("vehicleAccessLabel(%d) = %q, want %q", tc.rank, got, tc.want)
+		}
+	}
+}
+
+func TestVehicleIsOwner(t *testing.T) {
+	if !vehicleIsOwner(1) {
+		t.Error("rank 1 must be owner")
+	}
+	for _, r := range []int{0, 2, 3, 99} {
+		if vehicleIsOwner(r) {
+			t.Errorf("rank %d must not be owner", r)
+		}
+	}
+}
+
+// Vehicles live on a specific partition and dimension. A stock server spreads
+// them across sietches (HaggaBasin p1, Story_Faction_Outpost_Atre p16), which
+// the old single-map column could not express.
+func TestFormatVehicleLocation(t *testing.T) {
+	cases := []struct {
+		name      string
+		mapName   string
+		partition int64
+		dimension int
+		want      string
+	}{
+		{"map with partition and dimension", "HaggaBasin", 1, 0, "HaggaBasin p1/d0"},
+		{"other sietch", "Story_Faction_Outpost_Atre", 16, 0, "Story_Faction_Outpost_Atre p16/d0"},
+		{"nonzero dimension", "HaggaBasin", 2, 3, "HaggaBasin p2/d3"},
+		{"no map falls back to partition", "", 4, 0, "p4/d0"},
+		{"nothing known", "", 0, 0, ""},
+		{"map only, no partition", "HaggaBasin", 0, 0, "HaggaBasin"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatVehicleLocation(tc.mapName, tc.partition, tc.dimension)
+			if got != tc.want {
+				t.Errorf("formatVehicleLocation(%q,%d,%d) = %q, want %q",
+					tc.mapName, tc.partition, tc.dimension, got, tc.want)
+			}
+		})
+	}
+}
+
+// The old column showed COALESCE(recovered_vehicles.chassis_durability, 1.0) as
+// a percentage. recovered_vehicles is empty on a normal server, so every
+// vehicle read "100%" — a fabricated number. Real durability comes from
+// vehicle_modules, where only a minority of parts carry a max, so a percentage
+// is only reported when the denominator genuinely exists.
+func TestChassisCondition(t *testing.T) {
+	cases := []struct {
+		name    string
+		cur     float64
+		max     float64
+		wantPct float64
+		wantHas bool
+	}{
+		{"max present", 1750, 3500, 50, true},
+		{"max equals current", 3499.98, 3499.98, 100, true},
+		{"no max known", 3500, 0, 0, false},
+		{"no data at all", 0, 0, 0, false},
+		{"max present but zero current", 0, 2000, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pct, has := chassisConditionPct(tc.cur, tc.max)
+			if has != tc.wantHas {
+				t.Fatalf("hasPct = %v, want %v", has, tc.wantHas)
+			}
+			if has && pct != tc.wantPct {
+				t.Errorf("pct = %v, want %v", pct, tc.wantPct)
+			}
+		})
+	}
+}
+
+// A negative or inverted max must never produce a nonsense percentage.
+func TestChassisCondition_RejectsBadDenominator(t *testing.T) {
+	if _, has := chassisConditionPct(100, -5); has {
+		t.Error("negative max must not yield a percentage")
+	}
+}
+
+// Vehicle classes arrive as Unreal paths whose object name repeats the package
+// name: /Game/.../BP_Buggy_CHOAM.BP_Buggy_CHOAM_C. shortClass alone leaves
+// "BP_Buggy_CHOAM.BP_Buggy_CHOAM", which is twice as long as it needs to be and
+// gets clipped in the table (#313).
+func TestVehicleClassLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			"buggy",
+			"/Game/Dune/Systems/Vehicles/Blueprints/GroundVehicles/BP_Buggy_CHOAM.BP_Buggy_CHOAM_C",
+			"Buggy CHOAM",
+		},
+		{
+			"light ornithopter",
+			"/Game/Dune/Systems/Vehicles/Blueprints/FlyingVehicles/BP_LightOrnithopter_Choam.BP_LightOrnithopter_Choam_C",
+			"Light Ornithopter Choam",
+		},
+		{
+			"treadwheel",
+			"/Game/Dune/Systems/Vehicles/Blueprints/GroundVehicles/BP_TreadWheel.BP_TreadWheel_C",
+			"Tread Wheel",
+		},
+		{
+			"transport ornithopter",
+			"/Game/Dune/Systems/Vehicles/Blueprints/FlyingVehicles/BP_TransportOrnithopter_CHOAM.BP_TransportOrnithopter_CHOAM_C",
+			"Transport Ornithopter CHOAM",
+		},
+		{
+			"sandbike",
+			"/Game/Dune/Systems/Vehicles/Blueprints/GroundVehicles/BP_Sandbike_CHOAM.BP_Sandbike_CHOAM_C",
+			"Sandbike CHOAM",
+		},
+		{"already short", "BP_Buggy_CHOAM", "Buggy CHOAM"},
+		// Only a package name that matches its object name is collapsed; a
+		// genuinely different pair is left joined, though the rest of the
+		// cleanup still applies.
+		{"package differs from object", "BP_Thing.BP_Other_C", "Thing.BP Other"},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := vehicleClassLabel(tc.in); got != tc.want {
+				t.Errorf("vehicleClassLabel(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// An acronym must not be exploded into single letters by the camel-case split.
+func TestSplitCamelCase_PreservesAcronyms(t *testing.T) {
+	if got := splitCamelCase("CHOAM"); got != "CHOAM" {
+		t.Errorf("splitCamelCase(CHOAM) = %q, want CHOAM", got)
+	}
+	if got := splitCamelCase("OneManGroundcarChoam"); got != "One Man Groundcar Choam" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/cmd/dune-admin/model.go
+++ b/cmd/dune-admin/model.go
@@ -240,13 +240,30 @@ type msgItemTemplates struct {
 }
 
 type vehicleRow struct {
-	ID                int64   `json:"id"`
-	Class             string  `json:"class"`
-	Map               string  `json:"map"`
-	ChassisDurability float64 `json:"chassis_durability"`
-	VehicleName       string  `json:"vehicle_name"`
-	IsRecovered       bool    `json:"is_recovered"`
-	IsBackup          bool    `json:"is_backup"`
+	ID    int64  `json:"id"`
+	Class string `json:"class"`
+	Map   string `json:"map"`
+	// Partition and Dimension locate the vehicle on a multi-sietch server; the
+	// map name alone is ambiguous (#313). Location is the display form.
+	Partition int64  `json:"partition"`
+	Dimension int    `json:"dimension"`
+	Location  string `json:"location"`
+	// OwnerName is the rank-1 holder. AccessRank is the *viewing* player's rank,
+	// so a vehicle merely shared with them is distinguishable from their own.
+	OwnerName   string `json:"owner_name"`
+	AccessRank  int    `json:"access_rank"`
+	AccessLabel string `json:"access_label"`
+	IsOwner     bool   `json:"is_owner"`
+	// ChassisCurrent is the chassis module's absolute durability. ChassisMax is
+	// 0 unless the part has decayed (the game only records a max once it does),
+	// so ChassisPct is only meaningful when HasChassisPct is set.
+	ChassisCurrent float64 `json:"chassis_current"`
+	ChassisMax     float64 `json:"chassis_max"`
+	ChassisPct     float64 `json:"chassis_pct"`
+	HasChassisPct  bool    `json:"has_chassis_pct"`
+	VehicleName    string  `json:"vehicle_name"`
+	IsRecovered    bool    `json:"is_recovered"`
+	IsBackup       bool    `json:"is_backup"`
 }
 
 type cheatEntry struct {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -590,7 +590,18 @@ export type VehicleRow = {
   id: number
   class: string
   map: string
-  chassis_durability: number
+  partition: number
+  dimension: number
+  location: string
+  owner_name: string
+  access_rank: number
+  access_label: string
+  is_owner: boolean
+  /** Absolute chassis durability. chassis_pct is only meaningful when has_chassis_pct is true. */
+  chassis_current: number
+  chassis_max: number
+  chassis_pct: number
+  has_chassis_pct: boolean
   vehicle_name: string
   is_recovered: boolean
   is_backup: boolean

--- a/web/src/locales/de/translation.json
+++ b/web/src/locales/de/translation.json
@@ -1252,10 +1252,13 @@
         "class": "Klasse",
         "location": "Ort",
         "name": "Name",
+        "owner": "Besitzer",
         "type": "Typ"
       },
+      "granted": "Freigegeben",
       "noVehiclesFound": "Keine Fahrzeuge gefunden",
       "recovered": "Wiederhergestellt",
+      "unknownOwner": "Unbekannt",
       "vehiclesLabel": "Fahrzeuge"
     },
     "filter": {

--- a/web/src/locales/en-US/translation.json
+++ b/web/src/locales/en-US/translation.json
@@ -1252,10 +1252,14 @@
         "class": "Class",
         "location": "Location",
         "name": "Name",
+        "owner": "Owner",
         "type": "Type"
       },
+      "granted": "Granted",
       "noVehiclesFound": "No vehicles found",
+      "owner": "Owner",
       "recovered": "Recovered",
+      "unknownOwner": "Unknown",
       "vehiclesLabel": "Vehicles"
     },
     "filter": {

--- a/web/src/locales/en-US/translation.json
+++ b/web/src/locales/en-US/translation.json
@@ -1257,7 +1257,6 @@
       },
       "granted": "Granted",
       "noVehiclesFound": "No vehicles found",
-      "owner": "Owner",
       "recovered": "Recovered",
       "unknownOwner": "Unknown",
       "vehiclesLabel": "Vehicles"

--- a/web/src/locales/es/translation.json
+++ b/web/src/locales/es/translation.json
@@ -1269,10 +1269,13 @@
         "class": "Clase",
         "location": "Ubicación",
         "name": "Nombre",
+        "owner": "Propietario",
         "type": "Tipo"
       },
+      "granted": "Concedido",
       "noVehiclesFound": "No se encontraron vehículos",
       "recovered": "Recuperado",
+      "unknownOwner": "Desconocido",
       "vehiclesLabel": "Vehículos"
     },
     "filter": {

--- a/web/src/locales/fr/translation.json
+++ b/web/src/locales/fr/translation.json
@@ -1269,10 +1269,13 @@
         "class": "Classe",
         "location": "Emplacement",
         "name": "Nom",
+        "owner": "Propriétaire",
         "type": "Type"
       },
+      "granted": "Accordé",
       "noVehiclesFound": "Aucun véhicule trouvé",
       "recovered": "Récupéré",
+      "unknownOwner": "Inconnu",
       "vehiclesLabel": "Véhicules"
     },
     "filter": {

--- a/web/src/locales/ja/translation.json
+++ b/web/src/locales/ja/translation.json
@@ -1252,10 +1252,13 @@
         "class": "クラス",
         "location": "場所",
         "name": "名前",
+        "owner": "所有者",
         "type": "タイプ"
       },
+      "granted": "許可",
       "noVehiclesFound": "乗り物が見つかりません",
       "recovered": "回収済み",
+      "unknownOwner": "不明",
       "vehiclesLabel": "乗り物"
     },
     "filter": {

--- a/web/src/locales/pl/translation.json
+++ b/web/src/locales/pl/translation.json
@@ -1286,10 +1286,13 @@
         "class": "Klasa",
         "location": "Lokalizacja",
         "name": "Nazwa",
+        "owner": "Właściciel",
         "type": "Typ"
       },
+      "granted": "Przyznany",
       "noVehiclesFound": "Nie znaleziono pojazdów",
       "recovered": "Odzyskano",
+      "unknownOwner": "Nieznany",
       "vehiclesLabel": "Pojazdy"
     },
     "filter": {

--- a/web/src/locales/pt-BR/translation.json
+++ b/web/src/locales/pt-BR/translation.json
@@ -1269,10 +1269,13 @@
         "class": "Classe",
         "location": "Localização",
         "name": "Nome",
+        "owner": "Proprietário",
         "type": "Tipo"
       },
+      "granted": "Concedido",
       "noVehiclesFound": "Nenhum veículo encontrado",
       "recovered": "Recuperado",
+      "unknownOwner": "Desconhecido",
       "vehiclesLabel": "Veículos"
     },
     "filter": {

--- a/web/src/locales/ru/translation.json
+++ b/web/src/locales/ru/translation.json
@@ -1286,10 +1286,13 @@
         "class": "Класс",
         "location": "Местоположение",
         "name": "Название",
+        "owner": "Владелец",
         "type": "Тип"
       },
+      "granted": "Предоставлен",
       "noVehiclesFound": "Транспорт не найден",
       "recovered": "Восстановлен",
+      "unknownOwner": "Неизвестно",
       "vehiclesLabel": "Транспорт"
     },
     "filter": {

--- a/web/src/locales/tr/translation.json
+++ b/web/src/locales/tr/translation.json
@@ -1252,10 +1252,13 @@
         "class": "Sınıf",
         "location": "Konum",
         "name": "Ad",
+        "owner": "Sahip",
         "type": "Tür"
       },
+      "granted": "Verildi",
       "noVehiclesFound": "Araç bulunamadı",
       "recovered": "Kurtarıldı",
+      "unknownOwner": "Bilinmiyor",
       "vehiclesLabel": "Araçlar"
     },
     "filter": {

--- a/web/src/locales/zh-CN/translation.json
+++ b/web/src/locales/zh-CN/translation.json
@@ -1252,10 +1252,13 @@
         "class": "等级",
         "location": "位置",
         "name": "名称",
+        "owner": "所有者",
         "type": "类型"
       },
+      "granted": "已授权",
       "noVehiclesFound": "未找到载具",
       "recovered": "已恢复",
+      "unknownOwner": "未知",
       "vehiclesLabel": "载具"
     },
     "filter": {

--- a/web/src/tabs/PlayersTab/components/VehicleChassisCell.tsx
+++ b/web/src/tabs/PlayersTab/components/VehicleChassisCell.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import type { VehicleChassisCellProps } from './interfaces'
+
+/**
+ * Chassis durability cell.
+ *
+ * The game only records a maximum durability once a part has decayed, so most
+ * vehicles have no denominator and no percentage can be derived. The absolute
+ * value is always shown; the percentage is appended only when it is real.
+ *
+ * The column this replaces read COALESCE(recovered_vehicles.chassis_durability,
+ * 1.0), and recovered_vehicles is empty on a normal server — so every vehicle
+ * displayed "100%" (#313).
+ */
+export const VehicleChassisCell: React.FC<VehicleChassisCellProps> = ({ vehicle }): React.ReactElement => {
+  if (vehicle.chassis_current <= 0) {
+    return <span className="text-muted">—</span>
+  }
+  const worn = vehicle.has_chassis_pct && vehicle.chassis_pct < 30
+  return (
+    <span className={worn ? 'text-danger' : 'text-muted'}>
+      {Math.round(vehicle.chassis_current).toLocaleString()}
+      {vehicle.has_chassis_pct ? ` (${Math.round(vehicle.chassis_pct)}%)` : ''}
+    </span>
+  )
+}

--- a/web/src/tabs/PlayersTab/components/VehicleChassisCell.tsx
+++ b/web/src/tabs/PlayersTab/components/VehicleChassisCell.tsx
@@ -13,7 +13,9 @@ import type { VehicleChassisCellProps } from './interfaces'
  * displayed "100%" (#313).
  */
 export const VehicleChassisCell: React.FC<VehicleChassisCellProps> = ({ vehicle }): React.ReactElement => {
-  if (vehicle.chassis_current <= 0) {
+  // A zero reading is only "no data" when there is no maximum either. With a
+  // maximum present, 0 is a real destroyed chassis and must not be hidden.
+  if (vehicle.chassis_current <= 0 && !vehicle.has_chassis_pct) {
     return <span className="text-muted">—</span>
   }
   const worn = vehicle.has_chassis_pct && vehicle.chassis_pct < 30

--- a/web/src/tabs/PlayersTab/components/VehicleOwnerCell.tsx
+++ b/web/src/tabs/PlayersTab/components/VehicleOwnerCell.tsx
@@ -13,7 +13,10 @@ import type { VehicleOwnerCellProps } from './interfaces'
 export const VehicleOwnerCell: React.FC<VehicleOwnerCellProps> = ({ vehicle }): React.ReactElement => {
   const { t } = useTranslation()
   const name = vehicle.owner_name || t('players.vehicles.unknownOwner')
-  if (vehicle.is_owner) {
+  // Key off access_label, not !is_owner: an orphaned backup row carries rank 0
+  // and no owner, and labelling that "Granted" would be a claim about access
+  // that nothing supports.
+  if (vehicle.access_label !== 'granted') {
     return <span className="text-muted">{name}</span>
   }
   return (

--- a/web/src/tabs/PlayersTab/components/VehicleOwnerCell.tsx
+++ b/web/src/tabs/PlayersTab/components/VehicleOwnerCell.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import { Chip } from '@heroui/react'
+import { useTranslation } from 'react-i18next'
+import type { VehicleOwnerCellProps } from './interfaces'
+
+/**
+ * Owner cell.
+ *
+ * Vehicles reachable through an access grant used to render identically to
+ * owned ones, because the query filtered on the viewer's player id without
+ * reading their rank (#313). Rank 1 is the owner; anything above it is a grant.
+ */
+export const VehicleOwnerCell: React.FC<VehicleOwnerCellProps> = ({ vehicle }): React.ReactElement => {
+  const { t } = useTranslation()
+  const name = vehicle.owner_name || t('players.vehicles.unknownOwner')
+  if (vehicle.is_owner) {
+    return <span className="text-muted">{name}</span>
+  }
+  return (
+    <div className="flex items-center gap-1">
+      <span className="text-muted">{name}</span>
+      <Chip size="sm" color="default" variant="soft">{t('players.vehicles.granted')}</Chip>
+    </div>
+  )
+}

--- a/web/src/tabs/PlayersTab/components/interfaces.ts
+++ b/web/src/tabs/PlayersTab/components/interfaces.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import type { Player, SessionRecord, StatSnapshot } from '../../../api/client'
+import type { Player, SessionRecord, StatSnapshot, VehicleRow } from '../../../api/client'
 import type { PlayerSortKey, PlayerStatusFilter, SortDir } from '../types'
 
 export interface PlayerCardProps {
@@ -66,4 +66,12 @@ export interface PlayerListControlsProps {
   factionFilter: Set<number>
   onFactionFilterChange: (factions: Set<number>) => void
   factionOptions: PlayerFactionOption[]
+}
+
+export interface VehicleChassisCellProps {
+  vehicle: VehicleRow
+}
+
+export interface VehicleOwnerCellProps {
+  vehicle: VehicleRow
 }

--- a/web/src/tabs/PlayersTab/modals/InventoryModal.tsx
+++ b/web/src/tabs/PlayersTab/modals/InventoryModal.tsx
@@ -6,6 +6,8 @@ import { useTranslation } from 'react-i18next'
 import { api } from '../../../api/client'
 import type { InventoryItem, VehicleRow } from '../../../api/client'
 import { DataTable, Icon, LoadingState, Panel, SectionLabel, type Column } from '../../../dune-ui'
+import { VehicleChassisCell } from '../components/VehicleChassisCell'
+import { VehicleOwnerCell } from '../components/VehicleOwnerCell'
 import { EditItemModal } from './EditItemModal'
 import type { InventoryModalProps } from './interfaces'
 import type { ItemKey, VehicleKey } from './types'
@@ -29,6 +31,7 @@ export const InventoryModal: React.FC<InventoryModalProps> = ({ player, open, on
   const VEHICLE_COLUMNS: Column<VehicleKey>[] = [
     { key: 'class', label: t('players.vehicles.columns.class'), isRowHeader: true },
     { key: 'location', label: t('players.vehicles.columns.location') },
+    { key: 'owner', label: t('players.vehicles.columns.owner') },
     { key: 'chassis', label: t('players.vehicles.columns.chassis') },
     { key: 'name', label: t('players.vehicles.columns.name') },
     { key: 'type', label: t('players.vehicles.columns.type'), sortable: false },
@@ -212,12 +215,13 @@ export const InventoryModal: React.FC<InventoryModalProps> = ({ player, open, on
                           className="max-h-[180px]"
                           columns={VEHICLE_COLUMNS}
                           rows={vehicles}
-                          rowId={(v) => `${v.id}-${v.is_backup ? 'b' : 'a'}`}
+                          rowId={(v) => String(v.id)}
                           initialSort={{ column: 'class', direction: 'ascending' }}
                           sortValue={(v, k) => {
                             if (k === 'class') return v.class
-                            if (k === 'location') return v.map ?? ''
-                            if (k === 'chassis') return v.chassis_durability
+                            if (k === 'location') return v.location ?? ''
+                            if (k === 'owner') return v.owner_name ?? ''
+                            if (k === 'chassis') return v.chassis_current
                             if (k === 'name') return v.vehicle_name ?? ''
                             return ''
                           }}
@@ -234,14 +238,9 @@ export const InventoryModal: React.FC<InventoryModalProps> = ({ player, open, on
                           renderCell={(v, key) => {
                             switch (key) {
                               case 'class': return <span className="font-semibold">{v.class}</span>
-                              case 'location': return <span className="text-muted">{v.map || '–'}</span>
-                              case 'chassis':
-                                return (
-                                  <span className={v.chassis_durability < 0.3 ? 'text-danger' : 'text-muted'}>
-                                    {Math.round(v.chassis_durability * 100)}
-                                    %
-                                  </span>
-                                )
+                              case 'location': return <span className="text-muted">{v.location || '–'}</span>
+                              case 'owner': return <VehicleOwnerCell vehicle={v} />
+                              case 'chassis': return <VehicleChassisCell vehicle={v} />
                               case 'name': return <span className="text-muted">{v.vehicle_name || '–'}</span>
                               case 'type':
                                 return renderVehicleTypeChips(v)

--- a/web/src/tabs/PlayersTab/modals/types.ts
+++ b/web/src/tabs/PlayersTab/modals/types.ts
@@ -7,7 +7,7 @@ export type StagedItem = { template: string, qty: number, quality: number, _key:
 export type LocationKey = 'name' | 'x' | 'y' | 'z' | 'actions'
 
 export type ItemKey = 'template' | 'stack' | 'quality' | 'durability' | 'actions'
-export type VehicleKey = 'class' | 'location' | 'chassis' | 'name' | 'type' | 'actions'
+export type VehicleKey = 'class' | 'location' | 'owner' | 'chassis' | 'name' | 'type' | 'actions'
 
 export type PackDiff = { added: number, updated: number, removed: number, isDirty: boolean }
 

--- a/web/src/tabs/PlayersTab/views/VehiclesView.tsx
+++ b/web/src/tabs/PlayersTab/views/VehiclesView.tsx
@@ -6,6 +6,8 @@ import { useTranslation } from 'react-i18next'
 import { api } from '../../../api/client'
 import type { VehicleRow } from '../../../api/client'
 import { DataTable, LoadingState, SectionLabel, type Column } from '../../../dune-ui'
+import { VehicleChassisCell } from '../components/VehicleChassisCell'
+import { VehicleOwnerCell } from '../components/VehicleOwnerCell'
 import { usePermissions } from '../../../hooks/usePermissions'
 import type { VehiclesViewProps } from './interfaces'
 import type { VehicleKey } from './types'
@@ -20,6 +22,7 @@ export const VehiclesView: React.FC<VehiclesViewProps> = ({ player }) => {
   const ALL_VEHICLE_COLUMNS: Column<VehicleKey>[] = [
     { key: 'class', label: t('players.vehicles.columns.class'), isRowHeader: true },
     { key: 'location', label: t('players.vehicles.columns.location') },
+    { key: 'owner', label: t('players.vehicles.columns.owner') },
     { key: 'chassis', label: t('players.vehicles.columns.chassis') },
     { key: 'name', label: t('players.vehicles.columns.name') },
     { key: 'type', label: t('players.vehicles.columns.type'), sortable: false },
@@ -58,12 +61,13 @@ export const VehiclesView: React.FC<VehiclesViewProps> = ({ player }) => {
         className="min-h-0 max-h-full"
         columns={VEHICLE_COLUMNS}
         rows={vehicles}
-        rowId={(v) => `${v.id}-${v.is_backup ? 'b' : 'a'}`}
+        rowId={(v) => String(v.id)}
         initialSort={{ column: 'class', direction: 'ascending' }}
         sortValue={(v, k) => {
           if (k === 'class') return v.class
-          if (k === 'location') return v.map ?? ''
-          if (k === 'chassis') return v.chassis_durability
+          if (k === 'location') return v.location ?? ''
+          if (k === 'owner') return v.owner_name ?? ''
+          if (k === 'chassis') return v.chassis_current
           if (k === 'name') return v.vehicle_name ?? ''
           return ''
         }}
@@ -80,14 +84,9 @@ export const VehiclesView: React.FC<VehiclesViewProps> = ({ player }) => {
         renderCell={(v, key) => {
           switch (key) {
             case 'class': return <span className="font-semibold">{v.class}</span>
-            case 'location': return <span className="text-muted">{v.map || '—'}</span>
-            case 'chassis':
-              return (
-                <span className={v.chassis_durability < 0.3 ? 'text-danger' : 'text-muted'}>
-                  {Math.round(v.chassis_durability * 100)}
-                  %
-                </span>
-              )
+            case 'location': return <span className="text-muted">{v.location || '—'}</span>
+            case 'owner': return <VehicleOwnerCell vehicle={v} />
+            case 'chassis': return <VehicleChassisCell vehicle={v} />
             case 'name': return <span className="text-muted">{v.vehicle_name || '—'}</span>
             case 'type':
               return renderVehicleTypeChips(v)

--- a/web/src/tabs/PlayersTab/views/types.ts
+++ b/web/src/tabs/PlayersTab/views/types.ts
@@ -8,4 +8,4 @@ export type StagedItem = { template: string, qty: number, quality: number, _key:
 
 export type { GivePack }
 
-export type VehicleKey = 'class' | 'location' | 'chassis' | 'name' | 'type' | 'actions'
+export type VehicleKey = 'class' | 'location' | 'owner' | 'chassis' | 'name' | 'type' | 'actions'


### PR DESCRIPTION
Addresses #313

Covers three of the four items in the issue, plus two defects the investigation turned up that the issue did not name. Per-part wear expansion is deliberately left for a follow-up (see below).

## Vehicles listed twice

The query was a `UNION ALL` of the live `permission_actor` rows and the `backup_vehicles` rows. Taking a vehicle backup leaves the original actor in place, so a backed-up vehicle matched both arms. Checked against a live server: all three `backup_vehicles` rows also existed in `permission_actor`, so the duplicate was guaranteed, not occasional.

Backups are now a `LEFT JOIN` flag on one row. A backup whose vehicle actor is gone is still emitted as its own row so nothing disappears.

## The chassis column was fabricated

It read `COALESCE(recovered_vehicles.chassis_durability, 1.0)`. `recovered_vehicles` is empty on a normal server, so **every vehicle displayed 100%**.

Durability now comes from `dune.vehicle_modules`. One caveat worth knowing: the game only records a maximum once a part has decayed, so only 1 of 13 chassis modules on the test server has a denominator. The absolute value is always shown and a percentage is appended only when it is real. Inventing a denominator is what produced the original bug.

## Names and classes

Vehicle names rendered as raw placeholders (`##BuggyChoam`). Now stripped the same way container names already are, so only player-chosen names like `ICE-Scout-Stinger` survive.

Class names rendered as Unreal's `Package.Object` form and got clipped in the table:

| Before | After |
| --- | --- |
| `BP_Buggy_CHOAM.l` | Buggy CHOAM |
| `BP_LightOrnithopte` | Light Ornithopter Choam |
| `BP_TreadWheel.BP_` | Tread Wheel |

The camel-case split only fires on lower-to-upper boundaries, so acronyms survive (`CHOAM` stays `CHOAM`). This is scoped to vehicles rather than changing `shortClass`, which three other call sites depend on. Note that `shortClass` has the same latent problem elsewhere: player rows and live-map markers get `PlayerCharacter.PlayerCharacter`. Left alone here since it touches displays outside this issue.

## Owner and location

`permission_actor_rank.rank` is 1 for the owner and higher for granted access, but the query filtered on the viewer's player id without reading the rank, so a vehicle merely shared with a player was indistinguishable from their own. New Owner column shows the rank-1 holder and tags borrowed vehicles with a Granted chip.

Location now includes partition and dimension. Vehicles really are spread across sietches, so the map name alone was ambiguous.

`InventoryModal` rendered the same table with the same bugs copy-pasted. The owner and chassis cells are now shared components used by both tables.

## Testing

- 30 unit tests on the display helpers, including acronym handling and the missing-denominator case
- The query was validated by running it against a live server. One player's list went from 7 rows to 6, the backed-up vehicle appeared once, and a shared buggy correctly showed its real owner with the viewer holding rank 2
- Confirmed in the running UI
- `make verify`, `make gosec`, `pnpm typecheck`, `pnpm lint`, `pnpm build` all clean

## Not included

Item 4 of the issue asks for per-part wear on expand. The data supports it (`vehicle_modules.stats` carries `CurrentDurability`, `TotalActivationTime` and `LastDeteriorationCause` per part) but only 26 of 145 modules carry a maximum, so most parts can only show absolute values. That is a bigger UI change and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)