### PR TITLE
fix(players): stop listing and counting deleted characters

### DIFF
--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -58,11 +58,11 @@ func invalidateAllJourneyCache() {
 
 // ── data fetch commands ───────────────────────────────────────────────────────
 
-func cmdFetchPlayers(pool *pgxpool.Pool) Msg {
-	if pool == nil {
-		return msgPlayers{err: fmt.Errorf("not connected")}
-	}
-	rows, err := pool.Query(context.Background(), `
+// fetchPlayersSQL lists one row per LIVING player character. It is rooted on
+// dune.actors (the pawn) but binds each pawn to its OWN dune.player_state row
+// via playerStateByPawnJoin — see that helper for why resolving per account
+// listed deleted characters.
+var fetchPlayersSQL = `
 		SELECT a.id,
 		       COALESCE(a.owner_account_id, 0),
 		       COALESCE(ps.character_name, convert_from(e.encrypted_funcom_id, 'UTF8'), ''),
@@ -72,11 +72,17 @@ func cmdFetchPlayers(pool *pgxpool.Pool) Msg {
 		       COALESCE(a.map, ''),
 		       COALESCE(af.faction_id, 0),
 		       COALESCE(ps.online_status::text, 'Offline')
-		FROM dune.actors a`+playerStateCanonicalJoin+`
+		FROM dune.actors a` + playerStateByPawnJoin + `
 		LEFT JOIN dune.encrypted_accounts e ON e.id = a.owner_account_id
-		LEFT JOIN dune.accounts ac ON ac.id = a.owner_account_id`+factionByAccountJoin+`
+		LEFT JOIN dune.accounts ac ON ac.id = a.owner_account_id` + factionByAccountJoin + `
 		WHERE a.class ILIKE '%PlayerCharacter%' AND a.owner_account_id <> $1
-		ORDER BY a.id`, gmIdentityAccountID)
+		ORDER BY a.id`
+
+func cmdFetchPlayers(pool *pgxpool.Pool) Msg {
+	if pool == nil {
+		return msgPlayers{err: fmt.Errorf("not connected")}
+	}
+	rows, err := pool.Query(context.Background(), fetchPlayersSQL, gmIdentityAccountID)
 	if err != nil {
 		return msgPlayers{err: err}
 	}
@@ -194,6 +200,64 @@ func playerStateCanonicalJoinOn(actorAlias, psAlias string) string {
 // actor as "a"; this exposes the usual "ps" columns.
 var playerStateCanonicalJoin = playerStateCanonicalJoinOn("a", "ps")
 
+// playerStateByPawnJoinOn is the pawn-keyed counterpart of
+// playerStateCanonicalJoinOn, for queries rooted on the character actor.
+//
+// Deleting a character does not remove its actor rows: measured on a live
+// server, a character whose encrypted_player_state row reads
+// character_state = 'Deleted' still had all three of its actor rows
+// (Controller/State/Pawn) in dune.actors — e.g. account 656 with a deleted
+// character 6 (actors 1708/1709/1710) alongside its live character 84. Note
+// this is NOT what db-routines' dune.delete_account does (that one deletes
+// the actor rows outright); the surviving rows come from the in-game
+// character delete/re-create path, whichever routine the game uses for it.
+//
+// An actors-rooted query that resolves player_state per ACCOUNT therefore
+// emits a row for every dead pawn too, and — because the per-account LATERAL
+// picks the account's most-recently-active row — the dead pawn borrows the
+// LIVING character's name, controller id, faction and online status. On a
+// live server that showed 61 rows for 51 characters, three of them looking
+// like exact duplicates of a real player and seven nameless.
+//
+// Binding the pawn to its own character row fixes both: dune.player_state
+// only exposes live characters (measured: it returns exactly one row for the
+// account above), so a deleted character's pawn matches nothing and the
+// INNER join drops it — no 'Deleted' predicate of our own needed. The
+// canonical most-recently-active ordering is kept because the game's schema
+// migration dropped the unique constraint on account_id (#290), so even a
+// pawn-keyed match is not guaranteed unique. Aliases are compile-time
+// literals, never input.
+//
+// Trade-off: a pawn actor that exists before its player_state row references
+// it (the mirror image of the orphaning race documented on
+// restoreCharacterBackupParams.cleanupOrphanActors) now drops out of the
+// list until the state row catches up, where the per-account join used to
+// show it nameless. Listing nothing beats listing it under another
+// character's name.
+func playerStateByPawnJoinOn(actorAlias, psAlias string) string {
+	return fmt.Sprintf(`
+		JOIN LATERAL (
+			SELECT * FROM dune.player_state %[2]s2
+			WHERE %[2]s2.player_pawn_id = %[1]s.id
+			ORDER BY %[2]s2.last_login_time DESC NULLS LAST, %[2]s2.id DESC
+			LIMIT 1
+		) %[2]s ON true`, actorAlias, psAlias)
+}
+
+// playerStateByPawnJoin is the common "a"/"ps" form of
+// playerStateByPawnJoinOn.
+var playerStateByPawnJoin = playerStateByPawnJoinOn("a", "ps")
+
+// livingCharacterFilter is the aggregate-query counterpart of
+// playerStateByPawnJoin: the same "this pawn still has a living character
+// row" predicate, as an EXISTS rather than a join, for queries that count or
+// group over character actors and never read a player_state column. Without
+// it the Players dashboard keeps reporting deleted characters in its
+// population, per-map and economy figures. The outer query must alias the
+// character actor as "a".
+const livingCharacterFilter = `
+		AND EXISTS (SELECT 1 FROM dune.player_state lps WHERE lps.player_pawn_id = a.id)`
+
 const (
 	// factionByAccountJoin resolves a player's faction by ACCOUNT. Faction is
 	// stored on the PlayerController actor, NOT the PlayerCharacter, so joining
@@ -211,7 +275,7 @@ const (
 	serverByMapSQL = `
 		SELECT COALESCE(NULLIF(a.map, ''), 'Unknown') AS label, COUNT(*) AS count
 		FROM dune.actors a
-		WHERE a.class ILIKE '%PlayerCharacter%' AND a.owner_account_id <> $1
+		WHERE a.class ILIKE '%PlayerCharacter%' AND a.owner_account_id <> $1` + livingCharacterFilter + `
 		GROUP BY label
 		ORDER BY count DESC, label`
 
@@ -232,7 +296,7 @@ const (
 		FROM dune.actors a
 		JOIN dune.actor_fgl_entities afe ON afe.actor_id = a.id AND afe.slot_name = 'DuneCharacter'
 		JOIN dune.fgl_entities fe ON fe.entity_id = afe.entity_id
-		WHERE a.class ILIKE '%PlayerCharacter%' AND a.owner_account_id <> $1`
+		WHERE a.class ILIKE '%PlayerCharacter%' AND a.owner_account_id <> $1` + livingCharacterFilter
 
 	// Per-player (faction, char XP) for the per-faction average level (#130 ext).
 	// Same DuneCharacter XP source as serverCharXPSQL, joined to faction (LEFT
@@ -245,7 +309,7 @@ const (
 		JOIN dune.actor_fgl_entities afe ON afe.actor_id = a.id AND afe.slot_name = 'DuneCharacter'
 		JOIN dune.fgl_entities fe ON fe.entity_id = afe.entity_id` + factionByAccountJoin + `
 		LEFT JOIN dune.factions f ON f.id = af.faction_id
-		WHERE a.class ILIKE '%PlayerCharacter%' AND a.owner_account_id <> $1`
+		WHERE a.class ILIKE '%PlayerCharacter%' AND a.owner_account_id <> $1` + livingCharacterFilter
 )
 
 // Vars (not consts) because they embed playerStateCanonicalJoin, which is
@@ -261,7 +325,7 @@ var (
 		SELECT
 			COUNT(*) AS total,
 			COALESCE(SUM(CASE WHEN ps.online_status = 'Online' THEN 1 ELSE 0 END), 0) AS online
-		FROM dune.actors a` + playerStateCanonicalJoin + `
+		FROM dune.actors a` + playerStateByPawnJoin + `
 		WHERE a.class ILIKE '%PlayerCharacter%' AND a.owner_account_id <> $1`
 
 	// Players + economy grouped by faction. LEFT JOINs so characters with no
@@ -277,7 +341,7 @@ var (
 			COALESCE(SUM(CASE WHEN vcb.currency_id =  dune.get_solaris_id() THEN vcb.balance ELSE 0 END), 0) AS solaris,
 			COALESCE(SUM(CASE WHEN vcb.currency_id <> dune.get_solaris_id() THEN vcb.balance ELSE 0 END), 0) AS scrip
 		FROM dune.actors a` + factionByAccountJoin + `
-		LEFT JOIN dune.factions f ON f.id = af.faction_id` + playerStateCanonicalJoin + `
+		LEFT JOIN dune.factions f ON f.id = af.faction_id` + playerStateByPawnJoin + `
 		LEFT JOIN dune.player_virtual_currency_balances vcb ON vcb.player_controller_id = ps.player_controller_id
 		WHERE a.class ILIKE '%PlayerCharacter%' AND a.owner_account_id <> $1
 		GROUP BY faction
@@ -369,7 +433,7 @@ const serverAccountFactionSQL = `
 	SELECT a.owner_account_id, COALESCE(f.name, 'Unaligned')
 	FROM dune.actors a` + factionByAccountJoin + `
 	LEFT JOIN dune.factions f ON f.id = af.faction_id
-	WHERE a.class ILIKE '%PlayerCharacter%' AND a.owner_account_id <> $1`
+	WHERE a.class ILIKE '%PlayerCharacter%' AND a.owner_account_id <> $1` + livingCharacterFilter
 
 // cmdFetchAccountFactions returns account_id -> current faction name.
 func cmdFetchAccountFactions(ctx context.Context, pool *pgxpool.Pool) (map[int64]string, error) {
@@ -1737,7 +1801,7 @@ var findPlayersByNameSQL = `
 	       COALESCE(a.map, ''),
 	       COALESCE(af.faction_id, 0),
 	       COALESCE(ps.online_status::text, 'Offline')
-	FROM dune.actors a` + playerStateCanonicalJoin + `
+	FROM dune.actors a` + playerStateByPawnJoin + `
 	LEFT JOIN dune.encrypted_accounts e ON e.id = a.owner_account_id
 	LEFT JOIN dune.accounts ac ON ac.id = a.owner_account_id` + factionByAccountJoin + `
 	WHERE ps.character_name ILIKE '%' || $1 || '%'

--- a/cmd/dune-admin/db.go
+++ b/cmd/dune-admin/db.go
@@ -287,8 +287,6 @@ const (
 			COALESCE(SUM(CASE WHEN currency_id <> dune.get_solaris_id() THEN balance ELSE 0 END), 0) AS scrip
 		FROM dune.player_virtual_currency_balances`
 
-	// Players + economy grouped by faction. LEFT JOINs so characters with no
-	// dune.player_faction row fall into "Unaligned"; COUNT(DISTINCT a.id) stays
 	// Cumulative character XP per player (DuneCharacter FLevelComponent), fed
 	// through xpToLevel to compute the server's average character level.
 	serverCharXPSQL = `
@@ -312,15 +310,16 @@ const (
 		WHERE a.class ILIKE '%PlayerCharacter%' AND a.owner_account_id <> $1` + livingCharacterFilter
 )
 
-// Vars (not consts) because they embed playerStateCanonicalJoin, which is
-// built by playerStateCanonicalJoinOn at init.
+// Vars (not consts) because they embed playerStateByPawnJoin, which is built
+// by playerStateByPawnJoinOn at init.
 var (
 	// Population counts. The seeded GM identity ($1) is excluded — it is not a
 	// real player. online_status compares against the enum literal (see
 	// cmdFetchOnlineAccountIDs), summed via CASE to match existing query style.
-	// Uses playerStateCanonicalJoin (#290) so a duplicate player_state row
-	// can't inflate the total/online counts the same way it fanned out
-	// cmdFetchPlayers's list.
+	// Uses playerStateByPawnJoin, so deleted characters' surviving pawns stay
+	// out of the counts and — via the canonical ordering it keeps (#290) — a
+	// duplicate player_state row can't inflate the total/online counts the
+	// same way it fanned out cmdFetchPlayers's list.
 	serverCountsSQL = `
 		SELECT
 			COUNT(*) AS total,
@@ -1788,9 +1787,11 @@ func cmdGiveCurrencyCtx(ctx context.Context, db *pgxpool.Pool, controllerID, amo
 	return balance, nil
 }
 
-// findPlayersByNameSQL uses the canonical player_state join (#290) so an
-// account with duplicate state rows can't make a unique character name look
-// ambiguous to the Discord command that consumes this lookup.
+// findPlayersByNameSQL resolves player_state by pawn, so a deleted character
+// can't match the search under the living character's name. The canonical
+// ordering it keeps (#290) means an account with duplicate state rows still
+// can't make a unique character name look ambiguous to the Discord command
+// that consumes this lookup.
 var findPlayersByNameSQL = `
 	SELECT a.id,
 	       COALESCE(a.owner_account_id, 0),

--- a/cmd/dune-admin/db_player_state_canonical_test.go
+++ b/cmd/dune-admin/db_player_state_canonical_test.go
@@ -42,8 +42,12 @@ func TestPlayerStateFanOutQueriesUseCanonicalJoin(t *testing.T) {
 		"guildMembersSQL":          guildMembersSQL,
 		"guildInvitesSQL":          guildInvitesSQL,
 	}
+	// "JOIN LATERAL" and not "LEFT JOIN LATERAL": the pawn-keyed variant that
+	// drops soft-deleted characters is an INNER lateral (see
+	// db_players_ghost_rows_test.go). Both satisfy the #290 invariant — one
+	// bounded row per actor under the canonical ordering, never a bare join.
 	for name, sql := range queries {
-		if !strings.Contains(sql, "LEFT JOIN LATERAL") {
+		if !strings.Contains(sql, "JOIN LATERAL") {
 			t.Errorf("%s must use the canonical LATERAL join", name)
 		}
 		if !strings.Contains(sql, canonicalOrderFragment) {

--- a/cmd/dune-admin/db_players_ghost_rows_test.go
+++ b/cmd/dune-admin/db_players_ghost_rows_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The players list is rooted on dune.actors, and deleting a character leaves
+// its three actor rows (Controller/State/Pawn) behind — measured on a live
+// server against characters whose encrypted_player_state row reads
+// character_state = 'Deleted'. Resolving the player_state row per ACCOUNT
+// therefore emitted one row per surviving pawn and let the dead pawn borrow
+// the LIVING character's name, controller id, faction and online status: 61
+// rows for 51 living characters, 3 of them exact-looking name duplicates.
+//
+// The fix binds each pawn to ITS OWN character row (player_pawn_id) with an
+// INNER lateral: dune.player_state only exposes live characters, so a pawn
+// with no living character row drops out — which is precisely what "list the
+// real characters" means.
+
+func TestPlayerStateByPawnJoin_InnerLateralKeyedOnPawn(t *testing.T) {
+	t.Parallel()
+	got := playerStateByPawnJoinOn("sa", "sps")
+	for _, want := range []string{
+		"JOIN LATERAL",
+		"sps2.player_pawn_id = sa.id",
+		") sps ON true",
+		canonicalOrderFragment,
+		"LIMIT 1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("playerStateByPawnJoinOn missing %q:\n%s", want, got)
+		}
+	}
+	// INNER, not LEFT — a LEFT join would keep the ghost rows (nameless).
+	if strings.Contains(got, "LEFT JOIN LATERAL") {
+		t.Fatalf("playerStateByPawnJoinOn must be an INNER lateral join:\n%s", got)
+	}
+}
+
+// TestFetchPlayersSQL_DropsDeletedCharacters — the list query itself must use
+// the pawn-keyed join. Keyed per account it re-grows the ghost rows.
+func TestFetchPlayersSQL_DropsDeletedCharacters(t *testing.T) {
+	t.Parallel()
+	if !strings.Contains(fetchPlayersSQL, "ps2.player_pawn_id = a.id") {
+		t.Fatalf("fetchPlayersSQL must bind the pawn to its own character row:\n%s", fetchPlayersSQL)
+	}
+	if strings.Contains(fetchPlayersSQL, "LEFT JOIN LATERAL") {
+		t.Fatal("fetchPlayersSQL must not resolve the character per account — that is what showed deleted characters")
+	}
+	if strings.Contains(fetchPlayersSQL, barePlayerStateJoin) {
+		t.Fatal("fetchPlayersSQL still contains the bare fan-out join")
+	}
+	// The canonical ordering still bounds the join to one row per pawn: the
+	// game's schema migration dropped the unique constraint, so even a
+	// pawn-keyed join can match duplicates (#290).
+	if !strings.Contains(fetchPlayersSQL, canonicalOrderFragment) {
+		t.Fatalf("fetchPlayersSQL must keep the canonical most-recently-active ordering:\n%s", fetchPlayersSQL)
+	}
+}
+
+// TestPlayerCharacterQueriesExcludeDeletedCharacters — every actors-rooted
+// query over PlayerCharacter actors counts the same soft-deleted pawns. If
+// only the list were fixed, the Players dashboard would still report the
+// inflated population (measured: 61 vs 51) against a list showing 51.
+// Queries that need player_state columns use the pawn-keyed join; pure
+// aggregates carry the EXISTS filter instead of growing a join.
+func TestPlayerCharacterQueriesExcludeDeletedCharacters(t *testing.T) {
+	t.Parallel()
+	joined := map[string]string{
+		"fetchPlayersSQL":      fetchPlayersSQL,
+		"findPlayersByNameSQL": findPlayersByNameSQL,
+		"serverCountsSQL":      serverCountsSQL,
+		"serverByFactionSQL":   serverByFactionSQL,
+	}
+	for name, sql := range joined {
+		if !strings.Contains(sql, "ps2.player_pawn_id = a.id") {
+			t.Errorf("%s must resolve player_state by pawn, not by account", name)
+		}
+		if strings.Contains(sql, "LEFT JOIN LATERAL") {
+			t.Errorf("%s must use the INNER pawn-keyed lateral so deleted characters drop out", name)
+		}
+	}
+
+	filtered := map[string]string{
+		"serverByMapSQL":          serverByMapSQL,
+		"serverCharXPSQL":         serverCharXPSQL,
+		"serverFactionXPSQL":      serverFactionXPSQL,
+		"serverAccountFactionSQL": serverAccountFactionSQL,
+	}
+	for name, sql := range filtered {
+		if !strings.Contains(sql, livingCharacterFilter) {
+			t.Errorf("%s must exclude pawns whose character row is gone:\n%s", name, sql)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #321.

## What

Binds each PlayerCharacter pawn to **its own** `dune.player_state` row instead of
resolving one per account:

- **`playerStateByPawnJoinOn`** — the pawn-keyed counterpart of `playerStateCanonicalJoinOn`,
  joining on `player_pawn_id` with an **INNER** lateral. `dune.player_state` only exposes
  live characters, so a deleted character's pawn matches nothing and drops out; no
  `'Deleted'` predicate of our own. The canonical most-recently-active ordering is kept,
  because the dropped unique constraint from #290 means even a pawn-keyed match is not
  guaranteed unique.
- **`livingCharacterFilter`** — the same predicate as an `EXISTS`, for the dashboard
  aggregates that group over character actors without reading a `ps` column. Growing a
  join there would be gratuitous.

Applied to `fetchPlayersSQL` (extracted from `cmdFetchPlayers` so a test can pin it),
`findPlayersByNameSQL`, `serverCountsSQL`, `serverByFactionSQL`, `serverByMapSQL`,
`serverCharXPSQL`, `serverFactionXPSQL`, `serverAccountFactionSQL`.

The #290 test now pins `"JOIN LATERAL"` rather than `"LEFT JOIN LATERAL"` — the invariant
is *one bounded row per actor under the canonical ordering*, which the INNER pawn-keyed
form satisfies too.

## Why

Deleting a character leaves its Controller/State/Pawn actor rows in `dune.actors`. Since
the players list is actors-rooted and resolved `player_state` per **account**, each dead
pawn produced a row that borrowed the *living* character's name, controller id, faction
and online status — a duplicate that looks completely real. Measured: 61 rows for 51
living characters, three name-duplicates and seven nameless. Every dashboard aggregate
counted the same ghosts. Full analysis in #321.

## Testing

- New `db_players_ghost_rows_test.go` pins the join shape and that every affected query
  carries the fix — written first, red before the change.
- `make test-race` green, `make gosec` 0 issues, `make vulncheck` 0 called vulnerabilities,
  `golangci-lint` clean. (`make verify` also runs `lint-md`, which fails on my box for an
  unrelated Node 18 / markdownlint issue; no Markdown is touched here.)
- Ran on a live server: list 61 → 51 rows, all three name-duplicates and all seven nameless
  rows gone, no living player lost. List, population count and faction breakdown now agree
  (50 / 50 / 40+5+5 on a later measurement).

## One thing worth your review

That `dune.player_state` only exposes live characters is established **empirically** (the
row counts line up exactly), not from the schema in `db-routines/`. If the view's real
definition doesn't guarantee that, the `'Active'` filter should be made explicit rather
than implied by the join.

Also a deliberate trade-off, documented in the code: a pawn actor that exists *before* its
`player_state` row references it now drops out of the list until the state row catches up,
where the per-account join used to show it nameless. Listing nothing seemed better than
listing it under another character's name.
