### PR TITLE
chore(deps): bump Go to 1.26.6 for stdlib CVEs

### DIFF
--- a/SETUP_DOCKER.md
+++ b/SETUP_DOCKER.md
@@ -13,7 +13,7 @@ dune-admin
 
 | Requirement | Notes |
 |-------------|-------|
-| **Go 1.21+** | `brew install go` or <https://go.dev/dl/> |
+| **Go 1.26+** | `brew install go` or <https://go.dev/dl/> |
 | **Docker CLI** | Must be in `$PATH` |
 | **Docker access** | The user running dune-admin must be able to run `docker` (i.e. in the `docker` group or running as root) |
 

--- a/SETUP_KUBECTL.md
+++ b/SETUP_KUBECTL.md
@@ -15,7 +15,7 @@ your machine
 
 | Requirement | Notes |
 |-------------|-------|
-| **Go 1.21+** | `brew install go` or <https://go.dev/dl/> |
+| **Go 1.26+** | `brew install go` or <https://go.dev/dl/> |
 | **SSH key** | Private key authorised on the VM |
 | **VM access** | Port 22 reachable; SSH user needs passwordless `sudo kubectl` |
 

--- a/SETUP_LOCAL.md
+++ b/SETUP_LOCAL.md
@@ -14,7 +14,7 @@ dune-admin (same machine)
 
 | Requirement | Notes |
 |-------------|-------|
-| **Go 1.21+** | `brew install go` or <https://go.dev/dl/> |
+| **Go 1.26+** | `brew install go` or <https://go.dev/dl/> |
 | **PostgreSQL reachable** | `db_host` must be accessible from where dune-admin runs |
 | **Shell commands** | Optional — only needed for start/stop/restart/status in the Battlegroup tab |
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -20,7 +20,7 @@ COPY web/ ./
 RUN VITE_MARKET_BOT_ENABLED=true pnpm build
 
 # ── Go build ──────────────────────────────────────────────────────────────────
-FROM --platform=$BUILDPLATFORM golang:1.26.5 AS go-builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6 AS go-builder
 
 WORKDIR /build
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module dune-admin
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/bwmarrin/discordgo v0.29.0


### PR DESCRIPTION
## What

Bumps the Go toolchain from 1.26.5 to 1.26.6 in the two places it is actually pinned:

- `go.mod`
- `deploy/Dockerfile`

The workflows all resolve their toolchain with `go-version-file: go.mod`, so they pick this up without edits.

Also fixes the `SETUP_DOCKER.md` / `SETUP_KUBECTL.md` / `SETUP_LOCAL.md` prerequisite tables, which still asked for Go 1.21+ long after `go.mod` moved to 1.26.

## Why

`govulncheck` reports 7 stdlib vulnerabilities reachable from our code on 1.26.5. All are fixed in 1.26.6:

| ID | Package |
|---|---|
| GO-2026-6218 | `net/url` |
| GO-2026-6091 | `html/template` |
| GO-2026-6090 | `crypto/tls` |
| GO-2026-6089 | `net/http` |
| GO-2026-5026 | `net/http` |
| GO-2026-6088 | `encoding/xml` |
| GO-2026-5972 | `encoding/asn1` |

`govulncheck` is a required status check, so this currently blocks every open PR, not just this one. Main is affected too.

## Testing

`make verify` passes. `govulncheck` goes from 7 affecting vulnerabilities to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)