### PR TITLE
fix(docker): key per-map restart on container identity, not partition index

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Then run the setup wizard:
 ./dune-admin -setup
 ```
 
-Prerequisites: Go 1.26+, Node 20.19+ or 22.12+, pnpm 10.28+, `make`.
+Prerequisites: Go 1.26.6+, Node 20.19+ or 22.12+, pnpm 10.28+, `make`.
 
 > **Windows note:** `make build` works from PowerShell or `cmd.exe` as long as
 > [GNU Make](https://gnuwin32.sourceforge.net/packages/make.htm) is installed (e.g.

--- a/SETUP_DOCKER.md
+++ b/SETUP_DOCKER.md
@@ -13,7 +13,7 @@ dune-admin
 
 | Requirement | Notes |
 |-------------|-------|
-| **Go 1.26+** | `brew install go` or <https://go.dev/dl/> |
+| **Go 1.26.6+** | `brew install go` or <https://go.dev/dl/> |
 | **Docker CLI** | Must be in `$PATH` |
 | **Docker access** | The user running dune-admin must be able to run `docker` (i.e. in the `docker` group or running as root) |
 
@@ -152,6 +152,8 @@ one-entry list, so existing single-container configs keep running unchanged.
 **A non-game container shows up as a game server** — set `docker_gameservers` explicitly; the explicit list always wins over auto-detection.
 
 **A newly started map server does not appear** — `docker_gameservers` is pinned in config.yaml. Remove the key so detection runs on every poll.
+
+**"ambiguous restart target" when restarting a single map** — several of your game containers report the same partition index, which happens when their process args carry no `-PartitionIndex`. The panel sends the map name alongside the partition and normally resolves this on its own; seeing this error means the request reached the backend without one. Restarting the whole Battlegroup still works.
 
 **Players / queue / dimension columns are empty** — set `director_url` (the `dune-director` container publishes port `11717`).
 

--- a/SETUP_KUBECTL.md
+++ b/SETUP_KUBECTL.md
@@ -15,7 +15,7 @@ your machine
 
 | Requirement | Notes |
 |-------------|-------|
-| **Go 1.26+** | `brew install go` or <https://go.dev/dl/> |
+| **Go 1.26.6+** | `brew install go` or <https://go.dev/dl/> |
 | **SSH key** | Private key authorised on the VM |
 | **VM access** | Port 22 reachable; SSH user needs passwordless `sudo kubectl` |
 

--- a/SETUP_LOCAL.md
+++ b/SETUP_LOCAL.md
@@ -14,7 +14,7 @@ dune-admin (same machine)
 
 | Requirement | Notes |
 |-------------|-------|
-| **Go 1.26+** | `brew install go` or <https://go.dev/dl/> |
+| **Go 1.26.6+** | `brew install go` or <https://go.dev/dl/> |
 | **PostgreSQL reachable** | `db_host` must be accessible from where dune-admin runs |
 | **Shell commands** | Optional — only needed for start/stop/restart/status in the Battlegroup tab |
 

--- a/cmd/dune-admin/control.go
+++ b/cmd/dune-admin/control.go
@@ -60,8 +60,22 @@ type ControlPlane interface {
 // AMP and local run every partition's process inside one shared container, so
 // there is no narrower unit to restart there (see .claude/rules/amp.md) — those
 // planes don't implement this interface, and handlers type-assert for it.
+// restartTarget identifies the server row the operator asked to restart.
+//
+// Partition alone is not a reliable key. On docker the index is parsed out of
+// the container's process args, and a container that exposes no
+// -PartitionIndex parses to 0 — so on an install whose args differ from AMP's,
+// every row reports partition 0 and a partition-keyed lookup restarts whichever
+// container happens to sort first. Map carries the row's own identity (the
+// container name on docker) and disambiguates. kubectl pods are 1:1 with
+// partitions, so it keeps using Partition and ignores Map.
+type restartTarget struct {
+	Partition int    `json:"partition"`
+	Map       string `json:"map"`
+}
+
 type partitionRestarter interface {
-	RestartPartition(ctx context.Context, exec Executor, partition int) (string, error)
+	RestartPartition(ctx context.Context, exec Executor, target restartTarget) (string, error)
 }
 
 // supportsPartitionRestart reports whether the active plane can restart a single

--- a/cmd/dune-admin/control.go
+++ b/cmd/dune-admin/control.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
@@ -49,17 +50,6 @@ type ControlPlane interface {
 	ReadDefaultINI(ctx context.Context, exec Executor, filename string) string
 }
 
-// partitionRestarter is the optional control-plane capability for restarting a
-// single map/partition without cycling the whole Battlegroup.
-//
-// kubectl implements it via Funcom's ServerRestart CRD (serverrestarts.
-// igw.funcom.com) — a dedicated per-pod restart primitive distinct from the
-// whole-CRD "spec.stop" patch ExecCommand("restart") uses. docker implements it
-// by restarting the one container serving that partition (#311).
-//
-// AMP and local run every partition's process inside one shared container, so
-// there is no narrower unit to restart there (see .claude/rules/amp.md) — those
-// planes don't implement this interface, and handlers type-assert for it.
 // restartTarget identifies the server row the operator asked to restart.
 //
 // Partition alone is not a reliable key. On docker the index is parsed out of
@@ -74,6 +64,29 @@ type restartTarget struct {
 	Map       string `json:"map"`
 }
 
+// Restart targets the operator can correct are distinguished from genuine
+// failures so the handler can answer 4xx instead of 500: a stale row in the UI
+// is not a server fault, and the two need different messages.
+var (
+	// errRestartTargetUnknown: nothing matches the target (a stale row, or a
+	// container removed since the page last refreshed).
+	errRestartTargetUnknown = errors.New("restart target not found")
+	// errRestartTargetAmbiguous: several containers claim the partition, so
+	// acting on it would restart an arbitrary one.
+	errRestartTargetAmbiguous = errors.New("restart target is ambiguous")
+)
+
+// partitionRestarter is the optional control-plane capability for restarting a
+// single map/partition without cycling the whole Battlegroup.
+//
+// kubectl implements it via Funcom's ServerRestart CRD (serverrestarts.
+// igw.funcom.com) — a dedicated per-pod restart primitive distinct from the
+// whole-CRD "spec.stop" patch ExecCommand("restart") uses. docker implements it
+// by restarting the one container serving that partition (#311).
+//
+// AMP and local run every partition's process inside one shared container, so
+// there is no narrower unit to restart there (see .claude/rules/amp.md) — those
+// planes don't implement this interface, and handlers type-assert for it.
 type partitionRestarter interface {
 	RestartPartition(ctx context.Context, exec Executor, target restartTarget) (string, error)
 }

--- a/cmd/dune-admin/control_docker.go
+++ b/cmd/dune-admin/control_docker.go
@@ -32,6 +32,11 @@ type dockerGameContainer struct {
 	partition int    // -PartitionIndex= from the container args (0 if absent)
 	port      int    // -Port= from the container args (0 if absent)
 	mapName   string // container name minus the dune-server- prefix
+	// known is false for a name in docker_gameservers that docker has no record
+	// of. Such a row is still listed so the operator sees the stale entry, but
+	// it has no args to parse and so no partition identity — it must stay out
+	// of the collision math and out of partition-keyed restarts.
+	known bool
 }
 
 const (
@@ -180,10 +185,12 @@ func (c *dockerControl) discoverGameContainers(exec Executor) ([]dockerGameConta
 
 	containers := make([]dockerGameContainer, 0, len(selected))
 	for _, e := range selected {
+		_, seen := stateByName[e.name]
 		ct := dockerGameContainer{
 			name:    e.name,
 			state:   e.state,
 			mapName: strings.TrimPrefix(e.name, dockerGameNamePrefix),
+			known:   seen,
 		}
 		// The game server carries the same -PartitionIndex/-Port flags under
 		// every control plane, so the AMP regexes and parser apply verbatim.
@@ -376,6 +383,9 @@ func (c *dockerControl) RestartPartition(_ context.Context, exec Executor, targe
 func uniquePartitions(containers []dockerGameContainer) map[int]bool {
 	counts := make(map[int]int, len(containers))
 	for _, ct := range containers {
+		if !ct.known {
+			continue
+		}
 		counts[ct.partition]++
 	}
 	unique := make(map[int]bool, len(counts))
@@ -404,7 +414,9 @@ func resolveRestartContainer(containers []dockerGameContainer, target restartTar
 
 	var matches []dockerGameContainer
 	for _, ct := range containers {
-		if ct.partition == target.Partition {
+		// A container docker has no record of would fail `docker restart`
+		// anyway, and choosing it over a real one is strictly worse.
+		if ct.known && ct.partition == target.Partition {
 			matches = append(matches, ct)
 		}
 	}

--- a/cmd/dune-admin/control_docker.go
+++ b/cmd/dune-admin/control_docker.go
@@ -110,11 +110,26 @@ func selectGameContainers(entries []dockerPSEntry) []dockerPSEntry {
 	}
 	var byName []dockerPSEntry
 	for _, e := range entries {
-		if strings.HasPrefix(e.name, dockerGameNamePrefix) {
+		if strings.HasPrefix(e.name, dockerGameNamePrefix) && !isDockerSupportContainer(e.name) {
 			byName = append(byName, e)
 		}
 	}
 	return byName
+}
+
+// dockerSupportSuffixes name the containers that share the game servers' name
+// prefix but are not game servers. The image match excludes them for free
+// (their repos are seabass-server-gateway / -text-router); the prefix fallback
+// has to do it explicitly or a retagged install picks up the gateway.
+var dockerSupportSuffixes = []string{"gateway", "text-router", "router", "autoscaler", "director"}
+
+func isDockerSupportContainer(name string) bool {
+	for _, suffix := range dockerSupportSuffixes {
+		if strings.HasSuffix(name, "-"+suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 // configuredNames returns the explicitly configured container list, honouring
@@ -332,23 +347,61 @@ func (c *dockerControl) ExecCommand(_ context.Context, exec Executor, cmd string
 // RestartPartition cycles the single container serving a partition. Unlike AMP,
 // where every partition shares one container, docker runs one container each —
 // so a narrower restart unit genuinely exists here.
-func (c *dockerControl) RestartPartition(_ context.Context, exec Executor, partition int) (string, error) {
+func (c *dockerControl) RestartPartition(_ context.Context, exec Executor, target restartTarget) (string, error) {
 	containers, err := c.discoverGameContainers(exec)
 	if err != nil {
 		return "", err
 	}
-	for _, ct := range containers {
-		if ct.partition != partition {
-			continue
-		}
-		// #nosec G204 -- container name is shell-quoted; it comes from docker ps or operator config.
-		out, err := exec.Exec(fmt.Sprintf("docker restart %s 2>&1", shellQuote(ct.name)))
-		if err != nil {
-			return out, fmt.Errorf("docker restart %s: %w — %s", ct.name, err, strings.TrimSpace(out))
-		}
-		return out, nil
+	ct, err := resolveRestartContainer(containers, target)
+	if err != nil {
+		return "", err
 	}
-	return "", fmt.Errorf("docker control: no container found for partition %d", partition)
+	// #nosec G204 -- container name is shell-quoted; it comes from docker ps or operator config.
+	out, err := exec.Exec(fmt.Sprintf("docker restart %s 2>&1", shellQuote(ct.name)))
+	if err != nil {
+		return out, fmt.Errorf("docker restart %s: %w — %s", ct.name, err, strings.TrimSpace(out))
+	}
+	return out, nil
+}
+
+// resolveRestartContainer picks the one container a restart target names.
+//
+// The map is tried first because it is the row's own identity. Falling back to
+// the partition keeps working for installs whose args carry -PartitionIndex,
+// but when several containers report the same index the request is refused
+// rather than guessed: restarting an arbitrary map is worse than telling the
+// operator which rows collide.
+func resolveRestartContainer(containers []dockerGameContainer, target restartTarget) (dockerGameContainer, error) {
+	if target.Map != "" {
+		for _, ct := range containers {
+			if ct.mapName == target.Map || ct.name == target.Map {
+				return ct, nil
+			}
+		}
+		return dockerGameContainer{}, fmt.Errorf("docker control: no container found for map %q", target.Map)
+	}
+
+	var matches []dockerGameContainer
+	for _, ct := range containers {
+		if ct.partition == target.Partition {
+			matches = append(matches, ct)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return dockerGameContainer{}, fmt.Errorf("docker control: no container found for partition %d", target.Partition)
+	case 1:
+		return matches[0], nil
+	default:
+		var names []string
+		for _, ct := range matches {
+			names = append(names, ct.name)
+		}
+		return dockerGameContainer{}, fmt.Errorf(
+			"docker control: ambiguous restart target — %d containers report partition %d (%s); "+
+				"these containers expose no -PartitionIndex, so the map must be supplied",
+			len(matches), target.Partition, strings.Join(names, ", "))
+	}
 }
 
 // firstContainer returns a container to read install-wide values from. The
@@ -362,6 +415,16 @@ func (c *dockerControl) firstContainer(exec Executor) (string, error) {
 	if len(containers) == 0 {
 		return "", errNotSupported("docker", "no game server containers found")
 	}
+	// Discovery lists with `docker ps -a`, so the first entry can be a stopped
+	// container while another map is up. Both callers docker exec into the
+	// result, which fails against a stopped container for no good reason.
+	for _, ct := range containers {
+		if ct.state == "running" {
+			return ct.name, nil
+		}
+	}
+	// Nothing running: return the first anyway and let docker's own error
+	// surface, rather than inventing a different one here.
 	return containers[0].name, nil
 }
 

--- a/cmd/dune-admin/control_docker.go
+++ b/cmd/dune-admin/control_docker.go
@@ -241,6 +241,12 @@ func (c *dockerControl) GetStatus(ctx context.Context, exec Executor) (*Battlegr
 		componentLog("control_docker").Warn().Err(err).Msg("director enrichment unavailable")
 	}
 
+	// Director metadata is keyed by partition, so it can only be trusted where
+	// the partition identifies exactly one container. Containers whose args
+	// carry no -PartitionIndex all parse to 0, and enriching each of them from
+	// dirMeta[0] would show every map the same players, dimension and label.
+	unique := uniquePartitions(containers)
+
 	servers := make([]ServerRow, 0, len(containers))
 	running := 0
 	for _, ct := range containers {
@@ -254,7 +260,7 @@ func (c *dockerControl) GetStatus(ctx context.Context, exec Executor) (*Battlegr
 			Ready:     ct.state == "running",
 			Port:      ct.port,
 		}
-		if meta, ok := dirMeta[ct.partition]; ok {
+		if meta, ok := dirMeta[ct.partition]; ok && unique[ct.partition] {
 			row.Dimension = meta.dimension
 			row.Players = meta.players
 			row.PlayerHardCap = meta.playerHardCap
@@ -362,6 +368,21 @@ func (c *dockerControl) RestartPartition(_ context.Context, exec Executor, targe
 		return out, fmt.Errorf("docker restart %s: %w — %s", ct.name, err, strings.TrimSpace(out))
 	}
 	return out, nil
+}
+
+// uniquePartitions reports which partition indices identify exactly one
+// container. Anything claimed by two or more is not a usable key — see
+// restartTarget for why the index can collapse to 0.
+func uniquePartitions(containers []dockerGameContainer) map[int]bool {
+	counts := make(map[int]int, len(containers))
+	for _, ct := range containers {
+		counts[ct.partition]++
+	}
+	unique := make(map[int]bool, len(counts))
+	for partition, n := range counts {
+		unique[partition] = n == 1
+	}
+	return unique
 }
 
 // resolveRestartContainer picks the one container a restart target names.

--- a/cmd/dune-admin/control_docker.go
+++ b/cmd/dune-admin/control_docker.go
@@ -399,7 +399,7 @@ func resolveRestartContainer(containers []dockerGameContainer, target restartTar
 				return ct, nil
 			}
 		}
-		return dockerGameContainer{}, fmt.Errorf("docker control: no container found for map %q", target.Map)
+		return dockerGameContainer{}, fmt.Errorf("docker control: no container found for map %q: %w", target.Map, errRestartTargetUnknown)
 	}
 
 	var matches []dockerGameContainer
@@ -410,7 +410,7 @@ func resolveRestartContainer(containers []dockerGameContainer, target restartTar
 	}
 	switch len(matches) {
 	case 0:
-		return dockerGameContainer{}, fmt.Errorf("docker control: no container found for partition %d", target.Partition)
+		return dockerGameContainer{}, fmt.Errorf("docker control: no container found for partition %d: %w", target.Partition, errRestartTargetUnknown)
 	case 1:
 		return matches[0], nil
 	default:
@@ -419,9 +419,9 @@ func resolveRestartContainer(containers []dockerGameContainer, target restartTar
 			names = append(names, ct.name)
 		}
 		return dockerGameContainer{}, fmt.Errorf(
-			"docker control: ambiguous restart target — %d containers report partition %d (%s); "+
-				"these containers expose no -PartitionIndex, so the map must be supplied",
-			len(matches), target.Partition, strings.Join(names, ", "))
+			"docker control: %d containers report partition %d (%s); "+
+				"these containers expose no -PartitionIndex, so the map must be supplied: %w",
+			len(matches), target.Partition, strings.Join(names, ", "), errRestartTargetAmbiguous)
 	}
 }
 

--- a/cmd/dune-admin/control_docker.go
+++ b/cmd/dune-admin/control_docker.go
@@ -404,37 +404,60 @@ func uniquePartitions(containers []dockerGameContainer) map[int]bool {
 // operator which rows collide.
 func resolveRestartContainer(containers []dockerGameContainer, target restartTarget) (dockerGameContainer, error) {
 	if target.Map != "" {
-		for _, ct := range containers {
-			if ct.mapName == target.Map || ct.name == target.Map {
-				return ct, nil
-			}
-		}
-		return dockerGameContainer{}, fmt.Errorf("docker control: no container found for map %q: %w", target.Map, errRestartTargetUnknown)
+		return resolveByMap(containers, target.Map)
 	}
+	return resolveByPartition(containers, target.Partition)
+}
 
+// resolveByMap matches the row's own identity: the container name on docker,
+// or the map label derived from it.
+func resolveByMap(containers []dockerGameContainer, mapName string) (dockerGameContainer, error) {
+	for _, ct := range containers {
+		if ct.mapName != mapName && ct.name != mapName {
+			continue
+		}
+		// The row exists but docker has no record of the container behind it —
+		// a stale docker_gameservers entry, or one removed since the page last
+		// refreshed. That is the correctable case, not a server fault, so it
+		// must not shell out and surface as a 500.
+		if !ct.known {
+			return dockerGameContainer{}, fmt.Errorf(
+				"docker control: container %q for map %q is not in docker ps: %w",
+				ct.name, mapName, errRestartTargetUnknown)
+		}
+		return ct, nil
+	}
+	return dockerGameContainer{}, fmt.Errorf(
+		"docker control: no container found for map %q: %w", mapName, errRestartTargetUnknown)
+}
+
+// resolveByPartition keeps working for installs whose args carry
+// -PartitionIndex. A partition claimed by several containers is refused rather
+// than guessed: restarting an arbitrary map is worse than naming the collision.
+func resolveByPartition(containers []dockerGameContainer, partition int) (dockerGameContainer, error) {
 	var matches []dockerGameContainer
 	for _, ct := range containers {
 		// A container docker has no record of would fail `docker restart`
 		// anyway, and choosing it over a real one is strictly worse.
-		if ct.known && ct.partition == target.Partition {
+		if ct.known && ct.partition == partition {
 			matches = append(matches, ct)
 		}
 	}
 	switch len(matches) {
 	case 0:
-		return dockerGameContainer{}, fmt.Errorf("docker control: no container found for partition %d: %w", target.Partition, errRestartTargetUnknown)
+		return dockerGameContainer{}, fmt.Errorf(
+			"docker control: no container found for partition %d: %w", partition, errRestartTargetUnknown)
 	case 1:
 		return matches[0], nil
-	default:
-		var names []string
-		for _, ct := range matches {
-			names = append(names, ct.name)
-		}
-		return dockerGameContainer{}, fmt.Errorf(
-			"docker control: %d containers report partition %d (%s); "+
-				"these containers expose no -PartitionIndex, so the map must be supplied: %w",
-			len(matches), target.Partition, strings.Join(names, ", "), errRestartTargetAmbiguous)
 	}
+	names := make([]string, 0, len(matches))
+	for _, ct := range matches {
+		names = append(names, ct.name)
+	}
+	return dockerGameContainer{}, fmt.Errorf(
+		"docker control: %d containers report partition %d (%s); "+
+			"these containers expose no -PartitionIndex, so the map must be supplied: %w",
+		len(matches), partition, strings.Join(names, ", "), errRestartTargetAmbiguous)
 }
 
 // firstContainer returns a container to read install-wide values from. The

--- a/cmd/dune-admin/control_docker_restart_target_test.go
+++ b/cmd/dune-admin/control_docker_restart_target_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -315,5 +316,28 @@ func TestDockerRestartTarget_StaleConfiguredNameIsNotAPartitionMatch(t *testing.
 	}
 	if len(ran) != 1 || !strings.Contains(ran[0], "dune-server-overmap") {
 		t.Fatalf("restarted %v, want only the container docker knows about", ran)
+	}
+}
+
+// Restarting a row whose container docker no longer has is the stale-row case
+// errRestartTargetUnknown exists for, so it must answer 404 rather than
+// attempting `docker restart` and surfacing docker's failure as a 500.
+func TestDockerRestartTarget_StaleMapIsUnknownNotAServerError(t *testing.T) {
+	t.Parallel()
+	ps := "dune-server-overmap\tregistry.funcom.com/funcom/self-hosting/seabass-server:2048594-0-shipping\trunning\n"
+	var ran []string
+	exec := recordingDockerExec(ps, nil, &ran)
+	c := &dockerControl{gameservers: []string{"dune-server-overmap", "dune-server-gone"}}
+
+	_, err := c.RestartPartition(context.Background(), exec, restartTarget{Map: "gone"})
+	if !errors.Is(err, errRestartTargetUnknown) {
+		t.Fatalf("err = %v, want errRestartTargetUnknown so the handler answers 404", err)
+	}
+	if len(ran) != 0 {
+		t.Fatalf("must not shell out for a container docker has no record of, ran: %v", ran)
+	}
+	// The operator needs to know the name is stale, not just absent.
+	if !strings.Contains(err.Error(), "dune-server-gone") {
+		t.Fatalf("error = %q, want it to name the stale container", err)
 	}
 }

--- a/cmd/dune-admin/control_docker_restart_target_test.go
+++ b/cmd/dune-admin/control_docker_restart_target_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -179,5 +182,71 @@ func TestDockerSelectGameContainers_PrefixFallbackExcludesSupportContainers(t *t
 	want := []string{"dune-server-overmap", "dune-server-survival-1"}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("prefix fallback selected %v, want %v", got, want)
+	}
+}
+
+// Director metadata is keyed by partition, so the partition-0 collapse hits
+// GetStatus too: every row would take partition 0's players, dimension and
+// label and display them as its own. Refusing the restart but still showing
+// three maps with identical, wrong player counts fixes half the bug.
+//
+// Enrichment is applied only where the partition identifies exactly one
+// container. A blank column is honest; a fabricated one is not.
+func TestDockerGetStatus_SkipsDirectorEnrichmentWhenPartitionsCollide(t *testing.T) {
+	t.Parallel()
+	dir := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `{"servers":[{"partition":{"partitionId":0,"dimensionIndex":4,"label":"Hagga Basin"},
+			"numPlayersInGame":37,"numPlayersInQueue":9}]}`)
+	}))
+	defer dir.Close()
+
+	// No -PartitionIndex in any container's args, so all three parse to 0.
+	c := &dockerControl{directorURL: dir.URL}
+	st, err := c.GetStatus(context.Background(), dockerScript(dockerPSNoPartitionArgs, nil))
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if len(st.Servers) != 3 {
+		t.Fatalf("got %d rows, want 3", len(st.Servers))
+	}
+	for _, row := range st.Servers {
+		if row.Players != 0 || row.Dimension != 0 || row.Queue != 0 || row.Sietch != "" {
+			t.Errorf("row %q got enriched from an ambiguous partition: %+v", row.Map, row)
+		}
+	}
+}
+
+// The normal path must keep enriching: unique partitions still get their
+// players, dimension and label.
+func TestDockerGetStatus_EnrichesWhenPartitionsAreUnique(t *testing.T) {
+	t.Parallel()
+	dir := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `{"servers":[{"partition":{"partitionId":2,"dimensionIndex":4,"label":"Hagga Basin"},
+			"numPlayersInGame":37,"numPlayersInQueue":9}]}`)
+	}))
+	defer dir.Close()
+
+	args := map[string]string{
+		"dune-server-overmap":        `["-PartitionIndex=1"]`,
+		"dune-server-survival-1":     `["-PartitionIndex=2"]`,
+		"dune-server-deepdesert-1-8": `["-PartitionIndex=3"]`,
+	}
+	c := &dockerControl{directorURL: dir.URL}
+	st, err := c.GetStatus(context.Background(), dockerScript(dockerPSNoPartitionArgs, args))
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	var found bool
+	for _, row := range st.Servers {
+		if row.Partition != 2 {
+			continue
+		}
+		found = true
+		if row.Players != 37 || row.Dimension != 4 || row.Queue != 9 || row.Sietch != "Hagga Basin" {
+			t.Fatalf("partition 2 row not enriched: %+v", row)
+		}
+	}
+	if !found {
+		t.Fatal("no row reported partition 2")
 	}
 }

--- a/cmd/dune-admin/control_docker_restart_target_test.go
+++ b/cmd/dune-admin/control_docker_restart_target_test.go
@@ -250,3 +250,70 @@ func TestDockerGetStatus_EnrichesWhenPartitionsAreUnique(t *testing.T) {
 		t.Fatal("no row reported partition 2")
 	}
 }
+
+// A name in docker_gameservers that docker does not know about is deliberately
+// still listed, so the operator sees the stale entry rather than wondering
+// where their container went. But it has no args to parse, so it lands on
+// partition 0 — and if it counts toward the collision math it manufactures a
+// false ambiguity that suppresses enrichment for a real partition-0 container
+// and can be matched by a partition-keyed restart.
+//
+// A container docker cannot see has no partition identity. It stays in the
+// table; it stays out of the arithmetic.
+func TestDockerGetStatus_StaleConfiguredNameDoesNotFakeACollision(t *testing.T) {
+	t.Parallel()
+	dir := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `{"servers":[{"partition":{"partitionId":0,"dimensionIndex":4,"label":"Hagga Basin"},
+			"numPlayersInGame":37,"numPlayersInQueue":9}]}`)
+	}))
+	defer dir.Close()
+
+	ps := "dune-server-overmap\tregistry.funcom.com/funcom/self-hosting/seabass-server:2048594-0-shipping\trunning\n"
+	c := &dockerControl{
+		// "dune-server-gone" was removed since setup pinned it.
+		gameservers: []string{"dune-server-overmap", "dune-server-gone"},
+		directorURL: dir.URL,
+	}
+	st, err := c.GetStatus(context.Background(), dockerScript(ps, map[string]string{
+		"dune-server-overmap": `["-PartitionIndex=0"]`,
+	}))
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if len(st.Servers) != 2 {
+		t.Fatalf("got %d rows, want 2 — the stale name must stay visible", len(st.Servers))
+	}
+	var overmap *ServerRow
+	for i := range st.Servers {
+		if st.Servers[i].Map == "overmap" {
+			overmap = &st.Servers[i]
+		}
+	}
+	if overmap == nil {
+		t.Fatal("no overmap row")
+	}
+	// Partition 0 is unique among containers docker can actually see.
+	if overmap.Players != 37 || overmap.Dimension != 4 || overmap.Sietch != "Hagga Basin" {
+		t.Fatalf("overmap lost its enrichment to a phantom collision: %+v", *overmap)
+	}
+}
+
+// The same phantom must not be restartable by partition — `docker restart` on a
+// container that does not exist is a guaranteed failure, and picking it over a
+// real container is worse than picking nothing.
+func TestDockerRestartTarget_StaleConfiguredNameIsNotAPartitionMatch(t *testing.T) {
+	t.Parallel()
+	ps := "dune-server-overmap\tregistry.funcom.com/funcom/self-hosting/seabass-server:2048594-0-shipping\trunning\n"
+	var ran []string
+	exec := recordingDockerExec(ps, map[string]string{
+		"dune-server-overmap": `["-PartitionIndex=0"]`,
+	}, &ran)
+	c := &dockerControl{gameservers: []string{"dune-server-gone", "dune-server-overmap"}}
+
+	if _, err := c.RestartPartition(context.Background(), exec, restartTarget{Partition: 0}); err != nil {
+		t.Fatalf("RestartPartition: %v", err)
+	}
+	if len(ran) != 1 || !strings.Contains(ran[0], "dune-server-overmap") {
+		t.Fatalf("restarted %v, want only the container docker knows about", ran)
+	}
+}

--- a/cmd/dune-admin/control_docker_restart_target_test.go
+++ b/cmd/dune-admin/control_docker_restart_target_test.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// A docker install whose game-server args carry no -PartitionIndex parses every
+// container to partition 0 (parseAMPArgInt returns 0 on a miss). A
+// partition-keyed restart then matches the first container in the list and
+// restarts the wrong map, silently. That was latent while the Battlegroup tab
+// hid the per-map button on docker; unhiding it made it reachable.
+//
+// The target now carries the map, which on docker is the container identity, so
+// the row the operator clicked is the container that cycles.
+
+// dockerPSNoPartitionArgs is the reporter's layout with args that expose a port
+// but no partition index — the case that collapses every row to 0.
+const dockerPSNoPartitionArgs = "dune-server-deepdesert-1-8\tregistry.funcom.com/funcom/self-hosting/seabass-server:2048594-0-shipping\trunning\n" +
+	"dune-server-overmap\tregistry.funcom.com/funcom/self-hosting/seabass-server:2048594-0-shipping\trunning\n" +
+	"dune-server-survival-1\tregistry.funcom.com/funcom/self-hosting/seabass-server:2048594-0-shipping\trunning\n"
+
+// recordingDockerExec is dockerScript plus a record of every container name a
+// `docker restart` was issued against, so a test can assert that exactly one
+// container cycled — and which.
+func recordingDockerExec(psOut string, args map[string]string, ran *[]string) *dialingExecutor {
+	script := dockerScript(psOut, args)
+	inner := script.fn
+	return &dialingExecutor{&fnExecutor{fn: func(cmd string) (string, error) {
+		if strings.Contains(cmd, "docker restart") {
+			for _, line := range strings.Split(psOut, "\n") {
+				name, _, found := strings.Cut(strings.TrimSpace(line), "\t")
+				if found && name != "" && strings.Contains(cmd, name) {
+					*ran = append(*ran, cmd)
+				}
+			}
+			return "", nil
+		}
+		return inner(cmd)
+	}}}
+}
+
+// TestDockerRestartTarget_MapWinsOverAmbiguousPartition — with three rows all
+// parsing to partition 0, the map must decide which container restarts.
+func TestDockerRestartTarget_MapWinsOverAmbiguousPartition(t *testing.T) {
+	t.Parallel()
+	var ran []string
+	exec := recordingDockerExec(dockerPSNoPartitionArgs, nil, &ran)
+	c := &dockerControl{}
+
+	// Every row reports partition 0; only the map separates them.
+	if _, err := c.RestartPartition(context.Background(), exec,
+		restartTarget{Partition: 0, Map: "overmap"}); err != nil {
+		t.Fatalf("RestartPartition: %v", err)
+	}
+
+	if len(ran) != 1 {
+		t.Fatalf("restarted %d containers, want exactly 1: %v", len(ran), ran)
+	}
+	if !strings.Contains(ran[0], "dune-server-overmap") {
+		t.Fatalf("restarted %q, want the container for the overmap row", ran[0])
+	}
+}
+
+// TestDockerRestartTarget_AmbiguousPartitionWithoutMapErrors — refusing beats
+// guessing. Restarting an arbitrary map is worse than saying which rows collide.
+func TestDockerRestartTarget_AmbiguousPartitionWithoutMapErrors(t *testing.T) {
+	t.Parallel()
+	var ran []string
+	exec := recordingDockerExec(dockerPSNoPartitionArgs, nil, &ran)
+	c := &dockerControl{}
+
+	_, err := c.RestartPartition(context.Background(), exec, restartTarget{Partition: 0})
+	if err == nil {
+		t.Fatal("want an error when three containers share partition 0 and no map is given")
+	}
+	if len(ran) != 0 {
+		t.Fatalf("nothing may be restarted when the target is ambiguous, ran: %v", ran)
+	}
+	// The message has to name the collision, or the operator cannot act on it.
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("error = %q, want it to say the target is ambiguous", err)
+	}
+}
+
+// TestDockerRestartTarget_PartitionStillWorksWhenUnique — the normal path,
+// where args do carry -PartitionIndex, must be unchanged.
+func TestDockerRestartTarget_PartitionStillWorksWhenUnique(t *testing.T) {
+	t.Parallel()
+	var ran []string
+	args := map[string]string{
+		"dune-server-overmap":        "-PartitionIndex=1 -Port=7777",
+		"dune-server-survival-1":     "-PartitionIndex=2 -Port=7778",
+		"dune-server-deepdesert-1-8": "-PartitionIndex=3 -Port=7779",
+	}
+	exec := recordingDockerExec(dockerPSNoPartitionArgs, args, &ran)
+	c := &dockerControl{}
+
+	if _, err := c.RestartPartition(context.Background(), exec, restartTarget{Partition: 2}); err != nil {
+		t.Fatalf("RestartPartition: %v", err)
+	}
+	if len(ran) != 1 || !strings.Contains(ran[0], "dune-server-survival-1") {
+		t.Fatalf("restarted %v, want only dune-server-survival-1", ran)
+	}
+}
+
+// TestDockerRestartTarget_UnknownMapErrors — a map that matches nothing must
+// not silently fall through to a partition match.
+func TestDockerRestartTarget_UnknownMapErrors(t *testing.T) {
+	t.Parallel()
+	var ran []string
+	exec := recordingDockerExec(dockerPSNoPartitionArgs, nil, &ran)
+	c := &dockerControl{}
+
+	if _, err := c.RestartPartition(context.Background(), exec,
+		restartTarget{Partition: 0, Map: "arrakeen"}); err == nil {
+		t.Fatal("want an error for a map with no matching container")
+	}
+	if len(ran) != 0 {
+		t.Fatalf("nothing may be restarted for an unknown map, ran: %v", ran)
+	}
+}
+
+// firstContainer feeds CaptureJWT and ReadDefaultINI, which docker exec into
+// the container. Discovery lists with `docker ps -a`, so the first entry can be
+// exited while another map is up — and exec'ing a stopped container fails for
+// no reason. Prefer a running one.
+func TestDockerFirstContainer_PrefersRunningContainer(t *testing.T) {
+	t.Parallel()
+	ps := "dune-server-deepdesert-1-8\tregistry.funcom.com/funcom/self-hosting/seabass-server:2048594-0-shipping\texited\n" +
+		"dune-server-overmap\tregistry.funcom.com/funcom/self-hosting/seabass-server:2048594-0-shipping\trunning\n"
+	c := &dockerControl{}
+
+	got, err := c.firstContainer(dockerScript(ps, nil))
+	if err != nil {
+		t.Fatalf("firstContainer: %v", err)
+	}
+	if got != "dune-server-overmap" {
+		t.Fatalf("firstContainer = %q, want the running container", got)
+	}
+}
+
+// All stopped is still a usable answer: the caller's docker exec will fail with
+// docker's own message, which beats inventing one here.
+func TestDockerFirstContainer_FallsBackWhenNoneRunning(t *testing.T) {
+	t.Parallel()
+	ps := "dune-server-overmap\tregistry.funcom.com/funcom/self-hosting/seabass-server:2048594-0-shipping\texited\n"
+	c := &dockerControl{}
+
+	got, err := c.firstContainer(dockerScript(ps, nil))
+	if err != nil {
+		t.Fatalf("firstContainer: %v", err)
+	}
+	if got != "dune-server-overmap" {
+		t.Fatalf("firstContainer = %q, want the only container even though it is stopped", got)
+	}
+}
+
+// The name-prefix fallback only runs when no image matches seabass-server
+// (retagged or privately built images). It must carry the same exclusions the
+// image match gives for free, or it sweeps in the gateway and text-router —
+// which is exactly why detection keys off the image in the first place.
+func TestDockerSelectGameContainers_PrefixFallbackExcludesSupportContainers(t *testing.T) {
+	t.Parallel()
+	ps := "dune-server-gateway\tmyregistry/private-gateway:1\trunning\n" +
+		"dune-server-overmap\tmyregistry/private-dune:1\trunning\n" +
+		"dune-server-survival-1\tmyregistry/private-dune:1\trunning\n" +
+		"dune-server-text-router\tmyregistry/private-text-router:1\trunning\n"
+	entries, err := listDockerContainers(dockerScript(ps, nil))
+	if err != nil {
+		t.Fatalf("listDockerContainers: %v", err)
+	}
+
+	var got []string
+	for _, e := range selectGameContainers(entries) {
+		got = append(got, e.name)
+	}
+	want := []string{"dune-server-overmap", "dune-server-survival-1"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("prefix fallback selected %v, want %v", got, want)
+	}
+}

--- a/cmd/dune-admin/control_docker_test.go
+++ b/cmd/dune-admin/control_docker_test.go
@@ -321,7 +321,7 @@ func TestDockerRestartPartition_TargetsOnlyThatContainer(t *testing.T) {
 		return "", nil
 	}}
 	c := &dockerControl{}
-	if _, err := c.RestartPartition(context.Background(), exec, 2); err != nil {
+	if _, err := c.RestartPartition(context.Background(), exec, restartTarget{Partition: 2}); err != nil {
 		t.Fatalf("RestartPartition: %v", err)
 	}
 	if len(restarted) != 1 || restarted[0] != "dune-server-overmap" {
@@ -331,7 +331,7 @@ func TestDockerRestartPartition_TargetsOnlyThatContainer(t *testing.T) {
 
 func TestDockerRestartPartition_UnknownPartitionErrors(t *testing.T) {
 	c := &dockerControl{}
-	_, err := c.RestartPartition(context.Background(), dockerScript(issue311DockerPS, nil), 99)
+	_, err := c.RestartPartition(context.Background(), dockerScript(issue311DockerPS, nil), restartTarget{Partition: 99})
 	if err == nil {
 		t.Fatal("RestartPartition: want error for unknown partition, got nil")
 	}
@@ -349,20 +349,6 @@ func TestParseDockerPS_SkipsBlankAndMalformed(t *testing.T) {
 	}
 	if entries[1].name != "b" || entries[1].state != "exited" {
 		t.Errorf("entries[1] = %+v, want {b img2 exited}", entries[1])
-	}
-}
-
-// The wizard offers the auto-detected game servers as the default selection so
-// the operator confirms rather than guessing a name (#311).
-func TestDefaultGameserverSelection(t *testing.T) {
-	entries, err := listDockerContainers(dockerScript(issue311DockerPS, nil))
-	if err != nil {
-		t.Fatalf("listDockerContainers: %v", err)
-	}
-	got := defaultGameserverSelection(entries)
-	// deepdesert=6, overmap=8, survival=9 in the 1-based issue #311 listing.
-	if got != "6,8,9" {
-		t.Errorf("defaultGameserverSelection = %q, want %q", got, "6,8,9")
 	}
 }
 

--- a/cmd/dune-admin/control_kubectl.go
+++ b/cmd/dune-admin/control_kubectl.go
@@ -278,7 +278,10 @@ const serverRestartAPIVersion = "igw.funcom.com/v1"
 // object had ever been created on the reference cluster at the time this was
 // written, so the apply behavior itself (recreation timing, whether the
 // object is cleaned up afterward) is unverified against a live cluster.
-func (c *kubectlControl) RestartPartition(_ context.Context, exec Executor, partition int) (string, error) {
+func (c *kubectlControl) RestartPartition(_ context.Context, exec Executor, target restartTarget) (string, error) {
+	// Pods are 1:1 with partitions here, so the partition index is a reliable
+	// key and target.Map is not needed.
+	partition := target.Partition
 	kctl := kubectlCLI(exec)
 	ns := c.namespace
 

--- a/cmd/dune-admin/control_kubectl_restart_partition_test.go
+++ b/cmd/dune-admin/control_kubectl_restart_partition_test.go
@@ -213,7 +213,7 @@ func TestKubectlControl_RestartPartition_Success(t *testing.T) {
 	}}
 
 	c := &kubectlControl{namespace: "funcom-seabass-mybg"}
-	out, err := c.RestartPartition(context.Background(), exec, 1)
+	out, err := c.RestartPartition(context.Background(), exec, restartTarget{Partition: 1})
 	if err != nil {
 		t.Fatalf("RestartPartition: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestKubectlControl_RestartPartition_ServerSetNotFound(t *testing.T) {
 		return "", nil
 	}}
 	c := &kubectlControl{namespace: "funcom-seabass-mybg"}
-	if _, err := c.RestartPartition(context.Background(), exec, 99); err == nil {
+	if _, err := c.RestartPartition(context.Background(), exec, restartTarget{Partition: 99}); err == nil {
 		t.Fatal("expected error for a partition with no matching ServerSet")
 	}
 	if applied {
@@ -273,7 +273,7 @@ func TestKubectlControl_RestartPartition_ApplyError(t *testing.T) {
 		}
 	}}
 	c := &kubectlControl{namespace: "funcom-seabass-mybg"}
-	out, err := c.RestartPartition(context.Background(), exec, 1)
+	out, err := c.RestartPartition(context.Background(), exec, restartTarget{Partition: 1})
 	if err == nil {
 		t.Fatal("expected error when apply fails")
 	}

--- a/cmd/dune-admin/handlers_battlegroup.go
+++ b/cmd/dune-admin/handlers_battlegroup.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -162,7 +163,17 @@ func handleBGRestartPartition(w http.ResponseWriter, r *http.Request) {
 	}
 	out, err := restarter.RestartPartition(r.Context(), executorFromCtx(r), req)
 	if err != nil {
-		jsonErr(w, fmt.Errorf("restart partition %d: %w — output: %s", req.Partition, err, out), 500)
+		// A target the operator can correct is not a server fault: a stale row
+		// or a partition several containers claim needs a different message,
+		// and a different status, from a restart that genuinely failed.
+		status := http.StatusInternalServerError
+		switch {
+		case errors.Is(err, errRestartTargetUnknown):
+			status = http.StatusNotFound
+		case errors.Is(err, errRestartTargetAmbiguous):
+			status = http.StatusConflict
+		}
+		jsonErr(w, fmt.Errorf("restart partition %d: %w — output: %s", req.Partition, err, out), status)
 		return
 	}
 	// Same cache-drop as the whole-battlegroup lifecycle commands — a

--- a/cmd/dune-admin/handlers_battlegroup.go
+++ b/cmd/dune-admin/handlers_battlegroup.go
@@ -148,9 +148,9 @@ func handleBGRestartPartition(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, fmt.Errorf("%s control plane does not support per-partition restart", ctrl.Name()), http.StatusNotImplemented)
 		return
 	}
-	var req struct {
-		Partition int `json:"partition"`
-	}
+	// Map accompanies the partition because the index is not a reliable key on
+	// every plane — see restartTarget.
+	var req restartTarget
 	if err := decode(r, &req); err != nil {
 		jsonErr(w, err, 400)
 		return
@@ -159,7 +159,7 @@ func handleBGRestartPartition(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, fmt.Errorf("invalid partition %d", req.Partition), 400)
 		return
 	}
-	out, err := restarter.RestartPartition(r.Context(), executorFromCtx(r), req.Partition)
+	out, err := restarter.RestartPartition(r.Context(), executorFromCtx(r), req)
 	if err != nil {
 		jsonErr(w, fmt.Errorf("restart partition %d: %w — output: %s", req.Partition, err, out), 500)
 		return

--- a/cmd/dune-admin/handlers_battlegroup.go
+++ b/cmd/dune-admin/handlers_battlegroup.go
@@ -131,9 +131,10 @@ func handleBGExec(w http.ResponseWriter, r *http.Request) {
 // @Tags battlegroup
 // @Accept json
 // @Produce json
-// @Param body body object true "partition: partition index to restart"
+// @Param body body restartTarget true "partition index, plus the map name that disambiguates it when several rows report the same index"
 // @Success 200 {object} map[string]string
 // @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
 // @Failure 501 {object} map[string]string
 // @Failure 503 {object} map[string]string
 // @Router /api/v1/battlegroup/restart-partition [post]

--- a/cmd/dune-admin/handlers_battlegroup.go
+++ b/cmd/dune-admin/handlers_battlegroup.go
@@ -135,6 +135,8 @@ func handleBGExec(w http.ResponseWriter, r *http.Request) {
 // @Param body body restartTarget true "partition index, plus the map name that disambiguates it when several rows report the same index"
 // @Success 200 {object} map[string]string
 // @Failure 400 {object} map[string]string
+// @Failure 404 {object} map[string]string "no server matches the target (e.g. a stale row)"
+// @Failure 409 {object} map[string]string "several containers claim the partition; supply the map"
 // @Failure 500 {object} map[string]string
 // @Failure 501 {object} map[string]string
 // @Failure 503 {object} map[string]string

--- a/cmd/dune-admin/handlers_battlegroup_restart_partition_test.go
+++ b/cmd/dune-admin/handlers_battlegroup_restart_partition_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -130,5 +131,32 @@ func TestHandleBGRestartPartition_ControlPlaneError(t *testing.T) {
 	rr := postRestartPartition(t, `{"partition":5}`)
 	if rr.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusInternalServerError)
+	}
+}
+
+// A restart target the operator can correct — a map that matches no container,
+// or a partition several containers claim — is not a server fault. Returning
+// 500 for all of them leaves the UI unable to tell "your click was stale,
+// refresh" from "the restart itself broke".
+func TestHandleBGRestartPartition_TargetErrorsMapToClientStatus(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{"unknown target", fmt.Errorf("no container found for map %q: %w", "arrakeen", errRestartTargetUnknown), http.StatusNotFound},
+		{"ambiguous target", fmt.Errorf("3 containers report partition 0: %w", errRestartTargetAmbiguous), http.StatusConflict},
+		{"genuine failure", errors.New("docker daemon unreachable"), http.StatusInternalServerError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			saveRestartPartitionGlobals(t)
+			globalControl = &partitionRestartControl{err: tc.err}
+
+			rr := postRestartPartition(t, `{"partition":0,"map":"arrakeen"}`)
+			if rr.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body %s)", rr.Code, tc.wantStatus, rr.Body.String())
+			}
+		})
 	}
 }

--- a/cmd/dune-admin/handlers_battlegroup_restart_partition_test.go
+++ b/cmd/dune-admin/handlers_battlegroup_restart_partition_test.go
@@ -15,14 +15,16 @@ import (
 type partitionRestartControl struct {
 	stubControlPlane
 	gotPartition int
+	gotMap       string
 	out          string
 	err          error
 }
 
 func (p *partitionRestartControl) Name() string { return "kubectl" }
 
-func (p *partitionRestartControl) RestartPartition(_ context.Context, _ Executor, partition int) (string, error) {
-	p.gotPartition = partition
+func (p *partitionRestartControl) RestartPartition(_ context.Context, _ Executor, target restartTarget) (string, error) {
+	p.gotPartition = target.Partition
+	p.gotMap = target.Map
 	return p.out, p.err
 }
 
@@ -99,12 +101,17 @@ func TestHandleBGRestartPartition_Success(t *testing.T) {
 	ctrl := &partitionRestartControl{out: "serverrestart.igw.funcom.com/dune-admin-restart-abc created"}
 	globalControl = ctrl
 
-	rr := postRestartPartition(t, `{"partition":3}`)
+	rr := postRestartPartition(t, `{"partition":3,"map":"overmap"}`)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
 	}
 	if ctrl.gotPartition != 3 {
 		t.Fatalf("gotPartition = %d, want 3", ctrl.gotPartition)
+	}
+	// The map has to reach the plane: it is what disambiguates rows that all
+	// report the same partition index (see restartTarget).
+	if ctrl.gotMap != "overmap" {
+		t.Fatalf("gotMap = %q, want %q", ctrl.gotMap, "overmap")
 	}
 	var resp map[string]string
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {

--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -138,15 +138,16 @@ type appConfig struct {
 	// kubectl-specific
 	ControlNamespace string `yaml:"control_namespace" json:"control_namespace"`
 
-	// docker-specific — container names. DockerGameservers lists every
-	// game-server container (one per map/partition, see #311); it overrides
-	// runtime auto-detection. DockerGameserver is the legacy singular key,
-	// honoured when the list is empty.
+	// DockerGameservers lists every game-server container (one per
+	// map/partition, see #311) and overrides runtime auto-detection. Leave it
+	// empty to re-detect on every status poll.
 	DockerGameservers []string `yaml:"docker_gameservers" json:"docker_gameservers"`
-	DockerGameserver  string   `yaml:"docker_gameserver"  json:"docker_gameserver"`
-	DockerBrokerGame  string   `yaml:"docker_broker_game"  json:"docker_broker_game"`
-	DockerBrokerAdmin string   `yaml:"docker_broker_admin" json:"docker_broker_admin"`
-	DockerDB          string   `yaml:"docker_db"           json:"docker_db"`
+	// DockerGameserver is the legacy singular key, honoured as a one-entry list
+	// when DockerGameservers is empty.
+	DockerGameserver  string `yaml:"docker_gameserver"  json:"docker_gameserver"`
+	DockerBrokerGame  string `yaml:"docker_broker_game"  json:"docker_broker_game"`
+	DockerBrokerAdmin string `yaml:"docker_broker_admin" json:"docker_broker_admin"`
+	DockerDB          string `yaml:"docker_db"           json:"docker_db"`
 
 	// local-specific — configurable shell commands
 	CmdStart   string `yaml:"cmd_start"   json:"cmd_start"`

--- a/cmd/dune-admin/server_registry.go
+++ b/cmd/dune-admin/server_registry.go
@@ -47,14 +47,16 @@ type ServerConfig struct {
 	Control          string `yaml:"control"           json:"control"`
 	ControlNamespace string `yaml:"control_namespace" json:"control_namespace"`
 
-	// docker-specific container names. DockerGameservers lists every
-	// game-server container (one per map/partition, see #311) and overrides
-	// auto-detection; DockerGameserver is the legacy singular key.
+	// DockerGameservers lists every game-server container (one per
+	// map/partition, see #311) and overrides runtime auto-detection. Leave it
+	// empty to re-detect on every status poll.
 	DockerGameservers []string `yaml:"docker_gameservers"  json:"docker_gameservers"`
-	DockerGameserver  string   `yaml:"docker_gameserver"   json:"docker_gameserver"`
-	DockerBrokerGame  string   `yaml:"docker_broker_game"  json:"docker_broker_game"`
-	DockerBrokerAdmin string   `yaml:"docker_broker_admin" json:"docker_broker_admin"`
-	DockerDB          string   `yaml:"docker_db"           json:"docker_db"`
+	// DockerGameserver is the legacy singular key, honoured as a one-entry list
+	// when DockerGameservers is empty.
+	DockerGameserver  string `yaml:"docker_gameserver"   json:"docker_gameserver"`
+	DockerBrokerGame  string `yaml:"docker_broker_game"  json:"docker_broker_game"`
+	DockerBrokerAdmin string `yaml:"docker_broker_admin" json:"docker_broker_admin"`
+	DockerDB          string `yaml:"docker_db"           json:"docker_db"`
 
 	// local-specific shell commands.
 	CmdStart   string `yaml:"cmd_start"   json:"cmd_start"`

--- a/cmd/dune-admin/servers_columns_test.go
+++ b/cmd/dune-admin/servers_columns_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -29,6 +30,9 @@ func TestServerColumnsRoundTrip(t *testing.T) {
 		AmpAPIPort:       8081,
 		AmpUseContainer:  boolPtr(true),
 		MarketBotEnabled: boolPtr(false),
+		// Stored comma-joined in a TEXT column rather than as JSON, so a
+		// mismatched SELECT/Scan or write placeholder would only show up here.
+		DockerGameservers: []string{"dune-server-overmap", "dune-server-survival-1"},
 	}
 
 	id, err := s.insertServer(cfg, 0)
@@ -70,6 +74,9 @@ func assertServerEqual(t *testing.T, ctx string, got, want ServerConfig, id int)
 	if got.DBHost != want.DBHost || got.DBPort != want.DBPort || got.DBName != want.DBName {
 		t.Errorf("%s: db = %q/%d/%q, want %q/%d/%q", ctx, got.DBHost, got.DBPort, got.DBName,
 			want.DBHost, want.DBPort, want.DBName)
+	}
+	if strings.Join(got.DockerGameservers, ",") != strings.Join(want.DockerGameservers, ",") {
+		t.Errorf("%s: DockerGameservers = %v, want %v", ctx, got.DockerGameservers, want.DockerGameservers)
 	}
 	if got.Control != want.Control {
 		t.Errorf("%s: Control = %q, want %q", ctx, got.Control, want.Control)

--- a/cmd/dune-admin/setup.go
+++ b/cmd/dune-admin/setup.go
@@ -339,23 +339,6 @@ func runKubectlSetup(ask func(string, string) string, ok, fail func(string), cfg
 
 // ── docker setup flow ─────────────────────────────────────────────────────────
 
-// defaultGameserverSelection returns the 1-based, comma-separated indices of the
-// auto-detected game-server containers, for use as the prompt default.
-func defaultGameserverSelection(entries []dockerPSEntry) string {
-	game := selectGameContainers(entries)
-	isGame := make(map[string]bool, len(game))
-	for _, g := range game {
-		isGame[g.name] = true
-	}
-	var idx []string
-	for i, e := range entries {
-		if isGame[e.name] {
-			idx = append(idx, strconv.Itoa(i+1))
-		}
-	}
-	return strings.Join(idx, ",")
-}
-
 // parseIndexSelection maps a comma-separated 1-based index list onto container
 // names. Out-of-range entries, junk, and duplicates are dropped rather than
 // aborting setup.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -8262,10 +8262,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "docker_gameserver": {
+                    "description": "DockerGameserver is the legacy singular key, honoured as a one-entry list\nwhen DockerGameservers is empty.",
                     "type": "string"
                 },
                 "docker_gameservers": {
-                    "description": "docker-specific container names. DockerGameservers lists every\ngame-server container (one per map/partition, see #311) and overrides\nauto-detection; DockerGameserver is the legacy singular key.",
+                    "description": "DockerGameservers lists every game-server container (one per\nmap/partition, see #311) and overrides runtime auto-detection. Leave it\nempty to re-detect on every status poll.",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -8574,10 +8575,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "docker_gameserver": {
+                    "description": "DockerGameserver is the legacy singular key, honoured as a one-entry list\nwhen DockerGameservers is empty.",
                     "type": "string"
                 },
                 "docker_gameservers": {
-                    "description": "docker-specific — container names. DockerGameservers lists every\ngame-server container (one per map/partition, see #311); it overrides\nruntime auto-detection. DockerGameserver is the legacy singular key,\nhonoured when the list is empty.",
+                    "description": "DockerGameservers lists every game-server container (one per\nmap/partition, see #311) and overrides runtime auto-detection. Leave it\nempty to re-detect on every status poll.",
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -780,12 +780,12 @@ const docTemplate = `{
                 "summary": "Restart a single map/partition without cycling the whole Battlegroup",
                 "parameters": [
                     {
-                        "description": "partition: partition index to restart",
+                        "description": "partition index, plus the map name that disambiguates it when several rows report the same index",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object"
+                            "$ref": "#/definitions/main.restartTarget"
                         }
                     }
                 ],
@@ -801,6 +801,15 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -8253,8 +8262,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "docker_gameserver": {
-                    "description": "docker-specific container names.",
                     "type": "string"
+                },
+                "docker_gameservers": {
+                    "description": "docker-specific container names. DockerGameservers lists every\ngame-server container (one per map/partition, see #311) and overrides\nauto-detection; DockerGameserver is the legacy singular key.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "id": {
                     "description": "ID is the DB-assigned numeric server id (exposed as a JSON number). It is\nNOT read from YAML — legacy config.yaml stored string ids, captured by\nLegacyID below for the one-time import remap.",
@@ -8559,8 +8574,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "docker_gameserver": {
-                    "description": "docker-specific — container names",
                     "type": "string"
+                },
+                "docker_gameservers": {
+                    "description": "docker-specific — container names. DockerGameservers lists every\ngame-server container (one per map/partition, see #311); it overrides\nruntime auto-detection. DockerGameserver is the legacy singular key,\nhonoured when the list is empty.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "events_enabled": {
                     "description": "── Live events engine ─────────────────────────────────────────────────\nEventsEnabled starts the background polling engine. Per-event poll_seconds\nand jitter_seconds are configured on each event definition.",
@@ -9489,6 +9510,17 @@ const docTemplate = `{
                 }
             }
         },
+        "main.restartTarget": {
+            "type": "object",
+            "properties": {
+                "map": {
+                    "type": "string"
+                },
+                "partition": {
+                    "type": "integer"
+                }
+            }
+        },
         "main.restoreStepState": {
             "type": "object",
             "properties": {
@@ -9655,11 +9687,30 @@ const docTemplate = `{
         "main.vehicleRow": {
             "type": "object",
             "properties": {
-                "chassis_durability": {
+                "access_label": {
+                    "type": "string"
+                },
+                "access_rank": {
+                    "type": "integer"
+                },
+                "chassis_current": {
+                    "description": "ChassisCurrent is the chassis module's absolute durability. ChassisMax is\n0 unless the part has decayed (the game only records a max once it does),\nso ChassisPct is only meaningful when HasChassisPct is set.",
+                    "type": "number"
+                },
+                "chassis_max": {
+                    "type": "number"
+                },
+                "chassis_pct": {
                     "type": "number"
                 },
                 "class": {
                     "type": "string"
+                },
+                "dimension": {
+                    "type": "integer"
+                },
+                "has_chassis_pct": {
+                    "type": "boolean"
                 },
                 "id": {
                     "type": "integer"
@@ -9667,11 +9718,25 @@ const docTemplate = `{
                 "is_backup": {
                     "type": "boolean"
                 },
+                "is_owner": {
+                    "type": "boolean"
+                },
                 "is_recovered": {
                     "type": "boolean"
                 },
+                "location": {
+                    "type": "string"
+                },
                 "map": {
                     "type": "string"
+                },
+                "owner_name": {
+                    "description": "OwnerName is the rank-1 holder. AccessRank is the *viewing* player's rank,\nso a vehicle merely shared with them is distinguishable from their own.",
+                    "type": "string"
+                },
+                "partition": {
+                    "description": "Partition and Dimension locate the vehicle on a multi-sietch server; the\nmap name alone is ambiguous (#313). Location is the display form.",
+                    "type": "integer"
                 },
                 "vehicle_name": {
                     "type": "string"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -808,6 +808,24 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "404": {
+                        "description": "no server matches the target (e.g. a stale row)",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "several containers claim the partition; supply the map",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -802,6 +802,24 @@
                             }
                         }
                     },
+                    "404": {
+                        "description": "no server matches the target (e.g. a stale row)",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "several containers claim the partition; supply the map",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -774,12 +774,12 @@
                 "summary": "Restart a single map/partition without cycling the whole Battlegroup",
                 "parameters": [
                     {
-                        "description": "partition: partition index to restart",
+                        "description": "partition index, plus the map name that disambiguates it when several rows report the same index",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object"
+                            "$ref": "#/definitions/main.restartTarget"
                         }
                     }
                 ],
@@ -795,6 +795,15 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -8247,8 +8256,14 @@
                     "type": "string"
                 },
                 "docker_gameserver": {
-                    "description": "docker-specific container names.",
                     "type": "string"
+                },
+                "docker_gameservers": {
+                    "description": "docker-specific container names. DockerGameservers lists every\ngame-server container (one per map/partition, see #311) and overrides\nauto-detection; DockerGameserver is the legacy singular key.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "id": {
                     "description": "ID is the DB-assigned numeric server id (exposed as a JSON number). It is\nNOT read from YAML — legacy config.yaml stored string ids, captured by\nLegacyID below for the one-time import remap.",
@@ -8553,8 +8568,14 @@
                     "type": "string"
                 },
                 "docker_gameserver": {
-                    "description": "docker-specific — container names",
                     "type": "string"
+                },
+                "docker_gameservers": {
+                    "description": "docker-specific — container names. DockerGameservers lists every\ngame-server container (one per map/partition, see #311); it overrides\nruntime auto-detection. DockerGameserver is the legacy singular key,\nhonoured when the list is empty.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "events_enabled": {
                     "description": "── Live events engine ─────────────────────────────────────────────────\nEventsEnabled starts the background polling engine. Per-event poll_seconds\nand jitter_seconds are configured on each event definition.",
@@ -9483,6 +9504,17 @@
                 }
             }
         },
+        "main.restartTarget": {
+            "type": "object",
+            "properties": {
+                "map": {
+                    "type": "string"
+                },
+                "partition": {
+                    "type": "integer"
+                }
+            }
+        },
         "main.restoreStepState": {
             "type": "object",
             "properties": {
@@ -9649,11 +9681,30 @@
         "main.vehicleRow": {
             "type": "object",
             "properties": {
-                "chassis_durability": {
+                "access_label": {
+                    "type": "string"
+                },
+                "access_rank": {
+                    "type": "integer"
+                },
+                "chassis_current": {
+                    "description": "ChassisCurrent is the chassis module's absolute durability. ChassisMax is\n0 unless the part has decayed (the game only records a max once it does),\nso ChassisPct is only meaningful when HasChassisPct is set.",
+                    "type": "number"
+                },
+                "chassis_max": {
+                    "type": "number"
+                },
+                "chassis_pct": {
                     "type": "number"
                 },
                 "class": {
                     "type": "string"
+                },
+                "dimension": {
+                    "type": "integer"
+                },
+                "has_chassis_pct": {
+                    "type": "boolean"
                 },
                 "id": {
                     "type": "integer"
@@ -9661,11 +9712,25 @@
                 "is_backup": {
                     "type": "boolean"
                 },
+                "is_owner": {
+                    "type": "boolean"
+                },
                 "is_recovered": {
                     "type": "boolean"
                 },
+                "location": {
+                    "type": "string"
+                },
                 "map": {
                     "type": "string"
+                },
+                "owner_name": {
+                    "description": "OwnerName is the rank-1 holder. AccessRank is the *viewing* player's rank,\nso a vehicle merely shared with them is distinguishable from their own.",
+                    "type": "string"
+                },
+                "partition": {
+                    "description": "Partition and Dimension locate the vehicle on a multi-sietch server; the\nmap name alone is ambiguous (#313). Location is the display form.",
+                    "type": "integer"
                 },
                 "vehicle_name": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -8256,10 +8256,11 @@
                     "type": "string"
                 },
                 "docker_gameserver": {
+                    "description": "DockerGameserver is the legacy singular key, honoured as a one-entry list\nwhen DockerGameservers is empty.",
                     "type": "string"
                 },
                 "docker_gameservers": {
-                    "description": "docker-specific container names. DockerGameservers lists every\ngame-server container (one per map/partition, see #311) and overrides\nauto-detection; DockerGameserver is the legacy singular key.",
+                    "description": "DockerGameservers lists every game-server container (one per\nmap/partition, see #311) and overrides runtime auto-detection. Leave it\nempty to re-detect on every status poll.",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -8568,10 +8569,11 @@
                     "type": "string"
                 },
                 "docker_gameserver": {
+                    "description": "DockerGameserver is the legacy singular key, honoured as a one-entry list\nwhen DockerGameservers is empty.",
                     "type": "string"
                 },
                 "docker_gameservers": {
-                    "description": "docker-specific — container names. DockerGameservers lists every\ngame-server container (one per map/partition, see #311); it overrides\nruntime auto-detection. DockerGameserver is the legacy singular key,\nhonoured when the list is empty.",
+                    "description": "DockerGameservers lists every game-server container (one per\nmap/partition, see #311) and overrides runtime auto-detection. Leave it\nempty to re-detect on every status poll.",
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1830,6 +1830,18 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "404":
+          description: no server matches the target (e.g. a stale row)
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: several containers claim the partition; supply the map
+          schema:
+            additionalProperties:
+              type: string
+            type: object
         "500":
           description: Internal Server Error
           schema:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -97,12 +97,15 @@ definitions:
       docker_db:
         type: string
       docker_gameserver:
+        description: |-
+          DockerGameserver is the legacy singular key, honoured as a one-entry list
+          when DockerGameservers is empty.
         type: string
       docker_gameservers:
         description: |-
-          docker-specific container names. DockerGameservers lists every
-          game-server container (one per map/partition, see #311) and overrides
-          auto-detection; DockerGameserver is the legacy singular key.
+          DockerGameservers lists every game-server container (one per
+          map/partition, see #311) and overrides runtime auto-detection. Leave it
+          empty to re-detect on every status poll.
         items:
           type: string
         type: array
@@ -412,13 +415,15 @@ definitions:
       docker_db:
         type: string
       docker_gameserver:
+        description: |-
+          DockerGameserver is the legacy singular key, honoured as a one-entry list
+          when DockerGameservers is empty.
         type: string
       docker_gameservers:
         description: |-
-          docker-specific — container names. DockerGameservers lists every
-          game-server container (one per map/partition, see #311); it overrides
-          runtime auto-detection. DockerGameserver is the legacy singular key,
-          honoured when the list is empty.
+          DockerGameservers lists every game-server container (one per
+          map/partition, see #311) and overrides runtime auto-detection. Leave it
+          empty to re-detect on every status poll.
         items:
           type: string
         type: array

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -97,8 +97,15 @@ definitions:
       docker_db:
         type: string
       docker_gameserver:
-        description: docker-specific container names.
         type: string
+      docker_gameservers:
+        description: |-
+          docker-specific container names. DockerGameservers lists every
+          game-server container (one per map/partition, see #311) and overrides
+          auto-detection; DockerGameserver is the legacy singular key.
+        items:
+          type: string
+        type: array
       id:
         description: |-
           ID is the DB-assigned numeric server id (exposed as a JSON number). It is
@@ -405,8 +412,16 @@ definitions:
       docker_db:
         type: string
       docker_gameserver:
-        description: docker-specific — container names
         type: string
+      docker_gameservers:
+        description: |-
+          docker-specific — container names. DockerGameservers lists every
+          game-server container (one per map/partition, see #311); it overrides
+          runtime auto-detection. DockerGameserver is the legacy singular key,
+          honoured when the list is empty.
+        items:
+          type: string
+        type: array
       events_enabled:
         description: |-
           ── Live events engine ─────────────────────────────────────────────────
@@ -1045,6 +1060,13 @@ definitions:
       online_status:
         type: string
     type: object
+  main.restartTarget:
+    properties:
+      map:
+        type: string
+      partition:
+        type: integer
+    type: object
   main.restoreStepState:
     properties:
       key:
@@ -1153,18 +1175,48 @@ definitions:
     type: object
   main.vehicleRow:
     properties:
-      chassis_durability:
+      access_label:
+        type: string
+      access_rank:
+        type: integer
+      chassis_current:
+        description: |-
+          ChassisCurrent is the chassis module's absolute durability. ChassisMax is
+          0 unless the part has decayed (the game only records a max once it does),
+          so ChassisPct is only meaningful when HasChassisPct is set.
+        type: number
+      chassis_max:
+        type: number
+      chassis_pct:
         type: number
       class:
         type: string
+      dimension:
+        type: integer
+      has_chassis_pct:
+        type: boolean
       id:
         type: integer
       is_backup:
         type: boolean
+      is_owner:
+        type: boolean
       is_recovered:
         type: boolean
+      location:
+        type: string
       map:
         type: string
+      owner_name:
+        description: |-
+          OwnerName is the rank-1 holder. AccessRank is the *viewing* player's rank,
+          so a vehicle merely shared with them is distinguishable from their own.
+        type: string
+      partition:
+        description: |-
+          Partition and Dimension locate the vehicle on a multi-sietch server; the
+          map name alone is ambiguous (#313). Location is the display form.
+        type: integer
       vehicle_name:
         type: string
     type: object
@@ -1751,12 +1803,13 @@ paths:
       consumes:
       - application/json
       parameters:
-      - description: 'partition: partition index to restart'
+      - description: partition index, plus the map name that disambiguates it when
+          several rows report the same index
         in: body
         name: body
         required: true
         schema:
-          type: object
+          $ref: '#/definitions/main.restartTarget'
       produces:
       - application/json
       responses:
@@ -1768,6 +1821,12 @@ paths:
             type: object
         "400":
           description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
           schema:
             additionalProperties:
               type: string

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1222,7 +1222,11 @@ export const api = {
       return res.json()
     },
     restore: (file: string) => req<{ ok: string }>('POST', '/battlegroup/restore', { file }),
-    restartPartition: (partition: number) => req<BGOutput>('POST', '/battlegroup/restart-partition', { partition }),
+    /** `map` accompanies the partition because the index is not a reliable key
+     *  on every control plane: a docker container whose args carry no
+     *  -PartitionIndex parses to 0, so several rows can report the same
+     *  partition and the backend would otherwise restart the wrong one. */
+    restartPartition: (partition: number, map: string) => req<BGOutput>('POST', '/battlegroup/restart-partition', { partition, map }),
   },
 
   players: {

--- a/web/src/tabs/BattlegroupTab/BattlegroupTab.tsx
+++ b/web/src/tabs/BattlegroupTab/BattlegroupTab.tsx
@@ -139,7 +139,7 @@ export const BattlegroupTab: React.FC = () => {
     setCmdOutput(null)
     setCmdDone(false)
     try {
-      const res = await api.battlegroup.restartPartition(server.partition)
+      const res = await api.battlegroup.restartPartition(server.partition, server.map)
       setCmdOutput(res.output || t('battlegroup.noOutput'))
       setCmdDone(true)
       toast.success(t('battlegroup.restartPartition.success', { map: server.map }))


### PR DESCRIPTION
Follow-up to #315. Copilot's review landed eight minutes after that PR merged, so nothing got a chance to block. Four of its five findings were real; this fixes them, plus one doc nit from #324.

## The real bug

`parseAMPArgInt` returns 0 when the regex misses, so a docker container whose process args carry no `-PartitionIndex` parses to partition 0. On such an install **every** row reports partition 0, and `RestartPartition` returned the first container matching that index. Restarting the Deep Desert row cycled Overmap instead. `GetStatus` had the same shape: `dirMeta[ct.partition]` handed partition 0's player count and dimension to every row.

This was latent while the Battlegroup tab hid the per-map button on docker. Unhiding it in the last commit of #315 is what made it reachable, so it is a regression I introduced.

It is also exactly the assumption #315 flagged as unverified: that docker containers expose `-PartitionIndex` the way AMP's do. On @wofnull's install they evidently do, since their screenshots show different player counts per map rather than the same number three times. This is a hazard for installs whose args differ.

### Fix

`RestartPartition` takes a `restartTarget` carrying both the partition and the map. On docker the map is the container identity, so the row the operator clicked is the container that cycles.

- Map matches first.
- Partition still resolves when it is unique, so nothing changes on installs that parse correctly.
- A partition claimed by several containers is **refused**, naming the colliding containers. Restarting an arbitrary map is worse than saying which rows collide.

kubectl pods are 1:1 with partitions, so it reads `target.Partition` and ignores the map.

## The rest of that review

**`firstContainer` could return a stopped container.** Discovery lists with `docker ps -a`, so `containers[0]` may be exited while another map is up. `CaptureJWT` and `ReadDefaultINI` `docker exec` into the result and would fail for no reason. Now prefers a running container, falling back to the first only when nothing is running, so docker's own error surfaces rather than an invented one.

**The name-prefix fallback swept in `dune-server-gateway` and `dune-text-router`.** It only runs when no image matches `seabass-server`, which is the retagged/private-image path, but it now carries the same exclusions the image match gives for free. That exclusion is the whole reason detection keys off the image.

**`TestServerColumnsRoundTrip` never populated `DockerGameservers`.** The column is stored comma-joined in TEXT rather than JSON, so a mismatched SELECT/Scan or write placeholder would not have failed anything. Now covered.

**`defaultGameserverSelection` was orphaned.** My `askGameservers` rewrite in #315 stopped calling it, and it survived only through its own test, which is why `unused` never flagged it. Removed both; `resolveDockerGameservers` computes the detected set directly.

The fifth finding wanted `docs/plans/*.md` updated off `golang:1.26.5`. Declined: those are historical planning documents, and rewriting them to match current state makes them lie about what was planned.

## From #324

`SETUP_*.md` and `README.md` said "Go 1.26+", which still permits the 1.26.0-1.26.5 toolchains that #324 moved off for CVE reasons. Now 1.26.6+.

## Testing

Test-first. 8 new tests in `control_docker_restart_target_test.go` covering the partition-0 collapse, the ambiguity refusal, the unique-partition path staying intact, unknown-map handling, running-container preference, and the prefix-fallback exclusions.

- `make verify` passes
- `make gosec` 0 issues
- `cd web && pnpm build && pnpm lint` clean

## Not verified

Same caveat as #315: no real multi-container docker install here. The partition-0 case is driven by a fixture built from the reporter's container and image names with the partition args removed, which is the closest proxy available.

Addresses #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
