### PR TITLE
fix(setup): normalize bare listen ports, default docker DB password

### DIFF
--- a/cmd/dune-admin/listen_addr_test.go
+++ b/cmd/dune-admin/listen_addr_test.go
@@ -123,3 +123,60 @@ func TestResolveListenAddr(t *testing.T) {
 		}
 	})
 }
+
+// A bare port number ("18080") is a Go net.Listen error, not a config we
+// should hand to the HTTP server: reported by @wofnull on #325 — typing the
+// setup wizard's own displayed default port without its leading colon
+// produces "listen tcp: address 18080: missing port in address" and the
+// process exits. The wizard prompts for "HTTP listen address" but shows only
+// the port in its default (":8080" reads as "8080" at a glance), so the
+// mistake is easy to make.
+func TestNormalizeListenAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare port gets a colon", "18080", ":18080"},
+		{"already has a colon, unchanged", ":18080", ":18080"},
+		{"host:port, unchanged", "0.0.0.0:8080", "0.0.0.0:8080"},
+		{"empty, unchanged", "", ""},
+		// A host with no port is a different mistake; prepending ":" would
+		// turn it into a nonsensical ":127.0.0.1". Only an all-digit string is
+		// unambiguously a bare port.
+		{"host with no port, left alone", "127.0.0.1", "127.0.0.1"},
+		{"non-numeric junk, left alone", "abc", "abc"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeListenAddr(tt.in); got != tt.want {
+				t.Errorf("normalizeListenAddr(%q) = %q; want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// effectiveListenAddr is the one choke point every source (CLI flag, DB value,
+// setup-wizard-persisted config) funnels through before startServer binds, so
+// normalizing there catches a bare port regardless of where it came from.
+func TestEffectiveListenAddr_NormalizesBarePort(t *testing.T) {
+	tests := []struct {
+		name     string
+		flagAddr string
+		explicit bool
+		dbAddr   string
+		want     string
+	}{
+		{"explicit flag, bare port", "18080", true, "", ":18080"},
+		{"DB value, bare port", ":8080", false, "18080", ":18080"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := effectiveListenAddr(tt.flagAddr, tt.explicit, tt.dbAddr)
+			if got != tt.want {
+				t.Errorf("effectiveListenAddr(%q, %v, %q) = %q; want %q",
+					tt.flagAddr, tt.explicit, tt.dbAddr, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/dune-admin/main.go
+++ b/cmd/dune-admin/main.go
@@ -590,12 +590,33 @@ func resolveKeyPath() string {
 //  3. built-in default carried in flagAddr (":8080" from the flag definition)
 func effectiveListenAddr(flagAddr string, explicit bool, dbAddr string) string {
 	if explicit {
-		return flagAddr
+		return normalizeListenAddr(flagAddr)
 	}
 	if dbAddr != "" {
-		return dbAddr
+		return normalizeListenAddr(dbAddr)
 	}
-	return flagAddr
+	return normalizeListenAddr(flagAddr)
+}
+
+// normalizeListenAddr turns a bare port number into a net.Listen-shaped
+// address. "18080" fails at bind time with "listen tcp: address 18080:
+// missing port in address" — a Go net package error message, not an obvious
+// config mistake — and the setup wizard's own default is displayed as
+// ":8080", so typing just the digits is an easy slip (#325).
+//
+// Only an all-digit string is unambiguous. A bare host ("127.0.0.1") is a
+// different mistake, and prepending ":" would corrupt it into something that
+// looks like a port; that one is left for net.Listen's own error.
+func normalizeListenAddr(addr string) string {
+	if addr == "" {
+		return addr
+	}
+	for _, r := range addr {
+		if r < '0' || r > '9' {
+			return addr
+		}
+	}
+	return ":" + addr
 }
 
 // resolveListenAddr returns the address to bind the HTTP server to.

--- a/cmd/dune-admin/setup.go
+++ b/cmd/dune-admin/setup.go
@@ -88,7 +88,7 @@ func runSetup() {
 		// AMP web panel commonly binds :8080 on host installs.
 		defaultListenAddr = ":18080"
 	}
-	cfg.ListenAddr = ask("HTTP listen address", defaultListenAddr)
+	cfg.ListenAddr = normalizeListenAddr(ask("HTTP listen address", defaultListenAddr))
 	fmt.Println()
 
 	// ── Discord bot ────────────────────────────────────────────────────────────
@@ -485,24 +485,34 @@ func setupDockerContainers(ask func(string, string) string, ok, fail func(string
 	cfg.DirectorURL = ask("Battlegroup Director URL (optional)", directorDefault)
 }
 
+// runDockerSetupDBPrompts collects the DB connection fields for a docker
+// install. DBPass defaults to "dune" — dune-docker (the stock install this
+// wizard targets) hardens Postgres to 127.0.0.1-only and issues that one base
+// password, confirmed stable since the project's start (#325). It stays a
+// confirmable default like the others: ask() shows it in brackets and only
+// applies it on an empty answer.
+func runDockerSetupDBPrompts(ask func(string, string) string, cfg *appConfig) {
+	cfg.DBHost = ask("DB host (Docker DNS or IP)", "database")
+	cfg.DBPort = dbPort
+	portStr := ask(fmt.Sprintf("DB port [%d]", dbPort), fmt.Sprintf("%d", dbPort))
+	_, _ = fmt.Sscanf(portStr, "%d", &cfg.DBPort)
+	cfg.DBUser = ask("DB user", envOr("DB_USER", "dune"))
+	cfg.DBPass = ask("DB password", "dune")
+	cfg.DBName = ask("DB name", envOr("DB_NAME", "dune"))
+	cfg.DBSchema = ask("DB schema", envOr("DB_SCHEMA", "dune"))
+}
+
 func runDockerSetup(ask func(string, string) string, ok, fail func(string), cfg *appConfig) {
 	exec := &localExecutor{}
 	setupDockerContainers(ask, ok, fail, cfg, exec)
 	fmt.Println()
 
 	fmt.Println("Database connection:")
-	cfg.DBHost = ask("DB host (Docker DNS or IP)", "database")
-	cfg.DBPort = dbPort
-	portStr := ask(fmt.Sprintf("DB port [%d]", dbPort), fmt.Sprintf("%d", dbPort))
-	_, _ = fmt.Sscanf(portStr, "%d", &cfg.DBPort)
-	cfg.DBUser = ask("DB user", envOr("DB_USER", "dune"))
-	cfg.DBPass = ask("DB password", "")
+	runDockerSetupDBPrompts(ask, cfg)
 	if cfg.DBPass == "" {
 		fmt.Fprintln(os.Stderr, "Database password is required. Aborting.")
 		exitSetup(1)
 	}
-	cfg.DBName = ask("DB name", envOr("DB_NAME", "dune"))
-	cfg.DBSchema = ask("DB schema", envOr("DB_SCHEMA", "dune"))
 	fmt.Println()
 
 	fmt.Println("Connecting to database...")

--- a/cmd/dune-admin/setup.go
+++ b/cmd/dune-admin/setup.go
@@ -486,15 +486,21 @@ func setupDockerContainers(ask func(string, string) string, ok, fail func(string
 }
 
 // runDockerSetupDBPrompts collects the DB connection fields for a docker
-// install. DBPass defaults to "dune" — dune-docker (the stock install this
-// wizard targets) hardens Postgres to 127.0.0.1-only and issues that one base
-// password, confirmed stable since the project's start (#325). It stays a
-// confirmable default like the others: ask() shows it in brackets and only
-// applies it on an empty answer.
+// install. DBHost keeps its existing default: "database" fits a dune-admin
+// instance running inside the same compose network, and an operator on the
+// host (dune-admin's normal placement, per SETUP_DOCKER.md) overrides it with
+// an IP either way, same as @wofnull did in #325.
+//
+// DBPass defaults to "dune" — dune-docker itself hardens Postgres to
+// 127.0.0.1-only and issues that one base password, confirmed stable since
+// the project's start (#325). It stays a confirmable default like the
+// others: ask() shows it in brackets and only applies it on an empty answer.
 func runDockerSetupDBPrompts(ask func(string, string) string, cfg *appConfig) {
 	cfg.DBHost = ask("DB host (Docker DNS or IP)", "database")
 	cfg.DBPort = dbPort
-	portStr := ask(fmt.Sprintf("DB port [%d]", dbPort), fmt.Sprintf("%d", dbPort))
+	// The label is plain — ask() already renders the default in brackets, and
+	// a "[%d]" baked into the label too used to print "DB port [15432] [15432]:".
+	portStr := ask("DB port", fmt.Sprintf("%d", dbPort))
 	_, _ = fmt.Sscanf(portStr, "%d", &cfg.DBPort)
 	cfg.DBUser = ask("DB user", envOr("DB_USER", "dune"))
 	cfg.DBPass = ask("DB password", "dune")

--- a/cmd/dune-admin/setup_docker_autodetect_test.go
+++ b/cmd/dune-admin/setup_docker_autodetect_test.go
@@ -145,3 +145,33 @@ func TestSetupDockerContainers_DefaultAnswerLeavesConfigEmpty(t *testing.T) {
 		t.Fatal("director container is present in the listing, so its URL must be defaulted")
 	}
 }
+
+// dune-docker (the stock install these defaults target) hardens Postgres to
+// 127.0.0.1-only and issues one base password, "dune", visible in its own web
+// UI — confirmed stable "since start of the dune-docker project" (#325). The
+// wizard asked for it with no default at all, so every operator had to already
+// know it or go find it.
+func TestRunDockerSetupDBPrompts_DefaultsPasswordForStockInstall(t *testing.T) {
+	t.Parallel()
+	var cfg appConfig
+	ask := func(_, def string) string { return def } // operator presses Enter throughout
+	runDockerSetupDBPrompts(ask, &cfg)
+
+	if cfg.DBPass != "dune" {
+		t.Errorf("DBPass default = %q, want %q", cfg.DBPass, "dune")
+	}
+	// The password default must still be visible and overridable, not silently
+	// applied: ask() shows it in brackets and only takes it on an empty answer.
+	overridden := ""
+	askOverride := func(label, def string) string {
+		if label == "DB password" {
+			return "custom-secret"
+		}
+		return def
+	}
+	runDockerSetupDBPrompts(askOverride, &cfg)
+	overridden = cfg.DBPass
+	if overridden != "custom-secret" {
+		t.Errorf("DBPass with an explicit answer = %q, want the operator's own value", overridden)
+	}
+}

--- a/cmd/dune-admin/setup_docker_autodetect_test.go
+++ b/cmd/dune-admin/setup_docker_autodetect_test.go
@@ -175,3 +175,24 @@ func TestRunDockerSetupDBPrompts_DefaultsPasswordForStockInstall(t *testing.T) {
 		t.Errorf("DBPass with an explicit answer = %q, want the operator's own value", overridden)
 	}
 }
+
+// The port prompt's own label used to embed "[%d]", and ask() wraps every
+// label's default in brackets too, so the wizard rendered "DB port [15432]
+// [15432]:" — a duplicated default a Copilot review on #327 caught. The label
+// passed to ask() must be plain; the bracketed default is ask()'s job alone.
+func TestRunDockerSetupDBPrompts_PortLabelHasNoDuplicatedBracket(t *testing.T) {
+	t.Parallel()
+	var gotLabel string
+	ask := func(label, def string) string {
+		if strings.Contains(label, "port") || strings.Contains(label, "Port") {
+			gotLabel = label
+		}
+		return def
+	}
+	var cfg appConfig
+	runDockerSetupDBPrompts(ask, &cfg)
+
+	if strings.Contains(gotLabel, "[") {
+		t.Fatalf("port prompt label = %q, want no brackets — ask() adds the default's brackets itself", gotLabel)
+	}
+}


### PR DESCRIPTION
Addresses two of the three items in #325.

## Bare listen port crashes on startup

@wofnull typed `18080` for "HTTP listen address" instead of `:18080` and got `listen tcp: address 18080: missing port in address` on the next start. The wizard's own default is displayed as `:8080`, so typing just the digits is an easy slip, and Go's own error message gives no hint what's wrong.

`normalizeListenAddr` prepends `:` to an all-digit string. It runs in `effectiveListenAddr`, which every source — CLI flag, DB-persisted value, wizard-written config — already funnels through before `startServer` binds, so the fix covers all of them from one place. It also runs at the wizard prompt itself so the confirmation printed during setup is already correct.

A bare host with no port (`127.0.0.1`) is left untouched. Prepending `:` there would produce something that reads like a port but isn't, and that's a different mistake than the one being fixed.

## Docker DB password now defaults to the stock value

@wofnull confirmed dune-docker's Postgres is hardened to `127.0.0.1`-only and issues one base password, `dune`, stable since the project's start and visible in dune-docker's own web UI. The wizard asked for it with no default, so every operator had to already know it or go find it.

Still a confirmable default, not silent — `ask()` shows it in brackets and only takes it on an empty answer.

## What's not fixed here

The third item, a port collision between dune-admin and dune-docker's own panel, turned out not to exist — dune-docker uses `8088`, not `8080` or `18080`. No change needed.

## Testing

Test-first. `TestNormalizeListenAddr` and `TestEffectiveListenAddr_NormalizesBarePort` for the port fix; `TestRunDockerSetupDBPrompts_DefaultsPasswordForStockInstall` for the password default (extracted `runDockerSetupDBPrompts` from `runDockerSetup` so the prompt sequence is testable without hitting a real DB connection or `os.Exit`).

- `make verify` passes
- `make gosec` 0 issues

Addresses #325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
